### PR TITLE
Remove old loggregator properties

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -32,8 +32,6 @@ config_from_cf:
     dropsonde_incoming_port: (( properties.metron_agent.dropsonde_incoming_port ))
     protocols: (( properties.metron_agent.protocols ))
     preferred_protocol: (( properties.metron_agent.preferred_protocol ))
-    enable_buffer: (( properties.metron_agent.enable_buffer ))
-    buffer_size: (( properties.metron_agent.buffer_size ))
     tls:
       client_cert: (( properties.metron_agent.tls.client_cert ))
       client_key: (( properties.metron_agent.tls.client_key ))
@@ -89,8 +87,6 @@ properties:
     dropsonde_incoming_port: (( merge || nil ))
     protocols: (( merge || nil ))
     preferred_protocol: (( merge || nil ))
-    enable_buffer: (( merge || nil ))
-    buffer_size: (( merge || nil ))
     tls:
       client_cert: (( merge || nil ))
       client_key: (( merge || nil ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -31,8 +31,6 @@ config_from_cf:
     dropsonde_incoming_port: (( merge ))
     protocols: (( merge ))
     preferred_protocol: (( merge ))
-    enable_buffer: (( merge ))
-    buffer_size: (( merge ))
     tls:
       client_cert: (( merge ))
       client_key: (( merge ))

--- a/manifest-generation/diego-windows.yml
+++ b/manifest-generation/diego-windows.yml
@@ -121,8 +121,6 @@ properties:
     deployment: (( name ))
     protocols: (( config_from_cf.metron_agent.protocols ))
     preferred_protocol: (( config_from_cf.metron_agent.preferred_protocol ))
-    enable_buffer: (( config_from_cf.metron_agent.enable_buffer ))
-    buffer_size: (( config_from_cf.metron_agent.buffer_size ))
     tls:
       client_cert: (( config_from_cf.metron_agent.tls.client_cert ))
       client_key: (( config_from_cf.metron_agent.tls.client_key ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -432,8 +432,6 @@ properties:
     deployment: (( name ))
     protocols: (( config_from_cf.metron_agent.protocols ))
     preferred_protocol: (( config_from_cf.metron_agent.preferred_protocol ))
-    enable_buffer: (( config_from_cf.metron_agent.enable_buffer ))
-    buffer_size: (( config_from_cf.metron_agent.buffer_size ))
     tls:
       client_cert: (( config_from_cf.metron_agent.tls.client_cert ))
       client_key: (( config_from_cf.metron_agent.tls.client_key ))


### PR DESCRIPTION
These properties have been deprecated for quite some time, and we're removing them from diego and cf in preparation for removing them from loggregator.

[#117777293]

Signed-off-by: Jeremy Alvis <jalvis@pivotal.io>