### PR TITLE
Netman inherits its etcd configuration from CF etcd

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -19,6 +19,10 @@ config_from_cf:
     server_key: (( properties.consul.server_key ))
   etcd:
     advertise_urls_dns_suffix: (( properties.etcd.advertise_urls_dns_suffix ))
+    ca_cert: (( properties.etcd.ca_cert ))
+    client_cert: (( properties.etcd.client_cert ))
+    client_key: (( properties.etcd.client_key ))
+    require_ssl: (( properties.etcd.require_ssl ))
   loggregator:
     etcd_machines: (( properties.loggregator.etcd.machines ))
     etcd_require_ssl: (( properties.loggregator.etcd.require_ssl ))
@@ -76,6 +80,10 @@ properties:
     server_key: (( merge ))
   etcd:
     advertise_urls_dns_suffix: (( merge ))
+    ca_cert: (( merge || nil ))
+    client_cert: (( merge || nil ))
+    client_key: (( merge || nil ))
+    require_ssl: (( merge || nil ))
   loggregator:
     etcd:
       ca_cert: null

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -19,6 +19,10 @@ config_from_cf:
     server_key: (( merge ))
   etcd:
     advertise_urls_dns_suffix: (( merge ))
+    ca_cert: (( merge ))
+    client_cert: (( merge ))
+    client_key: (( merge ))
+    require_ssl: (( merge ))
   loggregator:
     etcd_ca_cert: (( merge ))
     etcd_require_ssl: (( merge ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -472,10 +472,6 @@ properties:
   # -- Properties below are used by the etcd from etcd-release --
   etcd: (( bbs_overrides.etcd_properties ))
 
-  # cf etcd used by netman
-  cf_etcd:
-    advertise_urls_dns_suffix: (( config_from_cf.etcd.advertise_urls_dns_suffix ))
-
   cflinuxfs2-rootfs:
     trusted_certs: (( property_overrides.rootfs_cflinuxfs2.trusted_certs || nil ))
 


### PR DESCRIPTION
Hi Diego team

Container networking team PR to do the following:
- netman pulls etcd properties from config_from_cf
- remove unused cf_etcd section

Please let us know if you have any questions or concerns.

For more information, please see
https://www.pivotaltracker.com/story/show/131579069

Thanks

@markstgodard && @karampok
Container Networking Team