### PR TITLE
Reduce size of etcd cluster

### DIFF
--- a/templates/infrastructure-aws.yml
+++ b/templates/infrastructure-aws.yml
@@ -23,16 +23,10 @@ jobs:
         static_ips: (( static_ips(0) ))
 
   - name: etcd_z2
-    instances: 1
-    networks:
-      - name: diego2
-        static_ips: (( static_ips(0) ))
+    instances: 0
 
   - name: etcd_z3
-    instances: 1
-    networks:
-      - name: diego3
-        static_ips: (( static_ips(0) ))
+    instances: 0
 
   - name: consul_z1
     instances: 1

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -324,11 +324,11 @@ jobs:
     templates:
       - name: etcd
       - name: etcd_metrics_server
-    instances: 1
+    instances: 0
     resource_pool: medium_z2
     networks:
       - name: diego2
-        static_ips: (( merge ))
+        static_ips: []
     properties:
       network_name: diego2
     update:
@@ -339,11 +339,11 @@ jobs:
     templates:
       - name: etcd
       - name: etcd_metrics_server
-    instances: 1
+    instances: 0
     resource_pool: medium_z3
     networks:
       - name: diego3
-        static_ips: (( merge ))
+        static_ips: []
     properties:
       network_name: diego3
     update:


### PR DESCRIPTION
Having three etcd nodes gave a higher chance of inconsistency, which
requires manual intervention. @Amit-PivotalLabs 

Signed-off-by: Adam Stegman astegman@pivotal.io
