### PR TITLE
Generalize running_in_container function

### DIFF
--- a/src/pid_utils.sh
+++ b/src/pid_utils.sh
@@ -182,5 +182,6 @@ file_must_include() {
 }
 
 running_in_container() {
-  grep -q -E '/instance|/docker/' /proc/self/cgroup
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
 }


### PR DESCRIPTION
This change allows jobs to run correctly in garden-runc containers
as well as in the previously supported garden-linux and docker containers.