### PR TITLE
Allow a way to configure each bbs template

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -145,7 +145,7 @@ jobs: (( cf_networking_overrides.jobs base.jobs ))
 base:
   jobs:
     - name: database_z1
-      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates))
+      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates_z1))
       instances: (( instance_count_overrides.database_z1.instances || 1 ))
       persistent_disk_pool: database_disks
       resource_pool: database_z1
@@ -167,7 +167,7 @@ base:
           max_open_connections: (( property_overrides.locket.database.max_open_connections || nil ))
 
     - name: database_z2
-      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates))
+      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates_z2))
       instances: (( instance_count_overrides.database_z2.instances || 1 ))
       persistent_disk_pool: database_disks
       resource_pool: database_z2
@@ -189,7 +189,7 @@ base:
           max_open_connections: (( property_overrides.locket.database.max_open_connections || nil ))
 
     - name: database_z3
-      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates))
+      templates: (( bbs_overrides.job_templates sql_lock_overrides.templates cf_networking_overrides.bbs_templates_z3))
       instances: (( instance_count_overrides.database_z3.instances || 1 ))
       persistent_disk_pool: database_disks
       resource_pool: database_z3
@@ -957,7 +957,9 @@ cf_networking_overrides:
   properties: (( merge || [] ))
   garden_properties: (( merge || [] ))
   jobs: (( merge || [] ))
-  bbs_templates: (( merge || [] ))
+  bbs_templates_z1: (( merge || [] ))
+  bbs_templates_z2: (( merge || [] ))
+  bbs_templates_z3: (( merge || [] ))
   bbs_consul_properties: (( merge || bbs_overrides.job_properties.consul ))
 
 route_emitter_overrides:

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -957,9 +957,10 @@ cf_networking_overrides:
   properties: (( merge || [] ))
   garden_properties: (( merge || [] ))
   jobs: (( merge || [] ))
-  bbs_templates_z1: (( merge || [] ))
-  bbs_templates_z2: (( merge || [] ))
-  bbs_templates_z3: (( merge || [] ))
+  bbs_templates: (( merge || [] ))
+  bbs_templates_z1: (( merge || cf_networking_overrides.bbs_templates ))
+  bbs_templates_z2: (( merge || cf_networking_overrides.bbs_templates ))
+  bbs_templates_z3: (( merge || cf_networking_overrides.bbs_templates ))
   bbs_consul_properties: (( merge || bbs_overrides.job_properties.consul ))
 
 route_emitter_overrides:


### PR DESCRIPTION
This is to allow different bbs `instance groups` to provide a different `named link`.
see: https://github.com/cloudfoundry-incubator/cf-networking-release/commit/b91dbac3c137a732adab0f2805d17627dd4001e0