### PR TITLE
Fix header rendering in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,7 +374,7 @@ If your local concourse VM is up and running, you have the `fly` CLI visible on 
 
 from the root of diego-release to run the integration tests. You can also run the integration tests against another concourse deployment by setting the `DIEGO_CI_TARGET` environment variable.
 
-###<a name="smokes-and-cats"></a> Running Smoke Tests, and CATs
+### <a name="smokes-and-cats"></a> Running Smoke Tests, and CATs
 
 You can test that your diego-release deployment is working and integrating with cf-release by running the lightweight [cf-smoke-tests](https://github.com/cloudfoundry/cf-smoke-tests) or the more thorough [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests). These test suites assume you have a BOSH environment to deploy cf and diego to. For local development, bosh-lite is an easy way to have a single-VM deployment. To deploy diego to bosh-lite, follow the instructions on [deploying diego to bosh-lite](README.md#deploy-bosh-lite).
 


### PR DESCRIPTION
The anchor tag right next to the '###' marker was preventing the header from being rendered properly.