### PR TITLE
Override garden property apparmor_profile

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -702,6 +702,7 @@ properties:
   garden:
     allow_host_access: (( property_overrides.garden.allow_host_access || nil ))
     allow_networks: (( property_overrides.garden.allow_networks || nil ))
+    apparmor_profile: (( property_overrides.garden.apparmor_profile || nil ))
     default_container_grace_time: (( property_overrides.garden.default_container_grace_time || 0 ))
     deny_networks: (( property_overrides.garden.deny_networks || ["0.0.0.0/0"] ))
     destroy_containers_on_start: (( property_overrides.garden.destroy_containers_on_start || true ))


### PR DESCRIPTION
This exposes the apparmor_profile property which will be configurable after this [PR](https://github.com/cloudfoundry/garden-runc-release/pull/22)