### PR TITLE
sync require_ssl property

### DIFF
--- a/jobs/cfdot/spec
+++ b/jobs/cfdot/spec
@@ -11,7 +11,7 @@ packages:
   - cfdot
 
 properties:
-  diego.cfdot.bbs.use_ssl:
+  diego.cfdot.bbs.require_ssl:
     description: "true if the bbs requires TLS connections, false otherwise"
     default: true
   diego.cfdot.bbs.ca_cert:

--- a/jobs/cfdot/templates/setup.erb
+++ b/jobs/cfdot/templates/setup.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export PATH=/var/vcap/packages/cfdot/bin:$PATH
-export BBS_URL=<%= p("diego.cfdot.bbs.use_ssl") ? 'https' : 'http' %>://bbs.service.cf.internal:8889
+export BBS_URL=<%= p("diego.cfdot.bbs.require_ssl") ? 'https' : 'http' %>://bbs.service.cf.internal:8889
 export BBS_CA_CERT_FILE=/var/vcap/jobs/cfdot/config/certs/bbs/ca.crt
 export BBS_CERT_FILE=/var/vcap/jobs/cfdot/config/certs/bbs/client.crt
 export BBS_KEY_FILE=/var/vcap/jobs/cfdot/config/certs/bbs/client.key

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -541,7 +541,7 @@ properties:
       log_level: (( property_overrides.auctioneer.log_level || nil ))
     cfdot:
       bbs:
-        use_ssl: (( property_overrides.bbs.require_ssl || nil ))
+        require_ssl: (( property_overrides.bbs.require_ssl || nil ))
         ca_cert: (( property_overrides.bbs.ca_cert ))
         client_cert: (( property_overrides.bbs.client_cert ))
         client_key: (( property_overrides.bbs.client_key ))


### PR DESCRIPTION
Aim of this PR is to change the property name from `use_ssl` to `require_ssl` for cfdot , to maintain uniformity among job properties.

As all other diego jobs are using `require_ssl` property to enable or disable communication with bbs.

[auctioneer](http://bosh.io/jobs/auctioneer?source=github.com/cloudfoundry/diego-release&version=1.10.1#p=diego.auctioneer.bbs.require_ssl)
[nsync](http://bosh.io/jobs/nsync?source=github.com/cloudfoundry/cf-release&version=253#p=capi.nsync.bbs.require_ssl)
[rep](http://bosh.io/jobs/rep?source=github.com/cloudfoundry/diego-release&version=1.10.1#p=diego.rep.bbs.require_ssl)
[ssh-proxy](http://bosh.io/jobs/ssh_proxy?source=github.com/cloudfoundry/diego-release&version=1.10.1#p=diego.ssh_proxy.bbs.require_ssl)
