### PR TITLE
Modify synopsis in manifest generation script

### DIFF
--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -7,7 +7,7 @@ manifest_generation=$(dirname $0)/../manifest-generation
 usage() {
   >&2 cat <<EOF
 SYNOPSIS:
-    Generate a manifest for a Diego deployment to accompany an existing CF deployment.
+    Generate a manifest for a Diego deployment to accompany an existing cf-release deployment.
 
 USAGE:
     $0 <MANDATORY ARGUMENTS> [OPTIONAL ARGUMENTS]


### PR DESCRIPTION
Now that "cf deployment" has special meaning, making the synopsis for this command less ambigiuous.