### PR TITLE
Make rep ping value timeout configurable

### DIFF
--- a/jobs/rep/templates/post-start.erb
+++ b/jobs/rep/templates/post-start.erb
@@ -1,8 +1,30 @@
 #!/bin/bash
 
+function convert_to_seconds {
+  hours_in_seconds=0
+  minutes_in_seconds=0
+  seconds=0
+
+  if echo "$1" | grep -q '[0-9]\+h'; then
+    hours_in_seconds=$(($(echo "$1" | grep -o '[0-9]\+h' | grep -o "[0-9]\+")*3600))
+  fi
+
+  if echo "$1" | grep -q '[0-9]\+m'; then
+    minutes_in_seconds=$(($(echo "$1" | grep -o '[0-9]\+m' | grep -o "[0-9]\+")*60))
+  fi
+
+  if echo "$1" | grep -q '[0-9]\+s'; then
+    seconds=$(echo "$1" | grep -o '[0-9]\+s' | grep -o "[0-9]\+")
+  fi
+
+  total_seconds=$(($hours_in_seconds + $minutes_in_seconds + $seconds))
+
+  echo $total_seconds
+}
+
 address=<%= p("diego.rep.listen_addr").sub(/^0\.0\.0\.0:/, "localhost:") %>
 start=`date +%s`
-timeout=300
+timeout=$(convert_to_seconds <%= p("diego.executor.garden_healthcheck.timeout") %>)
 
 echo "$(date): Pinging rep..."
 i=1


### PR DESCRIPTION
We noticed that PCF Dev repeatedly failed to complete the rep ping step within the allotted time. We'd like it to be configurable.

Signed-off-by: Anthony Emengo aemengo@pivotal.io
