### PR TITLE
Add instance_identity_add_spiffe_uri property to rep job

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -207,6 +207,9 @@ properties:
   diego.executor.instance_identity_validity_period_in_hours:
     description: "Validity period for the generated instance identity certificate"
     default: 24
+  diego.executor.instance_identity_add_spiffe_uri:
+    description: "Experimental: Enables the executor to add a default SPIFFE URI to the instance identity certificate Subject Alternative Name (SAN)."
+    default: false
 
   diego.rep.bbs.api_location:
     description: "Address to the BBS Server"

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -183,12 +183,14 @@
 
   if_p("diego.executor.instance_identity_ca_cert",
        "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |cert, key, validity_period|
+       "diego.executor.instance_identity_validity_period_in_hours",
+       "diego.executor.instance_identity_add_spiffe_uri") do |cert, key, validity_period, add_spiffe_uri|
     if !(cert.empty? || key.empty? || validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"
       config[:instance_identity_cred_dir] = instance_identity_dir
       config[:instance_identity_validity_period] = "#{validity_period}h"
+      config[:instance_identity_add_spiffe_uri] = add_spiffe_uri
     elsif validity_period < 1
       raise '"diego.executor.instance_identity_validity_period_in_hours" should be a positive integer'
     end

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -202,6 +202,9 @@ properties:
   diego.executor.instance_identity_validity_period_in_hours:
     description: "Validity period for the generated instance identity certificate"
     default: 24
+  diego.executor.instance_identity_add_spiffe_uri:
+    description: "Experimental: Enables the executor to add a default SPIFFE URI to the instance identity certificate Subject Alternative Name (SAN)."
+    default: false
 
   diego.rep.bbs.api_location:
     description: "Address to the BBS Server"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -183,12 +183,14 @@
 
   if_p("diego.executor.instance_identity_ca_cert",
        "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |cert, key, validity_period|
+       "diego.executor.instance_identity_validity_period_in_hours",
+       "diego.executor.instance_identity_add_spiffe_uri") do |cert, key, validity_period, add_spiffe_uri|
     if !(cert.empty? || key.empty? || validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"
       config[:instance_identity_cred_dir] = instance_identity_dir
       config[:instance_identity_validity_period] = "#{validity_period}h"
+      config[:instance_identity_add_spiffe_uri] = add_spiffe_uri
     elsif validity_period < 1
       raise '"diego.executor.instance_identity_validity_period_in_hours" should be a positive integer'
     end


### PR DESCRIPTION
This adds a `diego.executor.instance_identity_add_spiffe_uri` property to the rep to optionally add the default SPIFFE URI needed for the Istio work. Defaults to false. Needs this PR: https://github.com/cloudfoundry/executor/pull/45.