### PR TITLE
Allow bridge components to load from capi release with -b flag

### DIFF
--- a/manifest-generation/capi-bridge-properties.yml
+++ b/manifest-generation/capi-bridge-properties.yml
@@ -1,0 +1,5 @@
+bridge_overrides:
+  job_release: capi
+  releases:
+    - name: capi
+      version: (( release_versions.capi || "latest" ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -1,6 +1,6 @@
 name: (( config_from_cf.cf_deployment_name "-diego" ))
 
-releases: (( base_releases bbs_overrides.releases volman_overrides.releases [garden_overrides.release] [config_from_cf.cf_release] ))
+releases: (( base_releases bbs_overrides.releases volman_overrides.releases [garden_overrides.release] [config_from_cf.cf_release] bridge_overrides.releases ))
 
 director_uuid: (( config_from_cf.cf_director_uuid ))
 
@@ -665,7 +665,9 @@ iaas_settings: (( merge ))
 instance_count_overrides: (( merge || nil ))
 property_overrides: (( merge ))
 sql_overrides: (( merge  || nil ))
-bridge_overrides: (( merge || nil ))
+bridge_overrides:
+  job_release: cf
+  releases: (( merge || [] ))
 
 bbs_overrides:
   job_properties:
@@ -763,13 +765,13 @@ base_job_templates:
     - name: consul_agent
       release: cf
     - name: stager
-      release: cf
+      release: (( bridge_overrides.job_release || "cf" ))
     - name: nsync
-      release: cf
+      release: (( bridge_overrides.job_release || "cf" ))
     - name: tps
-      release: cf
+      release: (( bridge_overrides.job_release || "cf" ))
     - name: cc_uploader
-      release: cf
+      release: (( bridge_overrides.job_release || "cf" ))
     - name: metron_agent
       release: cf
   cell:

--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -42,6 +42,7 @@ EOF
 
 base_releases="${manifest_generation}/base-releases.yml"
 garden_properties=""
+bridge_properties=""
 
 while getopts "c:i:p:n:k:v:s:d:krbgx" opt; do
   case $opt in
@@ -60,6 +61,9 @@ while getopts "c:i:p:n:k:v:s:d:krbgx" opt; do
     g)
       garden_properties="${manifest_generation}/garden-runc-properties.yml";
       ;;
+    b)
+      bridge_properties="${manifest_generation}/capi-bridge-properties.yml";
+      ;;
     v)
       release_versions=$OPTARG
       ;;
@@ -71,9 +75,6 @@ while getopts "c:i:p:n:k:v:s:d:krbgx" opt; do
       ;;
     r)
       >&2 echo "DEPRECATED -r flag: The cflinuxfs2 rootfs now always comes from its own release."
-      ;;
-    b)
-      >&2 echo "DEPRECATED -b flag: CF-Release now always provides the CC-Bridge components."
       ;;
     d)
       voldriver_settings=$OPTARG
@@ -157,6 +158,7 @@ spiff merge \
   ${release_versions} \
   ${bbs_properties} \
   ${garden_properties} \
+  ${bridge_properties} \
   ${property_overrides} \
   ${instance_counts} \
   ${sql_settings} \


### PR DESCRIPTION
This allows the CAPI pipeline to use the latest versions of the bridge components from capi release.