### PR TITLE
Add hakim job for garden-windows

### DIFF
--- a/manifest-generation/diego-windows.yml
+++ b/manifest-generation/diego-windows.yml
@@ -45,6 +45,8 @@ resource_pools:
 jobs:
   - name: cell_windows_z1
     templates:
+      - name: hakim
+        release: garden-windows
       - name: rep_windows
         release: diego
       - name: garden-windows
@@ -69,6 +71,8 @@ jobs:
 
   - name: cell_windows_z2
     templates:
+      - name: hakim
+        release: garden-windows
       - name: rep_windows
         release: diego
       - name: garden-windows
@@ -93,6 +97,8 @@ jobs:
 
   - name: cell_windows_z3
     templates:
+      - name: hakim
+        release: garden-windows
       - name: rep_windows
         release: diego
       - name: garden-windows


### PR DESCRIPTION
We have add a new job `hakim` to garden-windows. The new job is available as of garden-windows-bosh-release version `0.0.8`.

[#131642039](https://www.pivotaltracker.com/story/show/131642039)

Signed-off-by: Charlie Vieth cviethjr@pivotal.io
