### PR TITLE
Import DB properties from CF config

### DIFF
--- a/examples/stub-sql.yml
+++ b/examples/stub-sql.yml
@@ -1,0 +1,11 @@
+config_from_cf: (( merge ))
+
+sql_overrides:
+  bbs:
+    db_driver: postgres
+    db_host: (( config_from_cf.sql.host ))
+    db_port: (( config_from_cf.sql.port ))
+    db_username: diego
+    db_password: (( config_from_cf.sql.password ))
+    db_schema: diego
+    max_open_connections: 500

--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -54,6 +54,10 @@ config_from_cf:
     ssh_proxy_client_secret: (( properties.uaa.clients.ssh-proxy.secret ))
     token_url: (( properties.uaa.url "/oauth/token" ))
   app_domains: (( properties.app_domains ))
+  sql:
+    host: (( properties.databases.address ))
+    port: (( properties.databases.port ))
+    password: (( properties.databases.roles.diego.password ))
 
 # The keys below should not be included in the final stub
 name: (( merge ))
@@ -77,6 +81,12 @@ properties:
     encrypt_keys: (( merge ))
     server_cert: (( merge ))
     server_key: (( merge ))
+  databases:
+    address: (( merge ))
+    port: (( merge ))
+    roles:
+    - name: diego
+      password: (( merge ))
   etcd:
     advertise_urls_dns_suffix: (( merge ))
     ca_cert: (( merge || nil ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -56,3 +56,8 @@ config_from_cf:
     ssh_proxy_client_secret: (( merge ))
     token_url: (( merge ))
   app_domains: (( merge ))
+  sql:
+    host: (( merge ))
+    port: (( merge ))
+    password: (( merge ))
+

--- a/scripts/generate-cf-postgres-sql-stub
+++ b/scripts/generate-cf-postgres-sql-stub
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ -z $1 ]; then
+  echo "Usage: $0 <path to CF manifest>"
+  exit 1
+fi
+
+spiff m examples/stub-sql.yml manifest-generation/config-from-cf-internal.yml $1


### PR DESCRIPTION
Starting from last release we have to provide DB properties to deploy Diego.
Unfortunately, there are no way to import current CF DB credentials to the stub file, because they are not merged in `config-from-cf` stubs.
Because of that, I've added example stub file along with changes to `config-from-cf` stubs to import CF database credentials, to use the same DB for Diego. 
Hope you see it helpful.