### PR TITLE
enable declarative healthcheck on windows 2016

### DIFF
--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -20,6 +20,7 @@
     enable_consul_service_registration: p("enable_consul_service_registration"),
     enable_declarative_healthcheck: p("enable_declarative_healthcheck"),
     declarative_healthcheck_path: "/var/vcap/packages/healthcheck",
+    declarative_healthcheck_user: "root",
     enable_container_proxy: p("container_proxy.enabled"),
     container_proxy_path: "/var/vcap/packages/proxy",
     container_proxy_config_path: "/var/vcap/data/rep/proxy_config",

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -264,6 +264,9 @@ properties:
   enable_declarative_healthcheck:
     description: "EXPERIMENTAL: When set, enables the rep to prefer the LRP CheckDefinition to healthcheck instances over the Monitor action."
     default: false
+  declarative_healthcheck_path:
+    description: "EXPERIMENTAL: The directory containing the declarative healthcheck binary"
+    default: "/var/vcap/packages/healthcheck_windows/external"
 
   container_proxy.enabled:
     description: "EXPERIMENTAL: Enable envoy proxy on garden containers. Currently doesn't work on windows cells but left here for compatability with the linux Rep"

--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -1,6 +1,15 @@
 ﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
+function allowContainerUsersAccess {
+  param([string] $directory)
+
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
+  $acl = Get-Acl $directory
+  $acl.AddAccessRule($rule)
+  Set-Acl $directory $acl
+}
+
 Write-Host "Running pre-start"
 
 $port="<%= p("diego.rep.enable_legacy_api_endpoints") ? p("diego.rep.listen_addr").sub(/^0\.0\.0\.0:/, "") : p("diego.rep.listen_addr_admin").sub(/^127\.0\.0\.1:/, "")%>"
@@ -27,33 +36,35 @@ if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "SecureRepPort
   }
 }
 
+$bindmountDirs = @()
+
 $cache_dir = "/var/vcap/data/rep/download_cache"
 New-Item -Path $cache_dir -ItemType "directory" -Force
+$bindmountDirs += $cache_dir
 
 $instance_identity_dir = "/var/vcap/data/rep/instance_identity"
 New-Item -Path $instance_identity_dir -ItemType "directory" -Force
+$bindmountDirs += $instance_identity_dir
+
+<% if_p("diego.rep.trusted_certs") do |value| %>
+  $conf_dir = "C:/var/vcap/jobs/rep_windows/config"
+  $trusted_certs_dir = "C:/var/vcap/data/rep/trusted_certs"
+
+  New-Item -Path $trusted_certs_dir -ItemType "directory" -Force
+  C:/var/vcap/packages/certsplitter_windows/certsplitter $conf_dir/certs/rep/trusted_certs.crt $trusted_certs_dir
+
+  $bindmountDirs += $trusted_certs_dir
+<% end %>
+
+<% if p("enable_declarative_healthcheck") %>
+  $healthcheckDir = "<%= p("declarative_healthcheck_path") %>"
+  $bindmountDirs += $healthcheckDir
+<% end %>
 
 <% if p("diego.rep.open_bindmounts_acl") %>
-  # Set ACL on download cache  + IICs to open up to container users
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
-  $acl = Get-Acl $cache_dir
-  $acl.AddAccessRule($rule)
-  Set-Acl $cache_dir $acl
-
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
-  $acl = Get-Acl $instance_identity_dir
-  $acl.AddAccessRule($rule)
-  Set-Acl $instance_identity_dir $acl
+  foreach ($dir in $bindmountDirs)
+  {
+    allowContainerUsersAccess($dir)
+  }
 <% end %>
 
-$conf_dir = "C:/var/vcap/jobs/rep_windows/config"
-<% if_p("diego.rep.trusted_certs") do |value| %>
-  $trusted_certs_dir = "C:/var/vcap/data/rep/trusted_certs"
-  New-Item -Path $trusted_certs_dir -ItemType "directory" -Force
-  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("Users", "ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow")
-  $acl = Get-Acl $trusted_certs_dir
-  $acl.AddAccessRule($rule)
-  Set-Acl $trusted_certs_dir $acl
-
-  C:/var/vcap/packages/certsplitter_windows/certsplitter $conf_dir/certs/rep/trusted_certs.crt $trusted_certs_dir
-<% end %>

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -19,7 +19,7 @@
     dropsonde_port: p("diego.rep.dropsonde_port"),
     enable_consul_service_registration: p("enable_consul_service_registration"),
     enable_declarative_healthcheck: p("enable_declarative_healthcheck"),
-    declarative_healthcheck_path: "/var/vcap/packages/healthcheck_windows",
+    declarative_healthcheck_path: p("declarative_healthcheck_path"),
     enable_container_proxy: p("container_proxy.enabled"),
     container_proxy_path: "/var/vcap/packages/proxy",
     container_proxy_config_path: "/var/vcap/data/rep/proxy_config",

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -20,6 +20,7 @@
     enable_consul_service_registration: p("enable_consul_service_registration"),
     enable_declarative_healthcheck: p("enable_declarative_healthcheck"),
     declarative_healthcheck_path: p("declarative_healthcheck_path"),
+    declarative_healthcheck_user: "",
     enable_container_proxy: p("container_proxy.enabled"),
     container_proxy_path: "/var/vcap/packages/proxy",
     container_proxy_config_path: "/var/vcap/data/rep/proxy_config",

--- a/packages/healthcheck_windows/packaging
+++ b/packages/healthcheck_windows/packaging
@@ -21,7 +21,15 @@ if ($LASTEXITCODE -ge 8) {
 
 $env:CGO_ENABLED=0
 
-go.exe build -tags=external -a -installsuffix static -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_path}"
+New-Item -ItemType directory -Path "${BOSH_INSTALL_TARGET}\internal" -Force
+New-Item -ItemType directory -Path "${BOSH_INSTALL_TARGET}\external" -Force
+
+go.exe build -tags=external -a -installsuffix static -o "${BOSH_INSTALL_TARGET}\external\${pkg_name}.exe" "${pkg_path}"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error compiling: ${pkg_path}"
+}
+
+go.exe build -a -installsuffix static -o "${BOSH_INSTALL_TARGET}\internal\${pkg_name}.exe" "${pkg_path}"
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Error compiling: ${pkg_path}"
 }

--- a/scripts/check-for-windows-drift
+++ b/scripts/check-for-windows-drift
@@ -11,7 +11,7 @@ if ! diff -u <(echo -e "$rep_windows_json") <(echo -e "$rep_json"); then
 fi
 
 rep_properties=$(cat jobs/rep/spec | sed -n '/properties/,$P' | grep -E '^  [a-z].*$' | tr -d '[:blank:]' | grep -v volman | grep -v bpm | sort)
-rep_windows_properties=$(cat jobs/rep_windows/spec | sed -n '/properties/,$P' | grep -E '^  [a-z].*$' | grep -v syslog | grep -v diego.rep.open_bindmounts_acl | tr -d '[:blank:]' | sort)
+rep_windows_properties=$(cat jobs/rep_windows/spec | sed -n '/properties/,$P' | grep -E '^  [a-z].*$' | grep -v syslog | grep -v diego.rep.open_bindmounts_acl | grep -v declarative_healthcheck_path | tr -d '[:blank:]' | sort)
 
 if ! diff -u <(echo -e "$rep_properties") <(echo -e "$rep_windows_properties"); then
     echo "rep specs have drifted"


### PR DESCRIPTION
Note: requires declarative healthcheck not to run as "root" on windows 2016: https://github.com/cloudfoundry/executor/blob/b9579532f2db284a91dde812621f7ad815fd1f63/depot/transformer/transformer.go#L493

[#151698336]

Signed-off-by: Sam Smith <sesmith177@gmail.com>