### PR TITLE
Make it possible to invoke scripts/run-inigo from a Mac

### DIFF
--- a/scripts/run-inigo
+++ b/scripts/run-inigo
@@ -12,7 +12,7 @@ echo "checking code for compilation errors..."
 pushd $DIEGO_RELEASE_DIR/src/code.cloudfoundry.org/inigo > /dev/null
   for pkg in `find . -maxdepth 1 -type d ! -path . -not -path '*/\.*'`; do
     echo $pkg
-    go test -c ./${pkg} > /dev/null
+    GOOS=linux GOARCH=amd64 go test -c ./${pkg} > /dev/null
   done
 popd > /dev/null
 


### PR DESCRIPTION
Without this change, `run-inigo` fails compilation checks because some modules don't compile for Darwin.  This change causes go to explicitly cross compile for linux.