### PR TITLE
Work around for the issue with close_wait and connection refused

### DIFF
--- a/jobs/rep/templates/set-rep-kernel-params.erb
+++ b/jobs/rep/templates/set-rep-kernel-params.erb
@@ -20,6 +20,10 @@ echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
 # Default value is 65536. We set it to a larger number to avoid running out of connections.
 echo 262144 > /proc/sys/net/netfilter/nf_conntrack_max
 
+# Default value is 60 (seconds). We set it to a larger number to avoid connection issues with remote endpoints or
+# firewalls which keep sessions for half-closed connections for longer than 1 minute.
+echo 900 > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_close_wait
+
 echo 2147483647 > /proc/sys/fs/inotify/max_user_watches
 echo 2147483647 > /proc/sys/fs/inotify/max_user_instances
 echo 2147483647 > /proc/sys/fs/inotify/max_queued_events


### PR DESCRIPTION
This is a fix for the issue with connection to the remote endpoint (HOST:PORT) being *randomly* (actually not) reset or timed out. Described below.

1. An app running in a container opens a connection to HOST:PORT on a remote server or load balancer
2. Remote server closes the connection at some point and the app instance keeps it in close_wait state (some libraries and frameworks do this intentionally to save resources by reusing sockets)
3. In 60 seconds (net.netfilter.nf_conntrack_tcp_timeout_close_wait) mapping between container ip:port and VM ip:port expires however on remote server (or load balancer, or firewall) it usually expires after longer time (defaults for load balancers varies from 180 to 600 seconds, for firewalls even longer)
4. If something running in another container (completely different unrelated application) on the same cell is given the same source port for a new connection to HOST:PORT it will not only fail, it will also refresh the expiration period on some types of load balancers and it gets back to maximum TTL (for example A10 behaves this way). Normally an ephemeral port is chosen an N+1 to the one which is in use now. In case of failure (timeout or reject) the counter will not be increased so next time the same port will be chosen and it will fail again with refreshing expiration time on load balancer. This can keep happening in a loop for very long (sometimes days) making most of containers on the celll failing to connect to HOST:PORT. This is especially critical for microservices where all the apps connect to the same endpoint (usually load balancer).

To prevent the issue from happening we increase nf_conntrack_tcp_timeout_close_wait from 60 (default) to 900 which is bigger than default timeouts on typical load balancers.