### PR TITLE
Make consulTTL value configurable

### DIFF
--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -48,3 +48,7 @@ properties:
     description: "capacity of the tls client cache"
   diego.auctioneer.bbs.max_idle_conns_per_host:
     description: "maximum number of idle http connections"
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/auctioneer/templates/auctioneer_as_vcap.erb
+++ b/jobs/auctioneer/templates/auctioneer_as_vcap.erb
@@ -32,6 +32,7 @@ export GODEBUG=netdns=cgo
         -bbsMaxIdleConnsPerHost=<%= value %> \
       <% end %> \
       -consulCluster=http://127.0.0.1:8500 \
+      -consulTTL=<%= p("consul.ttl_in_seconds") %> \
       -debugAddr=<%= p("diego.auctioneer.debug_addr") %> \
       -listenAddr=<%= p("diego.auctioneer.listen_addr") %> \
       -dropsondePort=<%= p("diego.auctioneer.dropsonde_port") %> \

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -101,3 +101,7 @@ properties:
   diego.bbs.convergence.expire_pending_task_duration_in_seconds:
     description: "unclaimed tasks are marked as failed, after this duration in seconds"
     default: 1800
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/bbs/templates/bbs_as_vcap.erb
+++ b/jobs/bbs/templates/bbs_as_vcap.erb
@@ -60,6 +60,7 @@ etcd_flags=""
   -advertiseURL=${ad_url_scheme}<%="://#{name.gsub('_', '-')}-#{spec.index}.#{p("diego.bbs.advertisement_base_hostname")}:#{p("diego.bbs.listen_addr").split(':')[1]}" %> \
   -auctioneerAddress=<%= p("diego.bbs.auctioneer.api_url") %> \
   -consulCluster=http://127.0.0.1:8500 \
+  -consulTTL=<%= p("consul.ttl_in_seconds") %> \
   -debugAddr=<%= p("diego.bbs.debug_addr") %> \
   <% p("diego.bbs.encryption_keys").each do |encryption_key| %> \
     -encryptionKey=<%= Shellwords.shellescape("#{encryption_key["label"]}:#{encryption_key["passphrase"]}") %> \

--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -28,3 +28,7 @@ properties:
   diego.file_server.dropsonde_port:
     description: "local metron agent's port"
     default: 3457
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/file_server/templates/file_server_as_vcap.erb
+++ b/jobs/file_server/templates/file_server_as_vcap.erb
@@ -11,6 +11,7 @@ export GODEBUG=netdns=cgo
 /var/vcap/packages/file_server/bin/file-server \
       -address=<%= p("diego.file_server.listen_addr") %> \
       -consulCluster=http://127.0.0.1:8500 \
+      -consulTTL=<%= p("consul.ttl_in_seconds") %> \
       -debugAddr=<%= p("diego.file_server.debug_addr") %> \
       -staticDirectory=<%= p("diego.file_server.static_directory") %> \
       -dropsondePort=<%= p("diego.file_server.dropsonde_port") %> \

--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -73,4 +73,6 @@ properties:
   diego.ssh_proxy.bbs.max_idle_conns_per_host:
     description: "maximum number of idle http connections"
 
-
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/ssh_proxy/templates/ssh_proxy_as_vcap.erb
+++ b/jobs/ssh_proxy/templates/ssh_proxy_as_vcap.erb
@@ -50,6 +50,7 @@ export GODEBUG=netdns=cgo
       ${uaa_flags} \
       -address=<%= p("diego.ssh_proxy.listen_addr") %> \
       -consulCluster=http://127.0.0.1:8500 \
+      -consulTTL=<%= p("consul.ttl_in_seconds") %> \
       -hostKey="$HOST_KEY" \
       <% if_p("diego.ssh_proxy.allowed_ciphers") do |value| %> \
         -allowedCiphers=<%= value %> \


### PR DESCRIPTION
- The default TTL value of 3 seconds results in a poll interval for 1.5 seconds for consul healthchecks.
  with all the diego components behaving this way, the consul in PCF Dev gets overloaded and goes unresponsive.
  PCF Dev needs this value to be increased/configurable.

This became necessary when these services switch from using `dns_health_check` to the TTL method. When the `dns_health_check` does not succeed within the TTL, consul will still respond to DNS queries for that service. Using the new TTL method, consul will unregister the service from it's DNS registry if it fails to update it's healthcheck status within the TTL.

This depends on these other PRs:
https://github.com/cloudfoundry/fileserver/pull/4
https://github.com/cloudfoundry/diego-ssh/pull/23
https://github.com/cloudfoundry/bbs/pull/11
https://github.com/cloudfoundry/auctioneer/pull/3

Signed-off-by: Anthony Emengo aemengo@pivotal.io
Signed-off-by: Mark DeLillo mdelillo@pivotal.io
