### PR TITLE
Increase additional memory for proxy to 32 MB

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -243,7 +243,7 @@ properties:
     default: false
   containers.proxy.additional_memory_allocation_mb:
     description: "EXPERIMENTAL: Additional memory allocated to each container for the envoy proxy. This value must not be negative"
-    default: 5
+    default: 32
 
   containers.trusted_ca_certificates:
     description: "List of PEM-encoded CA certificates to make available inside containers in a conventional location. List entries may be individual or concatenated CAs."

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -254,7 +254,7 @@ properties:
     default: false
   containers.proxy.additional_memory_allocation_mb:
     description: "EXPERIMENTAL: Additional memory allocated to each container for the envoy proxy. This must not be negative. Currently doesn't work on windows cells but left here for compatability with the linux Rep"
-    default: 5
+    default: 32
 
   containers.trusted_ca_certificates:
     description: "List of PEM-encoded CA certificates to make available inside containers in a conventional location. List entries may be individual or concatenated CAs."


### PR DESCRIPTION
Based on team findings in https://www.pivotaltracker.com/story/show/155945585, setting the default additional memory allocation to 32 MB should accommodate between 750 and 1024 concurrent connections without consuming the memory quota requested for the application instance itself. This default is also consistent with documentation at https://docs.cloudfoundry.org/concepts/http-routing.html#with-tls and with how this property has been set in several other environments.