### PR TITLE
fix app_manager key in tempaltes/jobs

### DIFF
--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -233,7 +233,7 @@ properties:
 
   warden: ~
 
-  app-manager:
+  app_manager:
     lifecycle_bundles: ~
 
   stager:


### PR DESCRIPTION
The templates use 'app_manager' instead of 'app-manager':
https://github.com/stefanschneider/diego-release/blob/develop/jobs/app-manager/spec#L17

I needed this to override lifecycle_bundles using spiff.
