### PR TITLE
Flag for permissive ACLs on bind mounted dirs

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -268,3 +268,7 @@ properties:
   container_proxy.enabled:
     description: "EXPERIMENTAL: Enable envoy proxy on garden containers. Requires valid TLS credentials in diego.executor.instance_identity_ca_cert and diego.executor.instance_identity_key."
     default: false
+
+  diego.rep.open_bindmounts_acl:
+    description: "Only affects Windows cells"
+    default: false

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -67,6 +67,9 @@ properties:
   diego.rep.trusted_certs:
     description: "Concatenation of trusted CA certificates to be made available on the cell."
     default: null
+  diego.rep.open_bindmounts_acl:
+    description: "Add more permissive ACLs to directories that are bind mounted into containers. Required for Windows 2016 cells"
+    default: false
 
   loggregator.use_v2_api:
     description: "True to use local metron agent gRPC v2 api. False, to use UDP v1 api"

--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -27,20 +27,24 @@ if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "SecureRepPort
   }
 }
 
-# Set ACL on download cache to open up to container users
 $cache_dir = "/var/vcap/data/rep/download_cache"
 New-Item -Path $cache_dir -ItemType "directory" -Force
-$rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
-$acl = Get-Acl $cache_dir
-$acl.AddAccessRule($rule)
-Set-Acl $cache_dir $acl
 
 $instance_identity_dir = "/var/vcap/data/rep/instance_identity"
 New-Item -Path $instance_identity_dir -ItemType "directory" -Force
-$rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
-$acl = Get-Acl $instance_identity_dir
-$acl.AddAccessRule($rule)
-Set-Acl $instance_identity_dir $acl
+
+<% if p("diego.rep.open_bindmounts_acl") %>
+  # Set ACL on download cache  + IICs to open up to container users
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
+  $acl = Get-Acl $cache_dir
+  $acl.AddAccessRule($rule)
+  Set-Acl $cache_dir $acl
+
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
+  $acl = Get-Acl $instance_identity_dir
+  $acl.AddAccessRule($rule)
+  Set-Acl $instance_identity_dir $acl
+<% end %>
 
 $conf_dir = "C:/var/vcap/jobs/rep_windows/config"
 <% if_p("diego.rep.trusted_certs") do |value| %>


### PR DESCRIPTION
On Windows 2016, BUILTIN\Users needs access to these directories to that
the container users can access bind mounts from them.

On Windows 2012R2, there isn't real filesystem isolation, BUILTIN\Users
should not have access to these directories.

By default, do not add the permissive ACL.

[#151704899]