### PR TITLE
Update BPM to 0.2.0

### DIFF
--- a/jobs/auctioneer/templates/bpm.yml.erb
+++ b/jobs/auctioneer/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  auctioneer:
-    executable: /var/vcap/packages/auctioneer/bin/auctioneer
-    args:
-      - -config=/var/vcap/jobs/auctioneer/config/auctioneer.json
-    limits:
-      open_files: 100000
+- name: auctioneer
+  executable: /var/vcap/packages/auctioneer/bin/auctioneer
+  args:
+    - -config=/var/vcap/jobs/auctioneer/config/auctioneer.json
+  limits:
+    open_files: 100000

--- a/jobs/bbs/templates/bbs_ctl.erb
+++ b/jobs/bbs/templates/bbs_ctl.erb
@@ -3,8 +3,7 @@
 run_dir=/var/vcap/sys/run/bbs
 log_dir=/var/vcap/sys/log/bbs
 conf_dir=/var/vcap/jobs/bbs/config
-data_dir=/var/vcap/data/bbs
-tmp_dir=$data_dir/tmp
+tmp_dir=/var/vcap/data/bbs/tmp
 
 pidfile=$run_dir/bbs.pid
 
@@ -20,9 +19,6 @@ case $1 in
 
     mkdir -p $log_dir
     chown -R vcap:vcap $log_dir
-
-    mkdir -p $data_dir
-    chown -R vcap:vcap $data_dir
 
     mkdir -p $tmp_dir
     chown -R vcap:vcap $tmp_dir

--- a/jobs/bbs/templates/bpm.yml.erb
+++ b/jobs/bbs/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  bbs:
-    executable: /var/vcap/packages/bbs/bin/bbs
-    args:
-      - -config=/var/vcap/jobs/bbs/config/bbs.json
-    limits:
-      open_files: 100000
+- name: bbs
+  executable: /var/vcap/packages/bbs/bin/bbs
+  args:
+    - -config=/var/vcap/jobs/bbs/config/bbs.json
+  limits:
+    open_files: 100000

--- a/jobs/file_server/templates/bpm.yml.erb
+++ b/jobs/file_server/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  file_server:
-    executable: /var/vcap/packages/file_server/bin/file-server
-    args:
-      - -config=/var/vcap/jobs/file_server/config/file_server.json
-    limits:
-      open_files: 100000
+- name: file_server
+  executable: /var/vcap/packages/file_server/bin/file-server
+  args:
+    - -config=/var/vcap/jobs/file_server/config/file_server.json
+  limits:
+    open_files: 100000

--- a/jobs/locket/templates/bpm.yml.erb
+++ b/jobs/locket/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  locket:
-    executable: /var/vcap/packages/locket/bin/locket
-    args:
-      - -config=/var/vcap/jobs/locket/config/locket.json
-    limits:
-      open_files: 100000
+- name: locket
+  executable: /var/vcap/packages/locket/bin/locket
+  args:
+    - -config=/var/vcap/jobs/locket/config/locket.json
+  limits:
+    open_files: 100000

--- a/jobs/locket/templates/locket_ctl.erb
+++ b/jobs/locket/templates/locket_ctl.erb
@@ -3,8 +3,7 @@
 run_dir=/var/vcap/sys/run/locket
 log_dir=/var/vcap/sys/log/locket
 conf_dir=/var/vcap/jobs/locket/config
-data_dir=/var/vcap/data/locket
-tmp_dir=$data_dir/tmp
+tmp_dir=/var/vcap/data/locket/tmp
 
 pidfile=$run_dir/locket.pid
 
@@ -20,9 +19,6 @@ case $1 in
 
     mkdir -p $log_dir
     chown -R vcap:vcap $log_dir
-
-    mkdir -p $data_dir
-    chown -R vcap:vcap $data_dir
 
     mkdir -p $tmp_dir
     chown -R vcap:vcap $tmp_dir

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -22,6 +22,7 @@ templates:
   rep.json.erb: config/rep.json
   bpm.yml.erb: config/bpm.yml
   bpm-pre-start.erb: bin/bpm-pre-start
+  mount_instance_identity.erb: bin/mount_instance_identity
   pre-start.erb: bin/pre-start
   post-start.erb: bin/post-start
   loggregator_ca.crt.erb: config/certs/loggregator/ca.crt

--- a/jobs/rep/templates/bpm-pre-start.erb
+++ b/jobs/rep/templates/bpm-pre-start.erb
@@ -1,32 +1,5 @@
 #!/bin/bash -e
 
 <% if p("bpm.enabled") %>
-conf_dir=/var/vcap/jobs/rep/config
-data_dir=/var/vcap/data/rep
-
-# Key and Cert are generally ~2048 bytes. Add an extra 2048 for extra space
-# add another 4096 to account for the temp files used to do atomic replacement #141163257
-instance_cert_and_key_size=10240
-instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' ' -f1)
-max_containers=250
-instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
-
-instance_identity_dir=${data_dir}/instance_identity
-if mount | grep -q $instance_identity_dir; then
-  umount -f $instance_identity_dir
-fi
-mkdir -p "$instance_identity_dir"
-mount -t tmpfs -o size=$instance_tmpfs_size tmpfs $instance_identity_dir
-chown -R vcap:vcap "$instance_identity_dir"
-chmod 0700 "$instance_identity_dir"
-
-trusted_certs_dir=${data_dir}/trusted_certs
-rm -rf "$trusted_certs_dir"
-<% if_p("diego.rep.trusted_certs") do |value| %>
-  mkdir -p "$trusted_certs_dir"
-  chown -R vcap:vcap $trusted_certs_dir
-
-  /var/vcap/packages/certsplitter/bin/certsplitter $conf_dir/certs/rep/trusted_certs.crt $trusted_certs_dir
-  chmod +r ${trusted_certs_dir}/*
-<% end %>
+/var/vcap/jobs/rep/bin/mount_instance_identity
 <% end %>

--- a/jobs/rep/templates/bpm.yml.erb
+++ b/jobs/rep/templates/bpm.yml.erb
@@ -1,11 +1,13 @@
 ---
 processes:
-  rep:
-    executable: /var/vcap/jobs/rep/bin/rep
-    limits:
-      open_files: 100000
-    hooks:
-      pre_start: /var/vcap/jobs/rep/bin/bpm-pre-start
-    volumes:
-      - <%= p("diego.executor.volman.driver_paths") %>
-      - /var/vcap/data/garden
+- name: rep
+  executable: /var/vcap/jobs/rep/bin/rep
+  limits:
+    open_files: 100000
+  hooks:
+    pre_start: /var/vcap/jobs/rep/bin/bpm-pre-start
+  volumes:
+    - path: <%= p("diego.executor.volman.driver_paths") %>
+      writable: true
+    - path : /var/vcap/data/garden
+      writable: true

--- a/jobs/rep/templates/bpm.yml.erb
+++ b/jobs/rep/templates/bpm.yml.erb
@@ -6,7 +6,7 @@ processes:
     open_files: 100000
   hooks:
     pre_start: /var/vcap/jobs/rep/bin/bpm-pre-start
-  volumes:
+  additional_volumes:
     - path: <%= p("diego.executor.volman.driver_paths") %>
       writable: true
     - path : /var/vcap/data/garden

--- a/jobs/rep/templates/bpm.yml.erb
+++ b/jobs/rep/templates/bpm.yml.erb
@@ -6,6 +6,7 @@ processes:
     open_files: 100000
   hooks:
     pre_start: /var/vcap/jobs/rep/bin/bpm-pre-start
+  ephemeral_disk: true
   additional_volumes:
     - path: <%= p("diego.executor.volman.driver_paths") %>
       writable: true

--- a/jobs/rep/templates/mount_instance_identity.erb
+++ b/jobs/rep/templates/mount_instance_identity.erb
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+conf_dir=/var/vcap/jobs/rep/config
+data_dir=/var/vcap/data/rep
+
+# Key and Cert are generally ~2048 bytes. Add an extra 2048 for extra space
+# add another 4096 to account for the temp files used to do atomic replacement #141163257
+instance_cert_and_key_size=10240
+instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' ' -f1)
+max_containers=250
+instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
+
+instance_identity_dir=${data_dir}/instance_identity
+if mount | grep -q $instance_identity_dir; then
+  umount -f $instance_identity_dir
+fi
+mkdir -p "$instance_identity_dir"
+mount -t tmpfs -o size=$instance_tmpfs_size tmpfs $instance_identity_dir
+chown -R vcap:vcap "$instance_identity_dir"
+chmod 0700 "$instance_identity_dir"
+
+trusted_certs_dir=${data_dir}/trusted_certs
+rm -rf "$trusted_certs_dir"
+<% if_p("diego.rep.trusted_certs") do |value| %>
+  mkdir -p "$trusted_certs_dir"
+  chown -R vcap:vcap $trusted_certs_dir
+
+  /var/vcap/packages/certsplitter/bin/certsplitter $conf_dir/certs/rep/trusted_certs.crt $trusted_certs_dir
+  chmod +r ${trusted_certs_dir}/*
+<% end %>

--- a/jobs/rep/templates/rep_ctl.erb
+++ b/jobs/rep/templates/rep_ctl.erb
@@ -35,31 +35,7 @@ case $1 in
     # Remove old cache dir so that disk space isn't wasted
     rm -rf /var/vcap/data/executor_cache
 
-    # Key and Cert are generally ~2048 bytes. Add an extra 2048 for extra space
-    # add another 4096 to account for the temp files used to do atomic replacement #141163257
-    instance_cert_and_key_size=10240
-    instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' ' -f1)
-    max_containers=250
-    instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
-
-    instance_identity_dir=${data_dir}/instance_identity
-    if mount | grep -q $instance_identity_dir; then
-      umount -f $instance_identity_dir
-    fi
-    mkdir -p "$instance_identity_dir"
-    mount -t tmpfs -o size=$instance_tmpfs_size tmpfs $instance_identity_dir
-    chown -R vcap:vcap "$instance_identity_dir"
-    chmod 0700 "$instance_identity_dir"
-
-    trusted_certs_dir=${data_dir}/trusted_certs
-    rm -rf "$trusted_certs_dir"
-    <% if_p("diego.rep.trusted_certs") do |value| %>
-      mkdir -p "$trusted_certs_dir"
-      chown -R vcap:vcap $trusted_certs_dir
-
-      /var/vcap/packages/certsplitter/bin/certsplitter $conf_dir/certs/rep/trusted_certs.crt $trusted_certs_dir
-      chmod +r ${trusted_certs_dir}/*
-    <% end %>
+    /var/vcap/jobs/rep/bin/mount_instance_identity
 
     if running_in_container; then
         echo "Not setting /proc/sys/net/ipv4 parameters, since I'm running inside a linux container"

--- a/jobs/route_emitter/templates/bpm.yml.erb
+++ b/jobs/route_emitter/templates/bpm.yml.erb
@@ -1,6 +1,6 @@
 ---
 processes:
-  route_emitter:
-    executable: /var/vcap/packages/route_emitter/bin/route-emitter
-    args:
-      - -config=/var/vcap/jobs/route_emitter/config/route_emitter.json
+- name: route_emitter
+  executable: /var/vcap/packages/route_emitter/bin/route-emitter
+  args:
+    - -config=/var/vcap/jobs/route_emitter/config/route_emitter.json

--- a/jobs/ssh_proxy/templates/bpm.yml.erb
+++ b/jobs/ssh_proxy/templates/bpm.yml.erb
@@ -1,6 +1,6 @@
 ---
 processes:
-  ssh_proxy:
-    executable: /var/vcap/packages/ssh_proxy/bin/ssh-proxy
-    args:
-      - -config=/var/vcap/jobs/ssh_proxy/config/ssh_proxy.json
+- name: ssh_proxy
+  executable: /var/vcap/packages/ssh_proxy/bin/ssh-proxy
+  args:
+    - -config=/var/vcap/jobs/ssh_proxy/config/ssh_proxy.json


### PR DESCRIPTION
*Note*: This PR should **NOT** be merged until BPM version `0.2.0` is on [release-candidate of cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/release-candidate/operations/experimental/enable-bpm.yml#L8)

This change set entails all the configuration changes necessary to migrate from BPM v0.1.0 to v0.2.0.

Configuration changes include:
- [Environment variables as a hash](https://www.pivotaltracker.com/story/show/151345092)
- [Processes as an array](https://www.pivotaltracker.com/story/show/151451341)
- [Volumes are read only by default](https://www.pivotaltracker.com/story/show/151408169)
- [Rename Volumes to AdditionalVolumes](https://www.pivotaltracker.com/story/show/151531845)
- [Opting into persistent volumes being mounted](https://www.pivotaltracker.com/story/show/151531925)
- [Opting into ephemeral volumes being mounted](https://www.pivotaltracker.com/story/show/151532030)