### PR TITLE
ssh_proxy provides conn link to be used by ha_proxy

### DIFF
--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -10,6 +10,10 @@ templates:
   uaa_ca.crt.erb: config/certs/uaa/ca.crt
   ssh_proxy.json.erb: config/ssh_proxy.json
 
+provides:
+- name: ssh_proxy
+  type: conn
+
 packages:
   - pid_utils
   - ssh_proxy

--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -12,7 +12,7 @@ templates:
 
 provides:
 - name: ssh_proxy
-  type: conn
+  type: ssh_proxy
 
 packages:
   - pid_utils


### PR DESCRIPTION
This effectively no-ops if no one consumes the link on the other side, but enable link consumption by the HAProxy on cf-release and avoids using consul templating.