### PR TITLE
Use diego-sshd package for windows_app_lifecycle

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -3,10 +3,6 @@ jq/jq-linux64:
   object_id: 176d1ae8-3602-4291-90c4-f29342b48aec
   sha: d8e36831c3c94bb58be34dd544f44a6c6cb88568
   size: 3027945
-lifecycles/windows_app_lifecycle-6f1b94d.tgz:
-  object_id: 1ae33eaf-0c05-4154-8e74-4f1bf37dd90c
-  sha: ea4ca26d21439377480ef12607d0174f1b06beb6
-  size: 4889563
 golang/go1.7.4.linux-amd64.tar.gz:
   object_id: 2b2e301b-ff53-4547-988a-5476630addf7
   sha: 2e5baf03d1590e048c84d1d5b4b6f2540efaaea1
@@ -15,3 +11,7 @@ golang/go1.7.4.windows-amd64.zip:
   object_id: bf5c2c01-a92b-4a28-a6b5-7d4b8fe138e3
   sha: a0da2f5d67e5b800eba811a34ca4b2aa22cca678
   size: 90409580
+lifecycles/windows_app_lifecycle-99fe343.tgz:
+  object_id: 4d7e4afc-b459-47d8-80d0-8c328a639b47
+  sha: 18e2fc9dee92776a27cca11265c4d9ae4d5899cb
+  size: 1799019

--- a/packages/diego-sshd/packaging
+++ b/packages/diego-sshd/packaging
@@ -8,12 +8,15 @@ export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
+GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
 
 ldd sshd && echo 'diego-sshd must be statically linked' && false
 
 mv sshd diego-sshd
-
 tar -czf ${BOSH_INSTALL_TARGET}/diego-sshd.tgz diego-sshd
+
+mv sshd.exe diego-sshd.exe
+tar -czf ${BOSH_INSTALL_TARGET}/diego-sshd-windows.tgz diego-sshd.exe
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -1,2 +1,6 @@
 set -e
-cp lifecycles/windows_app_lifecycle-*.tgz ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz
+
+mkdir -p tmp
+tar -xzf lifecycles/windows_app_lifecycle-*.tgz -C tmp
+tar -xzf /var/vcap/packages/diego-sshd/diego-sshd-windows.tgz -C tmp
+tar -czvf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz -C tmp .

--- a/packages/windows_app_lifecycle/spec
+++ b/packages/windows_app_lifecycle/spec
@@ -3,3 +3,6 @@ name: windows_app_lifecycle
 
 files:
   - lifecycles/windows_app_lifecycle-*.tgz
+
+dependencies:
+ - diego-sshd


### PR DESCRIPTION
Instead of the submoduling the `diego-release` in [`windows_app_lifecycle`](https://github.com/cloudfoundry/windows_app_lifecycle) we
can inject the `diego-sshd` in the packaging script instead. This way we are in-sync with the upstream changes.

[#135953721]

Signed-off-by: Amin Jamali <ajamali@pivotal.io>