### PR TITLE
Timeout Azure metadata query after 5 seconds

### DIFF
--- a/jobs/rep/templates/rep_as_vcap.erb
+++ b/jobs/rep/templates/rep_as_vcap.erb
@@ -42,7 +42,7 @@ export GODEBUG=netdns=cgo
 zone=<%= Shellwords.shellescape(spec.az || p("diego.rep.zone")) %>
 <% if p("diego.rep.use_azure_fault_domains") %> \
 set +e
-  azure_fd=$(curl -f --connect-timeout 5 --silent http://169.254.169.254/metadata/v1/InstanceInfo/FD)
+  azure_fd=$(curl -f --max-time 5 --connect-timeout 5 --silent http://169.254.169.254/metadata/v1/InstanceInfo/FD)
   if [ 0 -eq $? ]; then
     zone=z${azure_fd}
   fi


### PR DESCRIPTION
 for other clouds that may have stealth firewalls.  

We have a case of where a vSphere environment answers on this address and hangs, causing rep race conditions to occur and the Diego cells never to come up.   

This fixes https://www.pivotaltracker.com/story/show/132794513
