### PR TITLE
Consul job consumes nil consul links

### DIFF
--- a/manifest-generation/bbs-overrides-no-etcd.yml
+++ b/manifest-generation/bbs-overrides-no-etcd.yml
@@ -4,6 +4,7 @@ bbs_overrides:
     consul: {}
   job_templates:
   - name: consul_agent
+    consumes: {consul: nil}
     release: cf
   - name: bbs
     release: diego

--- a/manifest-generation/diego-benchmarks.yml
+++ b/manifest-generation/diego-benchmarks.yml
@@ -34,6 +34,7 @@ jobs:
   - name: benchmark-bbs
     release: diego
   - name: consul_agent
+    consumes: {consul: nil}
     release: cf
   lifecycle: errand
   instances: 1

--- a/manifest-generation/diego-vizzini.yml
+++ b/manifest-generation/diego-vizzini.yml
@@ -38,6 +38,7 @@ jobs:
   - name: vizzini
     release: diego
   - name: consul_agent
+    consumes: {consul: nil}
     release: cf
   lifecycle: errand
   instances: 1

--- a/manifest-generation/diego-windows.yml
+++ b/manifest-generation/diego-windows.yml
@@ -204,6 +204,7 @@ base_templates:
   - name: garden-windows
     release: garden-windows
   - name: consul_agent_windows
+    consumes: {consul: nil}
     release: cf
   - name: metron_agent_windows
     release: cf

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -860,6 +860,7 @@ base_releases:
 release_versions: (( merge || nil ))
 default_bridge_jobs:
   - name: consul_agent
+    consumes: {consul: nil}
     release: cf
   - name: stager
     release: (( bridge_overrides.job_release || "cf" ))
@@ -875,6 +876,7 @@ default_bridge_jobs:
 base_job_templates:
   access:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: ssh_proxy
       release: diego
@@ -886,6 +888,7 @@ base_job_templates:
       release: diego
   brain:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: auctioneer
       release: diego
@@ -896,6 +899,7 @@ base_job_templates:
   cc_bridge: (( merge || default_bridge_jobs ))
   cell:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: rep
       release: diego
@@ -909,6 +913,7 @@ base_job_templates:
       release: diego
   database:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: etcd
       release: etcd
@@ -920,6 +925,7 @@ base_job_templates:
       release: diego
   route_emitter:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: route_emitter
       release: diego

--- a/manifest-generation/disable-deprecated-bridge-jobs.yml
+++ b/manifest-generation/disable-deprecated-bridge-jobs.yml
@@ -1,6 +1,7 @@
 base_job_templates:
   cc_bridge:
     - name: consul_agent
+      consumes: {consul: nil}
       release: cf
     - name: tps
       release: (( bridge_overrides.job_release ))


### PR DESCRIPTION
Consul now provides links, these will be implicitly used unless explicitly ignored via `consumes: {consul: nil}`.