### PR TITLE
bump buildpackapplifecycle

### DIFF
--- a/packages/buildpack_app_lifecycle/spec
+++ b/packages/buildpack_app_lifecycle/spec
@@ -13,11 +13,24 @@ files:
   - code.cloudfoundry.org/buildpackapplifecycle/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/builder/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/containerpath/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/credhub/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/databaseuri/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/platformoptions/*.go # gosub
   - code.cloudfoundry.org/bytefmt/*.go # gosub
   - code.cloudfoundry.org/cacheddownloader/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/systemcerts/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/auth/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/auth/uaa/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/generate/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/values/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/permissions/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/server/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/vendor/github.com/hashicorp/go-version/*.go # gosub
   - golang.org/x/sys/windows/*.go # gosub
   - golang.org/x/sys/windows/*.s # gosub
   - gopkg.in/yaml.v2/*.go # gosub

--- a/packages/windows_app_lifecycle/spec
+++ b/packages/windows_app_lifecycle/spec
@@ -14,9 +14,24 @@ files:
   - code.cloudfoundry.org/buildpackapplifecycle/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/builder/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/containerpath/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/credhub/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/databaseuri/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/platformoptions/*.go # gosub
   - code.cloudfoundry.org/bytefmt/*.go # gosub
   - code.cloudfoundry.org/cacheddownloader/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/systemcerts/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/auth/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/auth/uaa/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/generate/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/credentials/values/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/permissions/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/credhub/server/*.go # gosub
+  - github.com/cloudfoundry-incubator/credhub-cli/vendor/github.com/hashicorp/go-version/*.go # gosub
+  - golang.org/x/sys/windows/*.go # gosub
+  - golang.org/x/sys/windows/*.s # gosub
   - gopkg.in/yaml.v2/*.go # gosub

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -57,6 +57,9 @@ sync_package docker_app_lifecycle    -app  code.cloudfoundry.org/dockerapplifecy
 sync_package buildpack_app_lifecycle -app  code.cloudfoundry.org/buildpackapplifecycle/builder \
   -app code.cloudfoundry.org/buildpackapplifecycle/launcher &
 
+sync_package windows_app_lifecycle -app  code.cloudfoundry.org/buildpackapplifecycle/builder \
+  -app code.cloudfoundry.org/buildpackapplifecycle/launcher &
+
 sync_package vizzini \
   -test code.cloudfoundry.org/vizzini/... \
   -app github.com/onsi/ginkgo/ginkgo &


### PR DESCRIPTION
    Also update package specs and ensure package specs updated for
    windows_app_lifecycle

    Submodule src/code.cloudfoundry.org/buildpackapplifecycle 6a12719..80aa8b7:
      > Always set DATABASE_URL from VCAP_SERVICES
      > Builder interpolates VCAP_SERVICES & sets DATABASE_URL
      > Remove VCAP_PLATFORM_OPTIONS from process env
      > Locate certs relative to USERPROFILE on Windows 2012R2
      > Path to CA certs is now passed via CF_SYSTEM_CERTS_PATH env var
      > Put profile.d scripts outside of the app directory
      > Determine DATABASE_URL from VCAP_SERVICES if unset
      > VCAP_SERVICES interpolation uses TLS
      > Launcher interpolates credhub-refs in VCAP_SERVICES