### PR TITLE
Removed unused properties

### DIFF
--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -521,11 +521,9 @@ property_overrides:
         Xzyf48aQ170lBX9uxw0ZrFfc3bf5+1EGqt3slc6WxZITk6Dtlypm
         -----END RSA PRIVATE KEY-----
   executor:
-    drain_timeout_in_seconds: 0
     garden:
       network: tcp
       address: 127.0.0.1:7777
-    log_level: debug
     instance_identity_ca_cert: |+
       -----BEGIN CERTIFICATE-----
       MIIC9jCCAd6gAwIBAgIBATANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDExBpbnN0

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -665,7 +665,6 @@ properties:
       auto_disk_capacity_overhead_mb: (( property_overrides.executor.auto_disk_capacity_overhead_mb || nil ))
       max_cache_size_in_bytes: (( property_overrides.executor.max_cache_size_in_bytes || nil ))
       memory_capacity_mb: (( property_overrides.executor.memory_capacity_mb || nil ))
-      drain_timeout_in_seconds: (( property_overrides.executor.drain_timeout_in_seconds || nil ))
       post_setup_hook: (( property_overrides.executor.post_setup_hook || nil ))
       post_setup_user: (( property_overrides.executor.post_setup_user || nil ))
       garden:
@@ -682,7 +681,6 @@ properties:
           args: (( property_overrides.executor.garden_healthcheck.process.args || nil ))
           env: (( property_overrides.executor.garden_healthcheck.process.env || nil ))
       ca_certs_for_downloads: (( property_overrides.executor.ca_certs_for_downloads || nil ))
-      log_level: (( property_overrides.executor.log_level || nil ))
       container_metrics_report_interval: (( property_overrides.executor.container_metrics_report_interval || nil ))
       instance_identity_ca_cert: (( property_overrides.executor.instance_identity_ca_cert || nil ))
       instance_identity_key: (( property_overrides.executor.instance_identity_key || nil ))


### PR DESCRIPTION
[#149285861]

Fixed #335

Removed following unused properties
- diego.executor.drain_timeout_in_seconds
- diego.executor.log_level

