### PR TITLE
add ability to configure instance_identity on Windows

### DIFF
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -9,6 +9,8 @@ templates:
   ca_certs_for_downloads.crt.erb: config/certs/rep/ca_certs_for_downloads.crt
   bbs_client.crt.erb: config/certs/bbs/client.crt
   bbs_client.key.erb: config/certs/bbs/client.key
+  instance_identity.crt.erb: config/certs/rep/instance_identity.crt
+  instance_identity.key.erb: config/certs/rep/instance_identity.key
   rep_ca.crt.erb: config/certs/ca.crt
   rep_server.crt.erb: config/certs/server.crt
   rep_server.key.erb: config/certs/server.key

--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -34,3 +34,10 @@ $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "
 $acl = Get-Acl $CACHE_DIR
 $acl.AddAccessRule($rule)
 Set-Acl $CACHE_DIR $acl
+
+$INSTANCE_IDENTITY_DIR = "/var/vcap/data/executor/instance_identity"
+New-Item -Path $INSTANCE_IDENTITY_DIR -ItemType "directory" -Force
+$rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
+$acl = Get-Acl $INSTANCE_IDENTITY_DIR
+$acl.AddAccessRule($rule)
+Set-Acl $INSTANCE_IDENTITY_DIR $acl


### PR DESCRIPTION
This PR supports instance identity credentials on windows2016. This does not enable it on windows2012R2 (it is a no-op for this platform) as bind mounts do not work on windows2012R2 in the same way as linux or windows2016.

- Add instance identity certs to rep_windows templates
- Create instance identity directory in executor data directory
