### PR TITLE
Open firewall port for rep

### DIFF
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -3,6 +3,7 @@ name: rep_windows
 
 templates:
   drain.ps1.erb: bin/drain.ps1
+  pre-start.ps1.erb: bin/pre-start.ps1
   start.ps1.erb: bin/start.ps1
   bbs_ca.crt.erb: config/certs/bbs/ca.crt
   trusted_certs.crt.erb: config/certs/rep/trusted_certs.crt

--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+Write-Host "Running pre-start"
+
+$PORT="<%= p("diego.rep.enable_legacy_api_endpoints") ? p("diego.rep.listen_addr").sub(/^0\.0\.0\.0:/, "") : p("diego.rep.listen_addr_admin").sub(/^127\.0\.0\.1:/, "")%>"
+
+if ($PORT -eq "") {
+  Write-Error "Unable to find the port for rep_windows"
+}
+if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "RepPort" })) {
+  New-NetFirewallRule -DisplayName "RepPort" -Action Allow -Direction Inbound -Enabled True -LocalPort $PORT -Protocol TCP
+  if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "RepPort" })) {
+    Write-Error "Unable to add RepPort firewall rule"
+  }
+}


### PR DESCRIPTION
After applying Group Policies for Windows stemcells (currently only vsphere stemcells), we need to open the port Rep is listening on.

[#135440395](https://www.pivotaltracker.com/story/show/135440395)