### PR TITLE
Bugfix diego.rep.trusted_certs leading two spaces in first certificate

### DIFF
--- a/jobs/rep/templates/trusted_certs.crt.erb
+++ b/jobs/rep/templates/trusted_certs.crt.erb
@@ -1,3 +1,3 @@
 <% if_p("diego.rep.trusted_certs") do |value| %>
-  <%= value %>
+<%= value %>
 <% end %>


### PR DESCRIPTION
When adding certificates with diego.rep.trusted_certs the first certificate gets a prefix of two spaces rendering it invalid. This should fix it.