### PR TITLE
Allow CA overriding when generating mutual TLS certs

### DIFF
--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -457,6 +457,7 @@ The CF and Diego release repositories provide scripts to generate the necessary 
 1. To generate certificates for consul, loggregator run:
 ```bash
 cd $DEPLOYMENT_DIR/certs
+$CF_RELEASE_DIR/scripts/generate-cf-diego-certs
 $CF_RELEASE_DIR/scripts/generate-consul-certs
 $CF_RELEASE_DIR/scripts/generate-loggregator-certs
 ```
@@ -477,7 +478,7 @@ popd
 
 1. To generate certificates for BBS servers in the Diego deployment, run:
 ```bash
-$DIEGO_RELEASE_DIR/scripts/generate-diego-certs
+$DIEGO_RELEASE_DIR/scripts/generate-diego-certs cf-diego-ca $CF_RELEASE_DIR/cf-diego-certs
 mv $DIEGO_RELEASE_DIR/diego-certs/* $DEPLOYMENT_DIR/certs
 ```
 
@@ -526,6 +527,7 @@ DEPLOYMENT_DIR/certs
 
 You can ignore any files with a `crl` or `csr` extension.
 
+The certificates in `cf-diego-certs` are used to set SSL properties for the communication between CF and Diego.
 The certificates in `consul-certs` are used to set SSL properties for the consul VMs.
 The certificates in `loggregator-certs` are used to set SSL properties for the Loggregator subsystem.
 The certificates in `uaa-certs` are used to set SSL properties for the UAA subsystem.

--- a/examples/aws/deploy_aws_environment
+++ b/examples/aws/deploy_aws_environment
@@ -49,6 +49,10 @@ cf_credentials() {
 ---
 cf_credentials:
   ssh_host_key_fingerprint: "$(cat keypair/ssh-proxy-host-key-fingerprint)"
+  cc:
+$(block ca_cert      certs/cf-diego-certs/cf-diego-ca.crt      | indent | indent)
+$(block public_cert  certs/cf-diego-certs/cloud-controller.crt | indent | indent)
+$(block private_key  certs/cf-diego-certs/cloud-controller.key | indent | indent)
   consul:
 $(block ca_cert     certs/consul-certs/server-ca.crt | indent | indent)
 $(block agent_cert  certs/consul-certs/agent.crt     | indent | indent)

--- a/examples/aws/stubs/cf/properties.yml
+++ b/examples/aws/stubs/cf/properties.yml
@@ -14,6 +14,21 @@ properties:
     encrypt_keys:
       - REPLACE_WITH_CONSUL_ENCRYPTION_KEY
 
+  mutual_tls:
+    ca_cert: REPLACE_WITH_CF_DIEGO_CA_CERT
+    public_cert: REPLACE_WITH_CLOUD_CONTROLLER_CERT
+    private_key: REPLACE_WITH_CLOUD_CONTROLLER_KEY
+
+  loggregator:
+    tls:
+      doppler:
+        cert: REPLACE_WITH_DOPPLER_CERT
+        key: REPLACE_WITH_DOPPLER_KEY
+      trafficcontroller:
+        cert: REPLACE_WITH_TRAFFICCONTROLLER_CERT
+        key: REPLACE_WITH_TRAFFICCONTROLLER_KEY
+      ca_cert: REPLACE_WITH_LOGGREGATOR_CA_CERT
+
   loggregator_endpoint:
     shared_secret: REPLACE_WITH_LOGGREGATOR_PASSWORD
 

--- a/examples/aws/stubs/cf/properties.yml
+++ b/examples/aws/stubs/cf/properties.yml
@@ -14,11 +14,6 @@ properties:
     encrypt_keys:
       - REPLACE_WITH_CONSUL_ENCRYPTION_KEY
 
-  mutual_tls:
-    ca_cert: REPLACE_WITH_CF_DIEGO_CA_CERT
-    public_cert: REPLACE_WITH_CLOUD_CONTROLLER_CERT
-    private_key: REPLACE_WITH_CLOUD_CONTROLLER_KEY
-
   loggregator:
     tls:
       doppler:

--- a/examples/aws/templates/cf/stub-internal.yml
+++ b/examples/aws/templates/cf/stub-internal.yml
@@ -171,6 +171,10 @@ properties:
       droplet_directory_key: (( Resources.Bucket.Droplets ))
     buildpacks:
       buildpack_directory_key: (( Resources.Bucket.Buildpacks ))
+    mutual_tls:
+      ca_cert: (( cf_credentials.cc.ca_cert ))
+      public_cert: (( cf_credentials.cc.public_cert ))
+      private_key: (( cf_credentials.cc.private_key ))
 
   ccdb:
     address: (( properties.databases.address ))

--- a/examples/aws/templates/cf/stub.yml
+++ b/examples/aws/templates/cf/stub.yml
@@ -177,6 +177,10 @@ properties:
       droplet_directory_key: (( merge ))
     buildpacks:
       buildpack_directory_key: (( merge ))
+    mutual_tls:
+      ca_cert: (( merge ))
+      public_cert: (( merge ))
+      private_key: (( merge ))
 
   loggregator:
     tls:

--- a/scripts/generate-diego-certs
+++ b/scripts/generate-diego-certs
@@ -2,11 +2,22 @@
 
 set -e -x
 
+existing_ca="$1"
+existing_depot="$2"
+
 pushd `dirname "$0"`/..
-  scripts/generate-diego-ca-certs
-  scripts/generate-bbs-certs diego-ca diego-certs
-  scripts/generate-rep-certs diego-ca diego-certs
-  scripts/generate-auctioneer-certs diego-ca diego-certs
+  if [ -z "$existing_ca" ]; then
+    scripts/generate-diego-ca-certs
+    existing_ca=diego-ca
+  fi
+
+  if [ -z "$existing_depot" ]; then
+    existing_depot=diego-certs
+  fi
+
+  scripts/generate-bbs-certs "$existing_ca" "$existing_depot"
+  scripts/generate-rep-certs "$existing_ca" "$existing_depot"
+  scripts/generate-auctioneer-certs "$existing_ca" "$existing_depot"
 popd
 
 echo "Outputted certs to diego-certs"


### PR DESCRIPTION
This enables the use case where Cloud Controller passes in HTTPS urls
for task callbacks that require mututal tls.
In that scenario, the CA that signs both diego and cloud controller
certificates have to be the same, this commit allows that CA to be
passed in as an argument.

Also, adds documentation to examples/aws/README.md as to how to deploy a
Diego cluster with this enabled.

Signed-off-by: Eric Promislow <eric.promislow@gmail.com>