### PR TITLE
Give BUILTIN/Users ReadAndExecute permission

### DIFF
--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -1,4 +1,4 @@
-$ErrorActionPreference = "Stop";
+﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
 Write-Host "Running pre-start"
@@ -26,3 +26,11 @@ if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "SecureRepPort
     Write-Error "Unable to add RepPort firewall rule"
   }
 }
+
+# Set ACL on executor cache to open up to container users
+$CACHE_DIR = "<%= p("diego.executor.cache_path") %>"
+New-Item -Path $CACHE_DIR -ItemType "directory" -Force
+$rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
+$acl = Get-Acl $CACHE_DIR
+$acl.AddAccessRule($rule)
+Set-Acl $CACHE_DIR $acl


### PR DESCRIPTION
This is so an unprivileged user in a container can read and execute buildpack / lifecycle binaries from the executor_cache

The change is compatible with garden-windows 2012 and 2016 as we are only adding permissions to the cache directory
