### PR TITLE
Mount shared_data as shared when bpm is enabled

### DIFF
--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -21,6 +21,10 @@ instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' '
 max_containers=250
 instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
 
+mkdir -p /var/vcap/data/rep/shared_data
+flock /var/vcap/sys/run/garden/mount.lock /bin/bash -c 'if ! grep -q " /var/vcap/data/rep/shared_data " /proc/self/mountinfo; then mount --bind /var/vcap/data/rep/shared_data /var/vcap/data/rep/shared_data; fi'
+mount --make-shared /var/vcap/data/rep/shared_data
+
 instance_identity_dir=${shared_data_dir}/instance_identity
 if mount | grep -q $instance_identity_dir; then
   umount -f $instance_identity_dir


### PR DESCRIPTION
This is so that Garden and `rep` can both access the `instance_identity` tmpfs
mount under `shared_data` in a way that doesn't cause races.

See for context: https://www.pivotaltracker.com/story/show/160322138
See corresponding commit in garden-runc-release: https://github.com/cloudfoundry/garden-runc-release/commit/61b47c66fcfae2794a71aaf67a0b4e8e8582ce07

This is intended as a temporary fix and should be removed once BPM (or
some other thing) allows us to mount `shared_data` into multiple BPM
containers in a safe way.

/cc @ostenbom