### PR TITLE
TPS-watcher uses mTLS to talk to CC

### DIFF
--- a/examples/aws/templates/diego/property-overrides.yml
+++ b/examples/aws/templates/diego/property-overrides.yml
@@ -51,3 +51,8 @@ property_overrides:
   ssh_proxy:
     enable_cf_auth: true
     host_key: (( merge ))
+  tps:
+    cc:
+      client_cert: (( merge ))
+      client_key: (( merge ))
+      ca_cert: (( merge ))

--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -710,3 +710,89 @@ property_overrides:
       -----END RSA PRIVATE KEY-----
     rep:
       require_tls: false
+  tps:
+    cc:
+      client_cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIEITCCAgmgAwIBAgIQasImDimkehsKb8vRERSoMDANBgkqhkiG9w0BAQsFADAQ
+        MQ4wDAYDVQQDEwViYnNDQTAeFw0xNzAxMjMyMjQ5NTdaFw0xOTAxMjMyMjQ5NTda
+        MBYxFDASBgNVBAMTC3RwcyB3YXRjaGVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+        MIIBCgKCAQEAqW2RL4j7Zl375KUbthflFsNrJqhMjzrKaTrQ6PTeeddeaqHS7QBa
+        RDUFEGjPrBuGGlQ1mmhMx6fIOAzETmDusXy2bLuZUHGMHtInGrwE8A2Nn89Sfif0
+        e940mkAqTVz92WERJm1EJpugkYRtluq2iU2txrnAC5r0ktPU/Asbmg9nJSqlycNi
+        bDwdJ0dMsMp9eeAD7hbpjew6qAEZ8PeheK42qacZkdK5sZtecjLyQRAHN3ys8ekF
+        kPrsHcXnyUmzHHOhaUiweakx2uHr8suUeqYfW+hSaMyzYjKQmlkCbKcf8zYF+1uf
+        Sou1oQM1m+QlnRXw9iXI0+C2mofOMadN2QIDAQABo3EwbzAOBgNVHQ8BAf8EBAMC
+        A7gwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBSyORSu
+        EyxJWhqmqPeuwLMXmljT9zAfBgNVHSMEGDAWgBTYcWew/0k5ZG8q8OzlhKSPH6v8
+        szANBgkqhkiG9w0BAQsFAAOCAgEASZ1FgYdXGQTpaPqRc73ewNkqRer2+lDXoLTM
+        RhUVbPbx+rlmn/kPupsrrery5LwssEVM2Jnn0/oPYGlkW6Z0dwjOd3+KOxyFnJ0G
+        Wp2aqiEE2EmLuxq4fMuLe2+xhw+hNz6Xa58VlaOUKtyXInh7F1mHBvSr8Jdvfrt6
+        T1HL/nE784qv+E3i+dB8A67mypU2TMCMMlHhXajfM0nkt/+lwWPrfUK2ghTzVKBI
+        E/StmnwA6GkrxupO7/v9hf9o300WuFEZoCeiWqb0K2WCt9YrfbD8soDVK5iSjtnV
+        rt1IyJAUAoCcZ13TscFun72s7OCmolup7yQs6z2hliMOsFKy4g4BnDa/QH9B7RdC
+        WubOxVU2BLXx1A2jKuzkrgbNlXAv3FOWkHpAEwzIch0BAADk/TzJeeiynIWSrIEv
+        vz91GuNSIu+lR8JFE/WX+aBaeWyIASKkfgZQ1hOLE5vMYbRJTcib1TMHeqgmJ1gz
+        FEl7bV/VG25bPIWyUbutBkM9dtMcHmNIE2VPRcHM6IMYJJ2MvUd1Ou2esH0TB5XX
+        3dXGuRuCXG0fDg/B7E2XXpZDZMEQU3yRBPCLlwGrmqs5bVWgWxjoH/tCTiAf72qY
+        eGOsw3gMY+7gVhBsQQj0HvuZsbK3LOPZQ6Va308rumePAhviSuKIMCGmHZGGuryz
+        EnGJ8kQ=
+        -----END CERTIFICATE-----
+      client_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpQIBAAKCAQEAqW2RL4j7Zl375KUbthflFsNrJqhMjzrKaTrQ6PTeeddeaqHS
+        7QBaRDUFEGjPrBuGGlQ1mmhMx6fIOAzETmDusXy2bLuZUHGMHtInGrwE8A2Nn89S
+        fif0e940mkAqTVz92WERJm1EJpugkYRtluq2iU2txrnAC5r0ktPU/Asbmg9nJSql
+        ycNibDwdJ0dMsMp9eeAD7hbpjew6qAEZ8PeheK42qacZkdK5sZtecjLyQRAHN3ys
+        8ekFkPrsHcXnyUmzHHOhaUiweakx2uHr8suUeqYfW+hSaMyzYjKQmlkCbKcf8zYF
+        +1ufSou1oQM1m+QlnRXw9iXI0+C2mofOMadN2QIDAQABAoIBAQCa5NOF3LrRpHyk
+        VRoXiJLlE7VDOzv6+emQ+LeDMlKum2nzHIykJd1gXASMMvYhR2x7Z5810cLYCRkv
+        vOQ/L7koxHZWw89vTs+mYcRkWZ4+BHYEs1qcgVSvZb87ggvqfGiLMoWmVuCmV0Md
+        pi82eNB2iHClrK3ZLkoIbedaoaETXyLA1nwTrUAiGV1001UfO0cEk6PGqGmzOV7W
+        zIsecErLc4bcrEHazV7YDz/PF16WL6gsJNQPxxkmcjcZ2jeA1GHx2B4oucCbq1D8
+        IjRJRQg3S8+LukWrojytYkhwuwv0K51c03f5OGY30ddsCAPrVlvjfKjaDHKGn6qU
+        qBSg4ei9AoGBANI9Vh3kS6tdxq7jPAVwelSbxAgIVLTclW1FWNuLP/YnihpaQBie
+        doW8biYru2GjZVuliINIr0wqCCFbr0q6OPytrUi3/ZFv9q3GuD1Hw8ha1M08ErcG
+        CRrEv6JmUlfk1UArNaLbBSQAqRzBrM8WAd0H98+DQqDjeisyDkB0w9wnAoGBAM5O
+        L7t/T03zSmbtwMvnaLAxnecunKjwGcq21jFjEQ2yimTVnuw9kVtrMWqL77pcvMWt
+        Y45Rx4GV1NaCAk3C4QAImvG0HjsKG5reFiMX6SseRmyE1587TTXohVNGO/prwik8
+        aIBdqZ5JGC0QTiZq+R/gf7sfZsDZ0YP3yZ1a08X/AoGBAMeOnvJqo4S6039ng65q
+        EEPFQrKZLcYq5s88ltZ1e7Xr3AOdjN+RclEJBcjHk+pezTPLkSOEV5hFAUignWei
+        EbuOI0A2HMLy8sQKLxFD0EuaJAnXLrB5UyUMghXlZ920ANMS8Ktvl5aP5fW8xIog
+        io5CJO/c2N6cbXcY4Tw/WTXbAoGBAI96qxHAgdwZpxYcpihpgVKAv2vH7CZGDfoA
+        3MiuOG8JS9zDAOsWCqDE1TJfrlMzKgplA0c4swL5vHOPKaEBNtB6K6CL/zZaWkaD
+        zGuNtplJTfstDHTunk0usILw5sfL59Yb8CXOfifaeBjnLSLk5Ov5i3wNY74d/uvE
+        ChEI2R3rAoGACLln5dpzZZN6u3tGxfk7fB8hfeIHR/uuivCA3lMwqK5FPPW7bsZV
+        DKRzrYEjMATvP2jsWOIbHWk6ETjvGw/v0CRr2o5fPPkxP5+BN80BjBV2JxVDAtZT
+        L/JpC+HhL2FaomBh4P0G9+uyZ+3P/yNrU1A5Jw8iKIQvfpqYMnvRk0k=
+        -----END RSA PRIVATE KEY-----
+      ca_cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIE/TCCAuegAwIBAgIBATALBgkqhkiG9w0BAQswEDEOMAwGA1UEAxMFYmJzQ0Ew
+        HhcNMTUwOTE1MjIyOTE4WhcNMjUwOTE1MjIyOTIxWjAQMQ4wDAYDVQQDEwViYnND
+        QTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKjxJkuxVD5jrls2jXfB
+        ZsWd3HisgpdpgrTObOeJnrb6g4BB7GOSqMlZDEl0ROEBuT4Ax+tSEyhO8FgDR6Mq
+        Ey8h/HyOmCOsxt+0ZOlgmY04eGrSgkzhG41UiBEkezgFdxNCB8NZjTwwQmO2qjM7
+        BsTS9SaEh11HdpIhoeu22aqXuP0r56ZaRC7rfPb+U9SaWaygwMfgXZ7ZDBizHz+n
+        gRSvQ+KnvHG1nZGR+vwuNikBdby8YRBVXaGjF1I7uZh/kcPm2XX9RwHaXSIgGyuK
+        C+YJy95L4WdX2sgm8Mm+mhIKRnGggBbmUmbDT8URkYIu11YEI/FqH/+WmEPv0UC7
+        U1rSVkQVhlHgO6Ohjoe251jw9U1UR0qXsfI/2maPESxJW2FDXOrBCzMK0/Us+y7M
+        rBRLhLkYJmv9GUFQG1M3eOfP6VIMMm6wZ1+2untcI7Eb+HZxhO91ddYlKNbFpZ7P
+        f0P0GuopPE6kzX3gFoivEHxIslumeoVDgMzQ4uj1TYGmOtjuiD48kIrVaeEKUcxN
+        7YzSt3tTZ+a1GKqFcuj+g/rbUYLBT5Ztj89O3AahnCzCymOJ3EkWQ4aJzdAs3KEG
+        RxGs2zzsBKkTp+UXXv4q/GrZ+J/PjqY9285TaQx3MZmdLdIyNoh6UwwFPdyEYsTv
+        xhtJb5NdjY9K56mkeVEkfuGtAgMBAAGjZjBkMA4GA1UdDwEB/wQEAwIABjASBgNV
+        HRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTYcWew/0k5ZG8q8OzlhKSPH6v8szAf
+        BgNVHSMEGDAWgBTYcWew/0k5ZG8q8OzlhKSPH6v8szALBgkqhkiG9w0BAQsDggIB
+        AFt3ueVxYhu5vT1IKL/xIuxfl8SXZqaJSg35DqJ6FlEDU+E/mjflrPMsV5Iz5ycd
+        JMO3hN9ipilkfx5m7gTIDcxl0izej2jlI2uncjLT6MsPI1+LsRxyVDR4+MDvM7ce
+        myfpIPNQlGQI/cTkmOT+tTaffwf6PLcvT/HvJivax/y0tIsCIqtTSoM6eoi6D9jN
+        n/VkMsZpaxxIt0nm87ZgcWA6IVPdtO51eLWlJyfz8/V8f/ySARUMdMSVkFiS6OMS
+        nxsrQGPLOOWTYepV6XD4GP9zDYL4aLArGfWprq79KHAtRYtGHixgcxFgbfBnon2y
+        6HG1vDa/sVFrleSwBRsCtVRgYvAShdn50hL4JgSn8OjkkTVB1wz74bqCj001RHfS
+        dxKhfzBPQsqsdGCMZKkRGUpUavM3qW/UAxbYgkjcS04hzmjyC/I1sKpDebQJyX9i
+        66F3zR7eRzwH7Y8s5PTo+dYZJmNxtN7vJKq++8Cg707XUzBT/U2SQV84TOsZO70Q
+        Hl7GKY3NdpVEslyiwMdi6DyhTH+MV3HMkEds16wCRNAVriSXPeg/GYNhQqcdTceU
+        I0YSumzEeQMcFbg0LUYayZ9PlhPgLosMba9BDK/K244OZvmGyRr1ANnnASsQg4cK
+        vsHDEV4jBWxHAw41ArfNLg9vA8ojf/1EU4E2d5GU5fVe
+        -----END CERTIFICATE-----

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -688,6 +688,9 @@ properties:
       cc:
         basic_auth_username: (( config_from_cf.cc.internal_api_user ))
         basic_auth_password: (( config_from_cf.cc.internal_api_password ))
+        ca_cert: (( property_overrides.tps.cc.ca_cert ))
+        client_cert: (( property_overrides.tps.cc.client_cert ))
+        client_key: (( property_overrides.tps.cc.client_key ))
       bbs:
         api_location: (( property_overrides.bbs.api_location || nil ))
         ca_cert: (( property_overrides.bbs.ca_cert ))


### PR DESCRIPTION
Add manifest generation to allow tps to configure mtls certs to use when communicating with CC