### PR TITLE
Add getenv binary to BAL and WAL.

### DIFF
--- a/packages/buildpack_app_lifecycle/packaging
+++ b/packages/buildpack_app_lifecycle/packaging
@@ -13,6 +13,7 @@ CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpacka
 
 GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder
 GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/launcher
+GOOS=windows CGO_ENABLED=0 go build -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/getenv
 
 for binary in builder launcher; do
     ldd $binary && echo "$binary must be statically linked" && false
@@ -26,7 +27,7 @@ cp /var/vcap/packages/healthcheck/healthcheck.exe .
 
 tar -czf ${BOSH_INSTALL_TARGET}/buildpack_app_lifecycle.tgz \
   builder launcher shell healthcheck diego-sshd  \
-  builder.exe launcher.exe healthcheck.exe diego-sshd.exe \
+  builder.exe launcher.exe getenv.exe healthcheck.exe diego-sshd.exe \
   winpty-agent.exe winpty.dll
 
 # clean up source artifacts

--- a/packages/buildpack_app_lifecycle/spec
+++ b/packages/buildpack_app_lifecycle/spec
@@ -17,6 +17,7 @@ files:
   - code.cloudfoundry.org/buildpackapplifecycle/credhub/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/databaseuri/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/env/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/getenv/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/profile/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/platformoptions/*.go # gosub

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -9,6 +9,7 @@ export PATH=$GOROOT/bin:$PATH
 
 GOOS=windows CGO_ENABLED=0 go build -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder
 GOOS=windows CGO_ENABLED=0 go build -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/launcher
+GOOS=windows CGO_ENABLED=0 go build -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/getenv
 
 mkdir -p tmp
 tar -xzf tar/tar-*.tgz -C tmp
@@ -17,7 +18,7 @@ cp /var/vcap/packages/diego-sshd/diego-sshd-windows2012R2.exe diego-sshd.exe
 cp /var/vcap/packages/healthcheck/healthcheck-external-port.exe healthcheck.exe
 cp tmp/tar-*.exe tar.exe
 
-tar -czf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz builder.exe launcher.exe healthcheck.exe diego-sshd.exe tar.exe
+tar -czf ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz builder.exe launcher.exe getenv.exe healthcheck.exe diego-sshd.exe tar.exe
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/windows_app_lifecycle/spec
+++ b/packages/windows_app_lifecycle/spec
@@ -18,6 +18,7 @@ files:
   - code.cloudfoundry.org/buildpackapplifecycle/credhub/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/databaseuri/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/env/*.go # gosub
+  - code.cloudfoundry.org/buildpackapplifecycle/getenv/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/launcher/profile/*.go # gosub
   - code.cloudfoundry.org/buildpackapplifecycle/platformoptions/*.go # gosub

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -56,10 +56,12 @@ sync_package docker_app_lifecycle    -app  code.cloudfoundry.org/dockerapplifecy
 
 sync_package buildpack_app_lifecycle -app  code.cloudfoundry.org/buildpackapplifecycle/builder \
   -app code.cloudfoundry.org/buildpackapplifecycle/launcher \
+  -app code.cloudfoundry.org/buildpackapplifecycle/getenv \
   -app code.cloudfoundry.org/buildpackapplifecycle/shell/shell &
 
 sync_package windows_app_lifecycle -app  code.cloudfoundry.org/buildpackapplifecycle/builder \
-  -app code.cloudfoundry.org/buildpackapplifecycle/launcher &
+  -app code.cloudfoundry.org/buildpackapplifecycle/launcher \
+  -app code.cloudfoundry.org/buildpackapplifecycle/getenv &
 
 sync_package vizzini \
   -test code.cloudfoundry.org/vizzini/... \


### PR DESCRIPTION
Fixes an issue on Windows with env variables containing newline(s).

This PR must come after the BAL submodule is bumped to [this commit](https://github.com/cloudfoundry/buildpackapplifecycle/commit/1e1fa5ae3fdb39bf974fe111ce2e7373473550fc)