### PR TITLE
Make possible for garden to access shared data in rootless

### DIFF
--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -1,9 +1,9 @@
 <%=
   conf_dir = "/var/vcap/jobs/#{p("diego.rep.job_name")}/config"
   tmp_dir = "/var/vcap/data/rep/tmp"
-  trusted_certs_dir = "/var/vcap/data/rep/shared_data/trusted_certs"
-  instance_identity_dir = "/var/vcap/data/rep/shared_data/instance_identity"
-  download_cache_dir= "/var/vcap/data/rep/shared_data/download_cache"
+  trusted_certs_dir = "/var/vcap/data/rep/shared/garden/trusted_certs"
+  instance_identity_dir = "/var/vcap/data/rep/shared/garden/instance_identity"
+  download_cache_dir= "/var/vcap/data/rep/shared/garden/download_cache"
 
   zone = spec.az
   if_p("diego.rep.zone") do |value|
@@ -47,7 +47,7 @@
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/proxy",
-    container_proxy_config_path: "/var/vcap/data/rep/shared_data/proxy_config",
+    container_proxy_config_path: "/var/vcap/data/rep/shared/garden/proxy_config",
     evacuation_polling_interval: "#{p("diego.rep.evacuation_polling_interval_in_seconds")}s",
     evacuation_timeout: "#{p("diego.rep.evacuation_timeout_in_seconds")}s",
     garden_addr: p("diego.executor.garden.address"),

--- a/jobs/rep/templates/rep_ctl.erb
+++ b/jobs/rep/templates/rep_ctl.erb
@@ -6,7 +6,7 @@ conf_dir=/var/vcap/jobs/rep/config
 bin_dir=/var/vcap/jobs/rep/bin
 
 data_dir=/var/vcap/data/rep
-shared_data_dir=${data_dir}/shared_data
+shared_data_dir=${data_dir}/shared/garden
 tmp_dir=$data_dir/tmp
 
 pidfile=$run_dir/rep.pid

--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 conf_dir=/var/vcap/jobs/rep/config
-shared_data_dir=/var/vcap/data/rep/shared_data
+shared_dir=/var/vcap/data/rep/shared
+garden_shared_dir=${shared_dir}/garden
 
 # Remove old data dirs so that disk space isn't wasted. This cleanup can be removed in v4
 old_data_dir=/var/vcap/data/rep
@@ -9,10 +10,17 @@ old_instance_identity_dir=${old_data_dir}/instance_identity
 if mount | grep -q $old_instance_identity_dir; then
   umount -f $old_instance_identity_dir
 fi
+
+old_shared_data_dir=${old_data_dir}/shared_data
+if mount | grep -q $old_shared_data_dir; then
+  umount -f -R $old_shared_data_dir
+fi
+
 rm -rf "${old_instance_identity_dir}"
 rm -rf "${old_data_dir}/trusted_certs"
 rm -rf "${old_data_dir}/download_cache"
 rm -rf "${old_data_dir}/proxy_config"
+rm -rf "${old_shared_data_dir}"
 
 # Key and Cert are generally ~2048 bytes. Add an extra 2048 for extra space
 # add another 4096 to account for the temp files used to do atomic replacement #141163257
@@ -21,20 +29,29 @@ instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' '
 max_containers=250
 instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
 
-instance_identity_dir=${shared_data_dir}/instance_identity
+instance_identity_dir=${garden_shared_dir}/instance_identity
+
 if mount | grep -q $instance_identity_dir; then
   umount -f $instance_identity_dir
 fi
+
+mkdir -p "$shared_dir"
+chown vcap:vcap "$shared_dir"
+chmod 0700 "$shared_dir"
+
+mkdir -p "$garden_shared_dir"
+flock /var/vcap/sys/run/garden/mount.lock /bin/bash -c 'if ! grep -q " /var/vcap/data/rep/shared/garden " /proc/self/mountinfo; then mount --bind /var/vcap/data/rep/shared/garden /var/vcap/data/rep/shared/garden; fi'
+mount --make-shared /var/vcap/data/rep/shared/garden
+
 mkdir -p "$instance_identity_dir"
 mount -t tmpfs -o size=$instance_tmpfs_size tmpfs $instance_identity_dir
 chown -R vcap:vcap "$instance_identity_dir"
-chmod 0700 "$instance_identity_dir"
 
-cache_dir=${shared_data_dir}/download_cache
+cache_dir=${garden_shared_dir}/download_cache
 mkdir -p "$cache_dir"
 chown -R vcap:vcap $cache_dir
 
-trusted_certs_dir=${shared_data_dir}/trusted_certs
+trusted_certs_dir=${garden_shared_dir}/trusted_certs
 rm -rf "$trusted_certs_dir"
 <% if_p("containers.trusted_ca_certificates") do %>
   mkdir -p "$trusted_certs_dir"
@@ -45,10 +62,9 @@ rm -rf "$trusted_certs_dir"
   chmod +r ${trusted_certs_dir}/*
 <% end %>
 
-proxy_config_dir=${shared_data_dir}/proxy_config
+proxy_config_dir=${garden_shared_dir}/proxy_config
 rm -rf "$proxy_config_dir"
 <% if p("containers.proxy.enabled") %>
   mkdir -p "$proxy_config_dir"
   chown -R vcap:vcap "$proxy_config_dir"
-  chmod 0700 "$proxy_config_dir"
 <% end %>

--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -41,20 +41,21 @@ Remove-Item -Path "/var/vcap/data/rep/download_cache" -Force -Recurse -ErrorActi
 Remove-Item -Path "/var/vcap/data/rep/instance_identity" -Force -Recurse -ErrorAction "Continue"
 Remove-Item -Path "/var/vcap/data/rep/trusted_certs" -Force -Recurse -ErrorAction "Continue"
 Remove-Item -Path "/var/vcap/data/rep/proxy_config" -Force -Recurse -ErrorAction "Continue"
+Remove-Item -Path "/var/vcap/data/rep/shared_data" -Force -Recurse -ErrorAction "Continue"
 
 $bindmountDirs = @()
 
-$cache_dir = "/var/vcap/data/rep/shared_data/download_cache"
+$cache_dir = "/var/vcap/data/rep/shared/garden/download_cache"
 New-Item -Path $cache_dir -ItemType "directory" -Force
 $bindmountDirs += $cache_dir
 
-$instance_identity_dir = "/var/vcap/data/rep/shared_data/instance_identity"
+$instance_identity_dir = "/var/vcap/data/rep/shared/garden/instance_identity"
 New-Item -Path $instance_identity_dir -ItemType "directory" -Force
 $bindmountDirs += $instance_identity_dir
 
 <% if_p("containers.trusted_ca_certificates") do |value| %>
   $conf_dir = "C:/var/vcap/jobs/rep_windows/config"
-  $trusted_certs_dir = "C:/var/vcap/data/rep/shared_data/trusted_certs"
+  $trusted_certs_dir = "C:/var/vcap/data/rep/shared/garden/trusted_certs"
 
   New-Item -Path $trusted_certs_dir -ItemType "directory" -Force
   C:/var/vcap/packages/certsplitter_windows/certsplitter $conf_dir/certs/rep/trusted_ca_certificates.json $trusted_certs_dir

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -1,9 +1,9 @@
 <%=
   conf_dir = "/var/vcap/jobs/#{p("diego.rep.job_name")}/config"
   tmp_dir = "/var/vcap/data/rep/tmp"
-  trusted_certs_dir = "/var/vcap/data/rep/shared_data/trusted_certs"
-  instance_identity_dir = "/var/vcap/data/rep/shared_data/instance_identity"
-  download_cache_dir= "/var/vcap/data/rep/shared_data/download_cache"
+  trusted_certs_dir = "/var/vcap/data/rep/shared/garden/trusted_certs"
+  instance_identity_dir = "/var/vcap/data/rep/shared/garden/instance_identity"
+  download_cache_dir= "/var/vcap/data/rep/shared/garden/download_cache"
 
   zone = spec.az
   if_p("diego.rep.zone") do |value|
@@ -47,7 +47,7 @@
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/proxy",
-    container_proxy_config_path: "/var/vcap/data/rep/shared_data/proxy_config",
+    container_proxy_config_path: "/var/vcap/data/rep/shared/garden/proxy_config",
     evacuation_polling_interval: "#{p("diego.rep.evacuation_polling_interval_in_seconds")}s",
     evacuation_timeout: "#{p("diego.rep.evacuation_timeout_in_seconds")}s",
     garden_addr: p("diego.executor.garden.address"),


### PR DESCRIPTION
Currently garden does not work when rootless and bpm are enabled because:
* on start we mount /var/vcap/data/rep/shared_data in the garden bpm container
* on container creation, garden (being run as a non-root user) tries to read from `/var/vcap/data/rep/shared_data/instance_identity`, but does not manage to since `/var/vcap/data/rep/shared_data` has `0700` permission and is owned by vcap

Our current approach to work around this problem is the following:
* have `/var/vcap/data/shared` owned by vcap and 0700 persmission so the data in there is still secured
* have a nested directory `vcap/vcap/data/shared/garden` which is a shared bind mount, which gets mounted in the garden bpm container. Since `/var/vcap/data/shared` does not get mounted in the container, that folder will result with 0755 permissions in the garden bpm container
* have the `vcap/vcap/data/shared/garden/instance_identity` tmpfs, which will get inherited in the garden bpm container since `/var/vcap/data/shared` is shared.

We are switching from  `/var/vcap/data/rep/shared_data` to /var/vcap/data/rep/shared` so we don't leak mounts when updating from an old to a new version. If we kept the old folder and for example if garden starts first during the update, it will create the new mounts under `/var/vcap/data/rep/shared_data/garden` and `/var/vcap/data/rep/shared_data/garden/instance_identity` and rep won't then be able to umount the old bind mount at `/var/vcap/data/rep/shared_data`

Making garden work will also require changing:
* adapting the new path in https://github.com/cloudfoundry/diego-release/pull/410 and merge it
* update garden with the new path https://github.com/cloudfoundry/garden-runc-release/commit/eae87875cc257972d674c12f9cd717983895644e

but we would like to hear your thoughts on this approach before proceeding with the other changes.

Co-authored-by: Claudia Beresford <cberesford@pivotal.io>
Co-authored-by: Danail Branekov <danailster@gmail.com>