### PR TITLE
Use BAL on windows2012R2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,11 +10,10 @@ jq/jq-1.5-linux64:
   size: 3027945
   object_id: b78765c7-2ce1-4a12-7a1d-6378a93af246
   sha: d8e36831c3c94bb58be34dd544f44a6c6cb88568
-lifecycles/windows_app_lifecycle-d74e304.tgz:
-  size: 1990290
-  object_id: 985bb641-1bc5-4914-7329-13029fcd5cf4
-  sha: 0e8902335a313a8724deee1e24cd85e3a395b125
 proxy/envoy-1.3.0.tgz:
   size: 2266298
   object_id: c10f7dcc-4010-4dfe-460a-250a0e1cded1
   sha: 45d667aa64a876ab857853b112f065a8800d3161
+tar/tar-1503683828.tgz:
+  size: 452214
+  sha: 4166d046bc684541fda6e75c6f2a2ac0edfd3bb2

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -16,4 +16,5 @@ proxy/envoy-1.3.0.tgz:
   sha: 45d667aa64a876ab857853b112f065a8800d3161
 tar/tar-1503683828.tgz:
   size: 452214
+  object_id: 2f1b2152-b17a-40d5-70f5-a4069c80ae8f
   sha: 4166d046bc684541fda6e75c6f2a2ac0edfd3bb2

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -1,7 +1,23 @@
 set -e
 
+mkdir -p ${BOSH_INSTALL_TARGET}/src
+cp -a . ${BOSH_INSTALL_TARGET}/src
+export GOPATH=$BOSH_INSTALL_TARGET
+
+export GOROOT=$(readlink -nf /var/vcap/packages/golang)
+export PATH=$GOROOT/bin:$PATH
+
+GOOS=windows CGO_ENABLED=0 go build -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder
+GOOS=windows CGO_ENABLED=0 go build -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/launcher
+
 mkdir -p tmp
-tar -xzf lifecycles/windows_app_lifecycle-*.tgz -C tmp
-cp /var/vcap/packages/diego-sshd/diego-sshd-external-port.exe tmp/diego-sshd.exe
-cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe tmp/healthcheck.exe
-tar -zcf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz -C tmp .
+tar -xzf tar/tar-*.tgz -C tmp
+
+cp /var/vcap/packages/diego-sshd/diego-sshd-external-port.exe diego-sshd.exe
+cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe healthcheck.exe
+cp tmp/tar-*.exe tar.exe
+
+tar -czf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz builder.exe launcher.exe healthcheck.exe diego-sshd.exe tar.exe
+
+# clean up source artifacts
+rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/windows_app_lifecycle/spec
+++ b/packages/windows_app_lifecycle/spec
@@ -1,9 +1,22 @@
 ---
 name: windows_app_lifecycle
 
-files:
-  - lifecycles/windows_app_lifecycle-*.tgz
-
 dependencies:
   - diego-sshd
   - healthcheck
+  - golang
+
+files:
+  - tar/tar-*.tgz
+  - golang.org/x/sys/windows/**/* #gosub
+  - code.cloudfoundry.org/archiver/compressor/*.go # gosub
+  - code.cloudfoundry.org/archiver/extractor/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/builder/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/launcher/*.go # gosub
+  - code.cloudfoundry.org/bytefmt/*.go # gosub
+  - code.cloudfoundry.org/cacheddownloader/*.go # gosub
+  - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/systemcerts/*.go # gosub
+  - gopkg.in/yaml.v2/*.go # gosub


### PR DESCRIPTION
There still needs to be a separate windows_app_lifecycle package to
account for differences betwen 2012R2 and 2016 (i.e diego-sshd /
lifecycle / BAL differences )

- Remove windows_app_lifecycle blob
- Add tar blob
- Compile BAL for windows2012R2 and install the correct versions of
diego-sshd.exe and lifecycle.exe

[#151173124]

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>