### PR TITLE
Bump go loggregator to v4.0.1

### DIFF
--- a/packages/auctioneer/spec
+++ b/packages/auctioneer/spec
@@ -31,7 +31,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/runtimeemitter/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/localip/*.go # gosub

--- a/packages/bbs/spec
+++ b/packages/bbs/spec
@@ -41,7 +41,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/runtimeemitter/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/locket/*.go # gosub

--- a/packages/benchmark-bbs/spec
+++ b/packages/benchmark-bbs/spec
@@ -33,7 +33,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/locket/*.go # gosub

--- a/packages/locket/spec
+++ b/packages/locket/spec
@@ -17,7 +17,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/runtimeemitter/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/locket/*.go # gosub

--- a/packages/rep/spec
+++ b/packages/rep/spec
@@ -50,7 +50,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/runtimeemitter/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/goshims/filepathshim/*.go # gosub
   - code.cloudfoundry.org/goshims/grpcshim/*.go # gosub
   - code.cloudfoundry.org/goshims/http_wrap/*.go # gosub

--- a/packages/rep_windows/spec
+++ b/packages/rep_windows/spec
@@ -51,7 +51,6 @@ files:
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/runtimeemitter/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/v1/*.go # gosub
-  - code.cloudfoundry.org/go-loggregator/v1/conversion/*.go # gosub
   - code.cloudfoundry.org/goshims/filepathshim/*.go # gosub
   - code.cloudfoundry.org/goshims/grpcshim/*.go # gosub
   - code.cloudfoundry.org/goshims/http_wrap/*.go # gosub


### PR DESCRIPTION
Promotes value metrics to container metrics when appropriate.

[#150906690]

Signed-off-by: Wesley Jeanette <wjeanette@pivotal.io>