### PR TITLE
update cc-uploader server cert to use 'cc-uploader.service.cf.internal' as common name

### DIFF
--- a/scripts/generate-cc-uploader-certs
+++ b/scripts/generate-cc-uploader-certs
@@ -43,9 +43,8 @@ mv -f "${ca_cert_directory}/${client_cn}.csr" "${output_path}/cc/client.csr"
 mv -f "${ca_cert_directory}/${client_cn}.crt" "${output_path}/cc/client.crt"
 
 # CC Uploader server certificate
-server_cn=cell.service.cf.internal
-server_domain='cc-uploader.service.cf.internal'
-certstrap --depot-path ${ca_cert_directory} request-cert --passphrase '' --common-name $server_cn --domain $server_domain
+server_cn='cc-uploader.service.cf.internal'
+certstrap --depot-path ${ca_cert_directory} request-cert --passphrase '' --common-name $server_cn
 certstrap --depot-path ${ca_cert_directory} sign $server_cn --CA $ca_name
 mv -f "${ca_cert_directory}/$server_cn.key" "${output_path}/server.key"
 mv -f "${ca_cert_directory}/$server_cn.csr" "${output_path}/server.csr"


### PR DESCRIPTION
CN of cc-uploader server cert should match the DNS name

[#143901625]

Signed-off-by: Nicolas Regez <nicolas.regez@swisscom.com>