### PR TITLE
Etcd should not consume links

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -981,6 +981,7 @@ base_job_templates:
       consumes: {consul: nil}
       release: cf
     - name: etcd
+      consumes: {etcd: nil}
       release: etcd
     - name: bbs
       release: diego


### PR DESCRIPTION
The next version of etcd-release will support links. This is to not break diego-release manifests when that happens.