### PR TITLE
Enable setting idle and open connections in bbs

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -118,6 +118,8 @@ properties:
     default: ""
   diego.bbs.sql.max_open_connections:
     description: "Maximum number of open connections to the SQL database"
+  diego.bbs.sql.max_idle_connections:
+    description: "Maximum number of idle connections to the SQL database"
   diego.bbs.sql.require_ssl:
     description: "Whether to require SSL for BBS communication to the SQL backend"
     default: false

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -126,7 +126,11 @@ if p("diego.bbs.sql.require_ssl")
 end
 
 if_p("diego.bbs.sql.max_open_connections") do |value|
-  config[:max_database_connections] = value
+  config[:max_open_database_connections] = value
+end
+
+if_p("diego.bbs.sql.max_idle_connections") do |value|
+  config[:max_idle_database_connections] = value
 end
 
 if_p("diego.bbs.sql.db_driver") do |value|


### PR DESCRIPTION
In collaboration with the BBS PR https://github.com/cloudfoundry/bbs/pull/16

This will allow for setting both the max open database connections and max idle database connections.

