### PR TITLE
Fix powershell error handling and exit code.

### DIFF
--- a/jobs/rep_windows/templates/drain.ps1.erb
+++ b/jobs/rep_windows/templates/drain.ps1.erb
@@ -1,3 +1,6 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
 $SERVICE_NAME="rep_windows"
 $LOG_DIR="/var/vcap/sys/log/rep_windows"
 $LOGFILE="${LOG_DIR}/drain.log"

--- a/packages/golang-windows/packaging
+++ b/packages/golang-windows/packaging
@@ -1,23 +1,17 @@
 . ./exiter.ps1
 
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
 $GOLANG_ZIP="golang/go1.7.3.windows-amd64.zip"
-try
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
 {
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    function Unzip
-    {
-        param([string]$zipfile, [string]$outpath)
+    param([string]$zipfile, [string]$outpath)
 
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
-    }
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
 
-    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
-    Unzip "$GOLANG_ZIP" "$BOSH_INSTALL_TARGET"
-}
-catch
-{
-    Write-Error "Error installing go:"
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+Unzip "$GOLANG_ZIP" "$env:BOSH_INSTALL_TARGET"
+
 Exit 0

--- a/packages/rep_windows/packaging
+++ b/packages/rep_windows/packaging
@@ -1,40 +1,38 @@
 . ./exiter.ps1
 
-try {
-    $BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
-} catch {
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
 
 $env:GOROOT="C:\var\vcap\packages\golang-windows\go"
 $env:GOPATH="${BOSH_INSTALL_TARGET}"
 $env:PATH="${env:GOROOT}\bin;${env:PATH}"
 $pkg_name="rep"
-$pkg_path="code.cloudfoundry.org\rep\cmd\rep"
+$pkg_path="code.cloudfoundry.org/rep/cmd/rep"
 
-try
-{
-    # Create GOPATH
-    New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}/src"
-    robocopy /E "${PWD}" "${BOSH_INSTALL_TARGET}/src"
-    if ($LASTEXITCODE -ge 8) {
-        Exit 1
-    }
+# Create GOPATH
+New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}\src"
 
-    go.exe build -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_path}"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Error compiling: ${pkg_path}"
-        Exit 1
-    }
-
-    # Cleanup build artifacts
-    Remove-Item -Force -Recurse "${BOSH_INSTALL_TARGET}/src"
+robocopy.exe /E "${PWD}" "${BOSH_INSTALL_TARGET}\src"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy.exe /E ${PWD} ${BOSH_INSTALL_TARGET}\src"
 }
-catch
-{
-    Write-Error $_.Exception.Message
-    Exit 1
+
+go.exe build -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_path}"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error compiling: ${pkg_path}"
 }
+
+# Cleanup build artifacts
+New-Item -ItemType directory -Path ".\emptydirectory" -Force
+
+robocopy.exe ".\emptydirectory" "${BOSH_INSTALL_TARGET}\src" /PURGE
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy.exe .\emptydirectory ${BOSH_INSTALL_TARGET}\src /PURGE"
+}
+
+Remove-Item -Recurse -Path "${BOSH_INSTALL_TARGET}\src" -Force
+Remove-Item -Recurse -Path ".\emptydirectory" -Force
 
 Exit 0


### PR DESCRIPTION
Stop script execution on error and return a non-zero exit code. Previously,
PowerShell happily plowed through errors with little regard for traps,
try catch blocks or the non-zero exits within them.

[#134462851]

Signed-off-by: Charlie Vieth <cviethjr@pivotal.io>