### PR TITLE
Compile healthcheck with useExternalPort ldflag

### DIFF
--- a/packages/healthcheck/packaging
+++ b/packages/healthcheck/packaging
@@ -9,6 +9,7 @@ export PATH=$GOROOT/bin:$PATH
 
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/healthcheck/cmd/healthcheck
 GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/healthcheck/cmd/healthcheck
+GOOS=windows CGO_ENABLED=0 go build -o healthcheck-external-port.exe -tags=external -a -installsuffix static code.cloudfoundry.org/healthcheck/cmd/healthcheck
 
 for binary in healthcheck; do
     ldd $binary && echo "$binary must be statically linked" && false
@@ -16,6 +17,7 @@ done
 
 cp healthcheck ${BOSH_INSTALL_TARGET}
 cp healthcheck.exe ${BOSH_INSTALL_TARGET}
+cp healthcheck-external-port.exe ${BOSH_INSTALL_TARGET}
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -3,5 +3,5 @@ set -e
 mkdir -p tmp
 tar -xzf lifecycles/windows_app_lifecycle-*.tgz -C tmp
 tar -xzf /var/vcap/packages/diego-sshd/diego-sshd-windows.tgz -C tmp
-cp /var/vcap/packages/healthcheck/healthcheck.exe tmp
+cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe tmp/healthcheck.exe
 tar -zcf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz -C tmp .


### PR DESCRIPTION
This is dependent on [Healthcheck PR](https://github.com/cloudfoundry/healthcheck/pull/4).

- WAL should pull in healthcheck-external-port.exe for windows2012R2
stack
- BAL can use the internal port healthcheck for windows2016 stack


Signed-off-by: Amin Jamali <ajamali@pivotal.io>