### PR TITLE
Add require_tls property to rep and rep_windows

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -13,6 +13,9 @@ templates:
   rep_ca.crt.erb: config/certs/ca.crt
   rep_server.crt.erb: config/certs/server.crt
   rep_server.key.erb: config/certs/server.key
+  consul_ca.crt.erb: config/certs/consul/ca.crt
+  consul_client.crt.erb: config/certs/consul/client.crt
+  consul_client.key.erb: config/certs/consul/client.key
   rep.json.erb: config/rep.json
   post-start.erb: bin/post-start
 
@@ -91,6 +94,16 @@ properties:
   diego.executor.ca_certs_for_downloads:
     description: "Concatenation of trusted CA certificates to be used when downloading assets."
     default: null
+
+  diego.rep.consul.require_tls:
+    description: "Require mutual TLS to talk to the local consul API"
+    default: false
+  diego.rep.consul.ca_cert:
+    description: "PEM-encoded CA certificate"
+  diego.rep.consul.client_cert:
+    description: "PEM-encoded client certificate"
+  diego.rep.consul.client_key:
+    description: "PEM-encoded client key"
 
   diego.executor.memory_capacity_mb:
     description: "the memory capacity the executor should manage.  this should not be greater than the actual memory on the VM"

--- a/jobs/rep/templates/consul_ca.crt.erb
+++ b/jobs/rep/templates/consul_ca.crt.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.ca_cert") %>
+<% end %>

--- a/jobs/rep/templates/consul_client.crt.erb
+++ b/jobs/rep/templates/consul_client.crt.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.client_cert") %>
+<% end %>

--- a/jobs/rep/templates/consul_client.key.erb
+++ b/jobs/rep/templates/consul_client.key.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.client_key") %>
+<% end %>

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -5,7 +5,6 @@ TRUSTED_CERTS_DIR = "/var/vcap/data/executor/trusted_certs"
 
 config = {
  "dropsonde_port" => p("diego.rep.dropsonde_port"),
- "consul_cluster" => "http://127.0.0.1:8500",
  "debug_address" => p("diego.rep.debug_addr"),
  "listen_addr" => p("diego.rep.enable_legacy_api_endpoints") ? p("diego.rep.listen_addr") : p("diego.rep.listen_addr_admin"),
  "listen_addr_securable" => p("diego.rep.listen_addr_securable"),
@@ -65,6 +64,15 @@ if p("diego.rep.require_tls")
 	config[:ca_cert_file] =  "#{CONF_DIR}/certs/ca.crt"
 	config[:server_cert_file] =  "#{CONF_DIR}/certs/server.crt"
 	config[:server_key_file] =  "#{CONF_DIR}/certs/server.key"
+end
+
+if p("diego.rep.consul.require_tls")
+ config[:consul_cluster] = "https://127.0.0.1:8500"
+ config[:consul_ca_cert] = "#{CONF_DIR}/certs/consul/ca.crt"
+ config[:consul_client_cert] = "#{CONF_DIR}/certs/consul/client.crt"
+ config[:consul_client_key] = "#{CONF_DIR}/certs/consul/client.key"
+else
+ config[:consul_cluster] = "http://127.0.0.1:8500"
 end
 
 if_p("diego.rep.bbs.client_session_cache_size") do |value|

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -11,6 +11,9 @@ templates:
   rep_ca.crt.erb: config/certs/ca.crt
   rep_server.crt.erb: config/certs/server.crt
   rep_server.key.erb: config/certs/server.key
+  consul_ca.crt.erb: config/certs/consul/ca.crt
+  consul_client.crt.erb: config/certs/consul/client.crt
+  consul_client.key.erb: config/certs/consul/client.key
   rep.json.erb: config/rep.json
 
 packages:
@@ -81,6 +84,16 @@ properties:
   diego.executor.ca_certs_for_downloads:
     description: "Concatenation of trusted CA certificates to be used when downloading assets."
     default: null
+
+  diego.rep.consul.require_tls:
+    description: "Require mutual TLS to talk to the local consul API"
+    default: false
+  diego.rep.consul.ca_cert:
+    description: "PEM-encoded CA certificate"
+  diego.rep.consul.client_cert:
+    description: "PEM-encoded client certificate"
+  diego.rep.consul.client_key:
+    description: "PEM-encoded client key"
 
   diego.executor.memory_capacity_mb:
     description: "the memory capacity the executor should manage.  this should not be greater than the actual memory on the VM"

--- a/jobs/rep_windows/templates/consul_ca.crt.erb
+++ b/jobs/rep_windows/templates/consul_ca.crt.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.ca_cert") %>
+<% end %>

--- a/jobs/rep_windows/templates/consul_client.crt.erb
+++ b/jobs/rep_windows/templates/consul_client.crt.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.client_cert") %>
+<% end %>

--- a/jobs/rep_windows/templates/consul_client.key.erb
+++ b/jobs/rep_windows/templates/consul_client.key.erb
@@ -1,0 +1,3 @@
+<% if p("diego.rep.consul.require_tls") %>
+<%= p("diego.rep.consul.client_key") %>
+<% end %>

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -5,7 +5,6 @@ TRUSTED_CERTS_DIR = "/var/vcap/data/executor/trusted_certs"
 
 config = {
  "dropsonde_port" => p("diego.rep.dropsonde_port"),
- "consul_cluster" => "http://127.0.0.1:8500",
  "debug_address" => p("diego.rep.debug_addr"),
  "listen_addr" => p("diego.rep.enable_legacy_api_endpoints") ? p("diego.rep.listen_addr") : p("diego.rep.listen_addr_admin"),
  "listen_addr_securable" => p("diego.rep.listen_addr_securable"),
@@ -65,6 +64,15 @@ if p("diego.rep.require_tls")
 	config[:ca_cert_file] =  "#{CONF_DIR}/certs/ca.crt"
 	config[:server_cert_file] =  "#{CONF_DIR}/certs/server.crt"
 	config[:server_key_file] =  "#{CONF_DIR}/certs/server.key"
+end
+
+if p("diego.rep.consul.require_tls")
+ config[:consul_cluster] = "https://127.0.0.1:8500"
+ config[:consul_ca_cert] = "#{CONF_DIR}/certs/consul/ca.crt"
+ config[:consul_client_cert] = "#{CONF_DIR}/certs/consul/client.crt"
+ config[:consul_client_key] = "#{CONF_DIR}/certs/consul/client.key"
+else
+ config[:consul_cluster] = "http://127.0.0.1:8500"
 end
 
 if_p("diego.rep.bbs.client_session_cache_size") do |value|

--- a/manifest-generation/diego-windows.yml
+++ b/manifest-generation/diego-windows.yml
@@ -152,7 +152,7 @@ properties:
   # -- Properties below are used by the consul_agent job from cf-release --
   consul:
     agent:
-      require_ssl: false
+      require_ssl: (( property_overrides.consul.agent.require_ssl || nil ))
       datacenter: (( config_from_cf.consul.datacenter ))
       domain: (( config_from_cf.consul.domain ))
       log_level: (( config_from_cf.consul.log_level ))
@@ -190,6 +190,11 @@ properties:
       ca_cert: (( property_overrides.rep.ca_cert || nil ))
       server_cert: (( property_overrides.rep.server_cert || nil ))
       server_key: (( property_overrides.rep.server_key || nil ))
+      consul:
+        require_tls: (( property_overrides.rep.consul.require_tls || nil ))
+        ca_cert: (( config_from_cf.consul.ca_cert ))
+        client_cert: (( property_overrides.rep.consul.client_cert || nil ))
+        client_key: (( property_overrides.rep.consul.client_key || nil ))
 
 # The keys below should not be included in the final stub
 config_from_cf: (( merge ))


### PR DESCRIPTION
This makes it possible to secure the local consul API.

Note that this depends on the corresponding functionality of consul-release that has been merged to develop (but not yet released.)