### PR TITLE
Bump Windows App Lifecyle

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ jq/jq-1.5-linux64:
   size: 3027945
   object_id: b78765c7-2ce1-4a12-7a1d-6378a93af246
   sha: d8e36831c3c94bb58be34dd544f44a6c6cb88568
-lifecycles/windows_app_lifecycle-d74e304.tgz:
-  size: 1990290
-  object_id: 985bb641-1bc5-4914-7329-13029fcd5cf4
-  sha: 0e8902335a313a8724deee1e24cd85e3a395b125
+lifecycles/windows_app_lifecycle-686f5c2.tgz:
+  size: 2192362
+  object_id: 7c44c6d6-49bd-4813-6b7e-8181d260c7d1
+  sha: 6e24de3e8b3cc28051a2516e9074de56454b8fbc
 proxy/envoy-1.3.0.tgz:
   size: 2266298
   object_id: c10f7dcc-4010-4dfe-460a-250a0e1cded1


### PR DESCRIPTION
Updates the WAL binary
- contains a new build of bsdtar