### PR TITLE
Make cellID configurable

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -71,6 +71,8 @@ properties:
   diego.rep.advertise_domain:
     description: "base domain at which the rep should advertise its secure API"
     default: "cell.service.cf.internal"
+  diego.rep.cell_id:
+    description: "Hostname of the cell"
   diego.rep.listen_addr_securable:
     description: "address where rep listens for LRP and task start auction requests"
     default: "0.0.0.0:1801"

--- a/jobs/rep/templates/rep_as_vcap.erb
+++ b/jobs/rep/templates/rep_as_vcap.erb
@@ -71,7 +71,7 @@ exec /var/vcap/packages/rep/bin/rep ${bbs_sec_flags} ${rep_sec_flags} \
   <%= p("diego.rep.rootfs_providers").map { |provider| "-rootFSProvider #{provider}" }.join(" ") %> \
   <%= p("diego.rep.placement_tags").map { |tag| "-placementTag #{Shellwords.shellescape(tag)}" }.join(" ") %> \
   <%= p("diego.rep.optional_placement_tags").map { |tag| "-optionalPlacementTag #{Shellwords.shellescape(tag)}" }.join(" ") %> \
-  -cellID=<%= spec.job.name %>-<%= spec.index %>-<%= spec.id %> \
+  -cellID=<%= p("diego.rep.cell_id", "#{spec.job.name}-#{spec.index}-#{spec.id}") %> \
   -zone="${zone}" \
   -pollingInterval=<%= "#{p("diego.rep.polling_interval_in_seconds")}s" %> \
   -evacuationPollingInterval=<%= "#{p("diego.rep.evacuation_polling_interval_in_seconds")}s" %> \

--- a/jobs/rep_windows/templates/start.ps1.erb
+++ b/jobs/rep_windows/templates/start.ps1.erb
@@ -67,7 +67,7 @@
   -advertiseDomain="#{p("diego.rep.advertise_domain")}" \
   -enableLegacyApiServer="#{p("diego.rep.enable_legacy_api_endpoints")}" \
   #{preloaded_rootfses} \
-  -cellID=#{spec.job.name}-#{spec.index}-#{spec.id} \
+  -cellID="#{p("diego.rep.cell_id", "#{spec.job.name}-#{spec.index}-#{spec.id}")}" \
   -zone="#{zone}" \
   -pollingInterval="#{p("diego.rep.polling_interval_in_seconds")}s" \
   -evacuationPollingInterval="#{p("diego.rep.evacuation_polling_interval_in_seconds")}s" \


### PR DESCRIPTION
Non-BOSH deployments may have a different mechanism to name VMs, so make the cellID configurable via a property (together with the advertise_domain it must form the FQDN of the cell).  If the property is not set, then the default naming algorithm will still be used, making this change completely backwards compatible.

Note: I've only tested the `rep_as_vcap` change, and then made a corresponding `start.ps1` change for the Windows cell. I hope I got it right!