### PR TITLE
Auctioneer tls enablement refactoring.

### DIFF
--- a/docs/tls-configuration.md
+++ b/docs/tls-configuration.md
@@ -12,15 +12,12 @@ the rep servers on the cell vms, via the `diego.rep.require_tls` and
 `false`. When enabled, the operator must provide TLS certificates and keys for
 the rep server and its clients (other components in the Diego deployment).
 
-TLS with mutual authentication can be enabled for communication to the Auctioneer
-server, via the presence of any of the following properties: `diego.auctioneer.ca_cert`,
-`diego.auctioneer.server_cert`, `diego.auctioneer.server_key`. If TLS is enabled for
-the Auctioneer, the operator must also specify the client certificates and keys
-required for mutual authentication in the following properties: `diego.bbs.auctioneer.ca_cert`,
-`diego.bbs.auctioneer.client_cert`, `diego.bbs.auctioneer.client_key`.
-The operator may also set `diego.bbs.auctioneer.require_tls` to `true` to ensure
-that all communication between the BBS and the Auctioneer server is secured using TLS
-with mutual authentication.
+
+TLS with mutual authentication can be enabled for communication to
+the Auctioneer server, via the `diego.auctioneer.require_tls` and
+`diego.bbs.auctioneer.require_tls` BOSH properties. These properties default to
+`false`. When enabled, the operator must provide TLS certificates and keys for
+the Auctioneer server and the BBS client.
 
 TLS with mutual authentication can be enabled for upload and download of assets
 into the containers, via the presence of the following properties:

--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -21,6 +21,9 @@ packages:
   - auctioneer
 
 properties:
+  diego.auctioneer.require_tls:
+    description: "Whether to require mutual TLS for communication to the securable auctioneer API server"
+    default: false
   diego.auctioneer.ca_cert:
     description: "PEM-encoded CA certificate for the auctioneer API server."
   diego.auctioneer.server_cert:

--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -2,6 +2,7 @@
   CONF_DIR = "/var/vcap/jobs/auctioneer/config"
 
   config = {
+    require_tls: p("diego.auctioneer.require_tls"),
     dropsonde_port: p("diego.auctioneer.dropsonde_port"),
     consul_cluster: "http://127.0.0.1:8500",
     debug_address: p("diego.auctioneer.debug_addr"),
@@ -37,7 +38,7 @@
     config[:rep_ca_cert] = "#{CONF_DIR}/certs/rep/ca.crt"
   end
 
-  if p("diego.auctioneer.ca_cert", "") != "" || p("diego.auctioneer.server_cert", "") != "" || p("diego.auctioneer.server_key", "") != ""
+  if p("diego.auctioneer.require_tls")
     config[:ca_cert_file] = "#{CONF_DIR}/certs/auctioneer/ca.crt"
     config[:server_cert_file] = "#{CONF_DIR}/certs/auctioneer/server.crt"
     config[:server_key_file] = "#{CONF_DIR}/certs/auctioneer/server.key"

--- a/jobs/auctioneer/templates/auctioneer_ca.crt.erb
+++ b/jobs/auctioneer/templates/auctioneer_ca.crt.erb
@@ -1,3 +1,7 @@
-<% if_p("diego.auctioneer.ca_cert") do |value| %>
+<% if p("diego.auctioneer.require_tls") %>
+<%= p("diego.auctioneer.ca_cert") %>
+<% else %>
+  <% if_p("diego.auctioneer.ca_cert") do |value| %>
 <%= value %>
+  <% end %>
 <% end %>

--- a/jobs/auctioneer/templates/auctioneer_server.crt.erb
+++ b/jobs/auctioneer/templates/auctioneer_server.crt.erb
@@ -1,3 +1,7 @@
-<% if_p("diego.auctioneer.server_cert") do |value| %>
+<% if p("diego.auctioneer.require_tls") %>
+<%= p("diego.auctioneer.server_cert") %>
+<% else %>
+  <% if_p("diego.auctioneer.server_cert") do |value| %>
 <%= value %>
+  <% end %>
 <% end %>

--- a/jobs/auctioneer/templates/auctioneer_server.key.erb
+++ b/jobs/auctioneer/templates/auctioneer_server.key.erb
@@ -1,3 +1,7 @@
-<% if_p("diego.auctioneer.server_key") do |value| %>
+<% if p("diego.auctioneer.require_tls") %>
+<%= p("diego.auctioneer.server_key") %>
+<% else %>
+  <% if_p("diego.auctioneer.server_key") do |value| %>
 <%= value %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Hi,

The current approach for enabling the tls communication to the auctioneer server is not so understandable, specially because other core components like `bbs` and `rep` make this enablement with a different approach(based on a single parameter), e.g. `diego.bbs.require_ssl` & `diego.rep.require_tls` respectively.

The PR proposes to sync `auctioneer` in the same way, with a new `diego.auctioneer.require_tls` instead of the presence of any of this three parameters, `diego.auctioneer.ca_cert`,`diego.auctioneer.server_cert`,`diego.auctioneer.server_key` .

This will allow the operator to follow the same approach, when moving to the use of tls/ssl in all diego server components.



