### PR TITLE
windows2016 supports cf ssh

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,3 +18,7 @@ proxy/envoy-1.3.0.tgz:
   size: 2266298
   object_id: c10f7dcc-4010-4dfe-460a-250a0e1cded1
   sha: 45d667aa64a876ab857853b112f065a8800d3161
+winpty/winpty-0.4.3.tgz:
+  size: 460765
+  object_id: 53072e58-c940-41f2-7844-95f46adf90ab
+  sha: 6bfe1962c47f10c1081410982d06b6eefaeb231c

--- a/packages/buildpack_app_lifecycle/packaging
+++ b/packages/buildpack_app_lifecycle/packaging
@@ -18,11 +18,15 @@ for binary in builder launcher; do
 done
 
 cp /var/vcap/packages/diego-sshd/diego-sshd .
-cp /var/vcap/packages/diego-sshd/diego-sshd.exe .
+cp /var/vcap/packages/diego-sshd/*.exe .
+cp /var/vcap/packages/diego-sshd/winpty.dll .
 cp /var/vcap/packages/healthcheck/healthcheck .
 cp /var/vcap/packages/healthcheck/healthcheck.exe .
 
-tar -czf ${BOSH_INSTALL_TARGET}/buildpack_app_lifecycle.tgz builder launcher healthcheck diego-sshd  builder.exe launcher.exe healthcheck.exe diego-sshd.exe
+tar -czf ${BOSH_INSTALL_TARGET}/buildpack_app_lifecycle.tgz \
+  builder launcher healthcheck diego-sshd  \
+  builder.exe launcher.exe healthcheck.exe diego-sshd.exe \
+  winpty-agent.exe winpty.dll
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/diego-sshd/packaging
+++ b/packages/diego-sshd/packaging
@@ -9,13 +9,15 @@ export PATH=$GOROOT/bin:$PATH
 
 CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
 GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
-GOOS=windows CGO_ENABLED=0 go build -o diego-sshd-external-port.exe -tags=external -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
+GOOS=windows CGO_ENABLED=0 go build -o diego-sshd-windows2012R2.exe -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd
 
 ldd sshd && echo 'diego-sshd must be statically linked' && false
 
 cp sshd ${BOSH_INSTALL_TARGET}/diego-sshd
 cp sshd.exe ${BOSH_INSTALL_TARGET}/diego-sshd.exe
-cp diego-sshd-external-port.exe ${BOSH_INSTALL_TARGET}
+cp diego-sshd-windows2012R2.exe ${BOSH_INSTALL_TARGET}
+
+tar -xzvf winpty/winpty-*.tgz -C ${BOSH_INSTALL_TARGET}
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/diego-sshd/spec
+++ b/packages/diego-sshd/spec
@@ -5,6 +5,7 @@ dependencies:
   - golang
 
 files:
+  - winpty/winpty-*.tgz
   - code.cloudfoundry.org/bbs/*.go # gosub
   - code.cloudfoundry.org/bbs/encryption/*.go # gosub
   - code.cloudfoundry.org/bbs/events/*.go # gosub
@@ -17,6 +18,7 @@ files:
   - code.cloudfoundry.org/diego-ssh/cmd/sshd/*.go # gosub
   - code.cloudfoundry.org/diego-ssh/daemon/*.go # gosub
   - code.cloudfoundry.org/diego-ssh/handlers/*.go # gosub
+  - code.cloudfoundry.org/diego-ssh/winpty/*.go # gosub
   - code.cloudfoundry.org/diego-ssh/helpers/*.go # gosub
   - code.cloudfoundry.org/diego-ssh/keys/*.go # gosub
   - code.cloudfoundry.org/diego-ssh/proxy/*.go # gosub
@@ -57,3 +59,4 @@ files:
   - golang.org/x/crypto/ed25519/*.go # gosub
   - golang.org/x/crypto/ed25519/internal/edwards25519/*.go # gosub
   - golang.org/x/crypto/ssh/*.go # gosub
+  - golang.org/x/sys/windows/**/*

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -2,6 +2,6 @@ set -e
 
 mkdir -p tmp
 tar -xzf lifecycles/windows_app_lifecycle-*.tgz -C tmp
-cp /var/vcap/packages/diego-sshd/diego-sshd-external-port.exe tmp/diego-sshd.exe
+cp /var/vcap/packages/diego-sshd/diego-sshd-windows2012R2.exe tmp/diego-sshd.exe
 cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe tmp/healthcheck.exe
 tar -zcf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz -C tmp .


### PR DESCRIPTION
- Add .tgz blob containing winpty.dll and winpty-agent.exe. These files
were extracted from: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip

- Update build flags to reflect changes in diego-ssh

[#150808829]

Signed-off-by: Amin Jamali <ajamali@pivotal.io>