### PR TITLE
Run rep.exe directly, no powershell start script

### DIFF
--- a/jobs/rep_windows/monit
+++ b/jobs/rep_windows/monit
@@ -2,8 +2,8 @@
   "processes": [
     {
       "name": "rep_windows",
-      "executable": "powershell",
-      "args": ["C:\\var\\vcap\\jobs\\rep_windows\\bin\\start.ps1"],
+      "executable": "C:\\var\\vcap\\packages\\rep_windows\\rep.exe",
+      "args": ["-config", "/var/vcap/jobs/rep_windows/config/rep.json"],
       "env": {
         "__PIPE_SYSLOG_HOST": "<%= p('syslog_daemon_config.address') %>",
         "__PIPE_SYSLOG_PORT": "<%= p('syslog_daemon_config.port') %>",

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -4,7 +4,6 @@ name: rep_windows
 templates:
   drain.ps1.erb: bin/drain.ps1
   pre-start.ps1.erb: bin/pre-start.ps1
-  start.ps1.erb: bin/start.ps1
   bbs_ca.crt.erb: config/certs/bbs/ca.crt
   trusted_certs.crt.erb: config/certs/rep/trusted_certs.crt
   bbs_client.crt.erb: config/certs/bbs/client.crt

--- a/jobs/rep_windows/templates/start.ps1.erb
+++ b/jobs/rep_windows/templates/start.ps1.erb
@@ -1,7 +1,0 @@
-<%=
-  CONF_DIR="/var/vcap/jobs/rep_windows/config"
-
-  %{/var/vcap/packages/rep_windows/rep.exe \
-  -config="#{CONF_DIR}/rep.json"
-  }
-%>


### PR DESCRIPTION
This PR removes the unnecessary powershell start script for rep.exe, as per [this story](https://www.pivotaltracker.com/story/show/134103211) and [this old PR](https://github.com/cloudfoundry/diego-release/pull/225)