### PR TITLE
Add syslog for rep_windows job

### DIFF
--- a/jobs/rep_windows/monit
+++ b/jobs/rep_windows/monit
@@ -3,7 +3,12 @@
     {
       "name": "rep_windows",
       "executable": "powershell",
-      "args": ["C:\\var\\vcap\\jobs\\rep_windows\\bin\\start.ps1"]
+      "args": ["C:\\var\\vcap\\jobs\\rep_windows\\bin\\start.ps1"],
+      "env": {
+        "__PIPE_SYSLOG_HOST": "<%= p('syslog_daemon_config.address') %>",
+        "__PIPE_SYSLOG_PORT": "<%= p('syslog_daemon_config.port') %>",
+        "__PIPE_SYSLOG_TRANSPORT": "<%= p('syslog_daemon_config.transport') %>"
+      }
     }
   ]
 }

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -185,3 +185,13 @@ properties:
   diego.rep.optional_placement_tags:
     description: "Array of optional tags used for scheduling Tasks and LRPs"
     default: []
+
+  syslog_daemon_config.address:
+    description: "Syslog host"
+    default: ""
+  syslog_daemon_config.port:
+    description: "Syslog port"
+    default: ""
+  syslog_daemon_config.transport:
+    description: "Syslog transport protocol (tcp or udp)"
+    default: "udp"


### PR DESCRIPTION
A/C: As an operator I should be able to see logs from `rep_windows` in
syslog destination `syslog_daemon_config` defined in my cf manifest.

The support for the new environment variables has been added to AWS stemcell version `0.0.73` and above. 

[#133698951]
https://www.pivotaltracker.com/story/show/133698951

Signed-off-by: Natalie Arellano <narellano@pivotal.io>