### PR TITLE
Improve tls notes documentation

### DIFF
--- a/docs/tls-configuration.md
+++ b/docs/tls-configuration.md
@@ -178,7 +178,7 @@ following steps to successfully generate the required certificates.
    Created out/clientName.crt from out/clientName.csr signed by out/cf-diego-ca.key
    ```
 
-   **Note** the following properties must be set in the `cell`, see the `rep` spec file for more information:
+   **Note** the following properties must be set in the `cell` job, see the `rep` spec file for more information:
    - `properties.tls.ca_cert`: The CF/Diego mutual TLS certificate authority
    - `properties.tls.cert`
    - `properties.tls.key`

--- a/docs/tls-configuration.md
+++ b/docs/tls-configuration.md
@@ -113,12 +113,10 @@ following steps to successfully generate the required certificates.
    Created out/locket.service.cf.internal.crt from out/locket.service.cf.internal.csr signed by out/diegoCA.key
    ```
 
-   The manifest property `tls.ca_cert` for the `locket` job should be set to
-   the certificate in `out/diegoCA.crt`.
-   The manifest property `tls.cert` for the `locket` job should be set to
-   the certificate in `out/locket.service.cf.internal.crt`.
-   The manifest property `tls.key` for the `locket` job should be set to
-   the certificate in `out/locket.service.cf.internal.key`.
+   **Note** the following properties must be set in the `database` job, see the `locket` spec file for more information:
+   - `properties.tls.ca_cert`: The BBS/Locket mutual TLS certificate authority
+   - `properties.tls.cert`:
+   - `properties.tls.key`:
 
 5. Create and sign a certificate for the Rep server.
    ```
@@ -180,7 +178,7 @@ following steps to successfully generate the required certificates.
    Created out/clientName.crt from out/clientName.csr signed by out/cf-diego-ca.key
    ```
 
-   **Note** the following properties must be set in the cell job spec:
+   **Note** the following properties must be set in the `cell`, see the `rep` spec file for more information:
    - `properties.tls.ca_cert`: The CF/Diego mutual TLS certificate authority
    - `properties.tls.cert`
    - `properties.tls.key`

--- a/docs/tls-configuration.md
+++ b/docs/tls-configuration.md
@@ -113,7 +113,7 @@ following steps to successfully generate the required certificates.
    Created out/locket.service.cf.internal.crt from out/locket.service.cf.internal.csr signed by out/diegoCA.key
    ```
 
-   **Note** the following properties must be set in the `database` job, see the `locket` spec file for more information:
+   **Note** the following properties must be set in the `database` instance_group, see the `locket` job spec file for more information:
    - `properties.tls.ca_cert`: The BBS/Locket mutual TLS certificate authority
    - `properties.tls.cert`:
    - `properties.tls.key`:
@@ -178,7 +178,7 @@ following steps to successfully generate the required certificates.
    Created out/clientName.crt from out/clientName.csr signed by out/cf-diego-ca.key
    ```
 
-   **Note** the following properties must be set in the `cell` job, see the `rep` spec file for more information:
+   **Note** the following properties must be set in the `cell` instance_group, see the `rep` job spec file for more information:
    - `properties.tls.ca_cert`: The CF/Diego mutual TLS certificate authority
    - `properties.tls.cert`
    - `properties.tls.key`


### PR DESCRIPTION
Hi,

Currently both `database` and `cell` jobs are having similar certificate paths. With `path` I mean something like `properties.tls.cert`. This is confusing, because in theory you could have under the `properties` block the same path(`properties.tls.cert`) and I´m not sure which job will take it(`database` or `cell`). Seems the best way to define them, its always inside the `job` itself.

Therefore I modified the description to be more explicit in relation to where those certs should be defined, and in which spec file their description can be found. 

Regards,
Enrique Encalada

