### PR TITLE
Allow Buildpack App Lifecycle to be built for Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -386,3 +386,6 @@
 [submodule "src/golang.org/x/text"]
 	path = src/golang.org/x/text
 	url = https://go.googlesource.com/text
+[submodule "src/golang.org/x/sys"]
+	path = src/golang.org/x/sys
+	url = https://go.googlesource.com/sys

--- a/packages/buildpack_app_lifecycle/packaging
+++ b/packages/buildpack_app_lifecycle/packaging
@@ -10,14 +10,19 @@ export PATH=$GOROOT/bin:$PATH
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/launcher
 
+GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder
+GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/launcher
+
 for binary in builder launcher; do
     ldd $binary && echo "$binary must be statically linked" && false
 done
 
 tar -xzf /var/vcap/packages/diego-sshd/diego-sshd.tgz
+tar -xzf /var/vcap/packages/diego-sshd/diego-sshd-windows.tgz
 cp /var/vcap/packages/healthcheck/healthcheck .
+cp /var/vcap/packages/healthcheck/healthcheck.exe .
 
-tar -czf ${BOSH_INSTALL_TARGET}/buildpack_app_lifecycle.tgz builder launcher healthcheck diego-sshd
+tar -czf ${BOSH_INSTALL_TARGET}/buildpack_app_lifecycle.tgz builder launcher healthcheck diego-sshd  builder.exe launcher.exe healthcheck.exe diego-sshd.exe
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/buildpack_app_lifecycle/spec
+++ b/packages/buildpack_app_lifecycle/spec
@@ -18,3 +18,4 @@ files:
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/systemcerts/*.go # gosub
   - github.com/cloudfoundry-incubator/candiedyaml/*.go # gosub
+  - golang.org/x/sys/windows/**/* #gosub


### PR DESCRIPTION
Once https://github.com/cloudfoundry/buildpackapplifecycle/pull/19 is merged, the Buildpack App Lifecycle will work on Windows 2016. This PR is to build the launcher and builder binaries for Windows as well

We added the `golang.org/x/sys` submodule in order for the launcher to work properly on Windows

[#147845349]

Signed-off-by: Amin Jamali <ajamali@pivotal.io>