### PR TITLE
Shrink unused subnets

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -23,10 +23,10 @@ networks:
     subnets: (( iaas_settings.subnet_configs.diego1.subnets ))
   - name: diego2
     type: manual
-    subnets: (( iaas_settings.subnet_configs.diego2.subnets ))
+    subnets: (( iaas_settings.subnet_configs.diego2.subnets || [] ))
   - name: diego3
     type: manual
-    subnets: (( iaas_settings.subnet_configs.diego3.subnets ))
+    subnets: (( iaas_settings.subnet_configs.diego3.subnets || [] ))
 
 disk_pools:
   - name: database_disks
@@ -41,11 +41,11 @@ resource_pools:
   - name: access_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.access_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.access_z2.cloud_properties || empty_hash ))
   - name: access_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.access_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.access_z3.cloud_properties || empty_hash ))
   - name: brain_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -53,11 +53,11 @@ resource_pools:
   - name: brain_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.brain_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.brain_z2.cloud_properties || empty_hash ))
   - name: brain_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.brain_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.brain_z3.cloud_properties || empty_hash ))
   - name: cc_bridge_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -65,11 +65,11 @@ resource_pools:
   - name: cc_bridge_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cc_bridge_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cc_bridge_z2.cloud_properties || empty_hash ))
   - name: cc_bridge_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cc_bridge_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cc_bridge_z3.cloud_properties || empty_hash ))
   - name: cell_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -77,11 +77,11 @@ resource_pools:
   - name: cell_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cell_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cell_z2.cloud_properties || empty_hash ))
   - name: cell_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cell_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.cell_z3.cloud_properties || empty_hash ))
   - name: database_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -89,11 +89,11 @@ resource_pools:
   - name: database_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.database_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.database_z2.cloud_properties || empty_hash ))
   - name: database_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.database_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.database_z3.cloud_properties || empty_hash ))
   - name: route_emitter_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -101,11 +101,11 @@ resource_pools:
   - name: route_emitter_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.route_emitter_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.route_emitter_z2.cloud_properties || empty_hash ))
   - name: route_emitter_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.route_emitter_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.route_emitter_z3.cloud_properties || empty_hash ))
   - name: colocated_z1
     network: diego1
     stemcell: (( iaas_settings.stemcell ))
@@ -113,11 +113,11 @@ resource_pools:
   - name: colocated_z2
     network: diego2
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.colocated_z2.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.colocated_z2.cloud_properties || empty_hash ))
   - name: colocated_z3
     network: diego3
     stemcell: (( iaas_settings.stemcell ))
-    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.colocated_z3.cloud_properties ))
+    cloud_properties: (( iaas_settings.resource_pool_cloud_properties.colocated_z3.cloud_properties || empty_hash ))
 
 jobs:
   - name: database_z1

--- a/manifest-generation/examples/openstack/iaas-settings.yml
+++ b/manifest-generation/examples/openstack/iaas-settings.yml
@@ -8,67 +8,69 @@ iaas_settings:
     - name: access_z1
       cloud_properties:
         instance_type: m1.small
-    - name: access_z2
-      cloud_properties:
-        instance_type: m1.small
-    - name: access_z3
-      cloud_properties:
-        instance_type: m1.small
     - name: brain_z1
-      cloud_properties:
-        instance_type: m1.small
-    - name: brain_z2
-      cloud_properties:
-        instance_type: m1.small
-    - name: brain_z3
       cloud_properties:
         instance_type: m1.small
     - name: cc_bridge_z1
       cloud_properties:
         instance_type: m1.small
-    - name: cc_bridge_z2
-      cloud_properties:
-        instance_type: m1.small
-    - name: cc_bridge_z3
-      cloud_properties:
-        instance_type: m1.small
     - name: cell_z1
-      cloud_properties:
-        instance_type: m1.large
-    - name: cell_z2
-      cloud_properties:
-        instance_type: m1.large
-    - name: cell_z3
       cloud_properties:
         instance_type: m1.large
     - name: colocated_z1
       cloud_properties:
         instance_type: m1.large
-    - name: colocated_z2
-      cloud_properties:
-        instance_type: m1.large
-    - name: colocated_z3
-      cloud_properties:
-        instance_type: m1.large
     - name: database_z1
-      cloud_properties:
-        instance_type: m1.small
-    - name: database_z2
-      cloud_properties:
-        instance_type: m1.small
-    - name: database_z3
       cloud_properties:
         instance_type: m1.small
     - name: route_emitter_z1
       cloud_properties:
         instance_type: m1.small
+    - name: errand
+      cloud_properties:
+        instance_type: m1.small
+# z2 & z3 are used for high-available deployments
+# You can safely remove them if you run a single-zone deployment
+    - name: access_z2
+      cloud_properties:
+        instance_type: m1.small
+    - name: brain_z2
+      cloud_properties:
+        instance_type: m1.small
+    - name: cc_bridge_z2
+      cloud_properties:
+        instance_type: m1.small
+    - name: cell_z2
+      cloud_properties:
+        instance_type: m1.large
+    - name: colocated_z2
+      cloud_properties:
+        instance_type: m1.large
+    - name: database_z2
+      cloud_properties:
+        instance_type: m1.small
     - name: route_emitter_z2
       cloud_properties:
         instance_type: m1.small
-    - name: route_emitter_z3
+    - name: access_z3
       cloud_properties:
         instance_type: m1.small
-    - name: errand
+    - name: brain_z3
+      cloud_properties:
+        instance_type: m1.small
+    - name: cc_bridge_z3
+      cloud_properties:
+        instance_type: m1.small
+    - name: cell_z3
+      cloud_properties:
+        instance_type: m1.large
+    - name: colocated_z3
+      cloud_properties:
+        instance_type: m1.large
+    - name: database_z3
+      cloud_properties:
+        instance_type: m1.small
+    - name: route_emitter_z3
       cloud_properties:
         instance_type: m1.small
 
@@ -84,6 +86,9 @@ iaas_settings:
           security_groups:
           - bosh
           - cf-private
+
+# Diego2 & diego3 subnets are used for high-available deployments
+# They can be safely removed if you run a single-zone deployment
     - name: diego2
       type: manual
       subnets:


### PR DESCRIPTION
Hi there!
In many cases we want to have a quite simple deployment in one single AZ. However, we have to keep descriptions for all resource pools and all 3 subnets in the manifest stub. This makes the stub file overloaded and looks dirty. Otherwise manifest generation script does not work.

This PR adds a few fixes into `diego.yml`, which makes it possible to keep stub file as clean as possible.