### PR TITLE
Use ca_certs_for_downloads in rep_windows

### DIFF
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -6,6 +6,7 @@ templates:
   pre-start.ps1.erb: bin/pre-start.ps1
   bbs_ca.crt.erb: config/certs/bbs/ca.crt
   trusted_certs.crt.erb: config/certs/rep/trusted_certs.crt
+  ca_certs_for_downloads.crt.erb: config/certs/rep/ca_certs_for_downloads.crt
   bbs_client.crt.erb: config/certs/bbs/client.crt
   bbs_client.key.erb: config/certs/bbs/client.key
   rep_ca.crt.erb: config/certs/ca.crt

--- a/jobs/rep_windows/templates/ca_certs_for_downloads.crt.erb
+++ b/jobs/rep_windows/templates/ca_certs_for_downloads.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("diego.executor.ca_certs_for_downloads") do |value| %>
+  <%= value %>
+<% end %>


### PR DESCRIPTION
This is required to enable SSL cert verification with custom CA certs. Currently custom certificates do not work in Windows cells because of the missing line this PR adds.