### PR TITLE
Fix template generation for garden-runc versions

### DIFF
--- a/manifest-generation/garden-runc-properties.yml
+++ b/manifest-generation/garden-runc-properties.yml
@@ -1,3 +1,4 @@
+release_versions: (( merge ))
 garden_overrides:
   job_release: garden-runc
   release:

--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -157,9 +157,9 @@ spiff merge \
 
 spiff merge \
   ${manifest_generation}/diego.yml \
+  ${garden_properties} \
   ${release_versions} \
   ${bbs_properties} \
-  ${garden_properties} \
   ${bridge_properties} \
   ${property_overrides} \
   ${instance_counts} \


### PR DESCRIPTION
- Spiff didn't know where to find release_versions in garden-runc-properties,
so we had to merge it.
- The spiff merge order in manifest generation was in the wrong order
for garden-runc-properties to inherit the proper properties.

[#129105083] Garden runc deploy version should be update from the compatibility metrics from Diego.

Signed-off-by: Derek Reeve <dreeve@pivotal.io>