### PR TITLE
increase duration of garden_healthcheck.process

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -177,7 +177,7 @@ properties:
     default: "/bin/sh"
   diego.executor.garden_healthcheck.process.args:
     description: "List of command line args to pass to the garden health check process"
-    default: "-c, ls > /tmp/test"
+    default: "-c, sleep 2"
   diego.executor.garden_healthcheck.process.user:
     description: "User to use while performing a container healthcheck"
     default: "vcap"


### PR DESCRIPTION
`garden_healthcheck.process` currently only does an `ls` which causes the container to spin up and close down within 0.002 seconds.

As this will create a bridge interface on the underlying host, this can cause the OS to crash in case multicast traffic is present.

The newly created bridge will perform an mcast group join. While the mcast join is performed, the bridge interface is already being removed may causing the kernel to experience a memory corruption: https://lists.linuxfoundation.org/pipermail/bridge/2017-April/010395.html

It turned out that leaving the garden healtcheck container up for 2 seconds (i.e. using `sleep 2`) allows the kernel to perform all required operations on that bridge and its save to perform a removal of the container.