### PR TITLE
Bump diego-ssh submodule and update packaging scripts

### DIFF
--- a/packages/buildpack_app_lifecycle/packaging
+++ b/packages/buildpack_app_lifecycle/packaging
@@ -17,8 +17,8 @@ for binary in builder launcher; do
     ldd $binary && echo "$binary must be statically linked" && false
 done
 
-tar -xzf /var/vcap/packages/diego-sshd/diego-sshd.tgz
-tar -xzf /var/vcap/packages/diego-sshd/diego-sshd-windows.tgz
+cp /var/vcap/packages/diego-sshd/diego-sshd .
+cp /var/vcap/packages/diego-sshd/diego-sshd.exe .
 cp /var/vcap/packages/healthcheck/healthcheck .
 cp /var/vcap/packages/healthcheck/healthcheck.exe .
 

--- a/packages/diego-sshd/packaging
+++ b/packages/diego-sshd/packaging
@@ -9,14 +9,13 @@ export PATH=$GOROOT/bin:$PATH
 
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
 GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
+GOOS=windows CGO_ENABLED=0 go build -o diego-sshd-external-port.exe -tags=external -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
 
 ldd sshd && echo 'diego-sshd must be statically linked' && false
 
-mv sshd diego-sshd
-tar -czf ${BOSH_INSTALL_TARGET}/diego-sshd.tgz diego-sshd
-
-mv sshd.exe diego-sshd.exe
-tar -czf ${BOSH_INSTALL_TARGET}/diego-sshd-windows.tgz diego-sshd.exe
+cp sshd ${BOSH_INSTALL_TARGET}/diego-sshd
+cp sshd.exe ${BOSH_INSTALL_TARGET}/diego-sshd.exe
+cp diego-sshd-external-port.exe ${BOSH_INSTALL_TARGET}
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/docker_app_lifecycle/packaging
+++ b/packages/docker_app_lifecycle/packaging
@@ -14,7 +14,7 @@ for binary in builder launcher; do
     ldd $binary && echo "$binary must be statically linked" && false
 done
 
-tar -xzf /var/vcap/packages/diego-sshd/diego-sshd.tgz
+cp /var/vcap/packages/diego-sshd/diego-sshd .
 cp /var/vcap/packages/healthcheck/healthcheck .
 
 tar -czf ${BOSH_INSTALL_TARGET}/docker_app_lifecycle.tgz builder launcher healthcheck diego-sshd

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -2,6 +2,6 @@ set -e
 
 mkdir -p tmp
 tar -xzf lifecycles/windows_app_lifecycle-*.tgz -C tmp
-tar -xzf /var/vcap/packages/diego-sshd/diego-sshd-windows.tgz -C tmp
+cp /var/vcap/packages/diego-sshd/diego-sshd-external-port.exe tmp/diego-sshd.exe
 cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe tmp/healthcheck.exe
 tar -zcf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz -C tmp .


### PR DESCRIPTION
 - Now use internal/external build flag to determine if port mapping
 will be performed by sshd.

 [#148169141]

Note that this relies on https://github.com/cloudfoundry/diego-ssh/pull/33

Signed-off-by: Sam Smith <sesmith177@gmail.com>