### PR TITLE
Correct route_emitter health check address description

### DIFF
--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -48,7 +48,7 @@ properties:
     description: "address at which to serve debug info"
     default: "127.0.0.1:17009"
   diego.route_emitter.healthcheck_address:
-    description: "address at which to serve debug info"
+    description: "address for the route_emitter health endpoint."
     default: "127.0.0.1:17011"
   diego.route_emitter.sync_interval_in_seconds:
     description: "Interval to sync routes to the router in seconds."

--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -38,7 +38,7 @@ properties:
     description: "address at which to serve debug info"
     default: "127.0.0.1:17009"
   diego.route_emitter.healthcheck_address:
-    description: "address at which to serve debug info"
+    description: "address for the route_emitter health endpoint."
     default: "127.0.0.1:17011"
   diego.route_emitter.sync_interval_in_seconds:
     description: "Interval to sync routes to the router in seconds."


### PR DESCRIPTION
Corrects C&P description for route_emitter health_check address