### PR TITLE
Remove dead submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -331,9 +331,6 @@
 	path = src/golang.org/x/sys
 	url = https://go.googlesource.com/sys
 	branch = master
-[submodule "src/github.com/paulcwarren/spec"]
-	path = src/github.com/paulcwarren/spec
-	url = https://github.com/paulcwarren/spec.git
 [submodule "src/code.cloudfoundry.org/diego-logging-client"]
 	path = src/code.cloudfoundry.org/diego-logging-client
 	url = https://github.com/cloudfoundry/diego-logging-client


### PR DESCRIPTION
I'm guessing this was an old submodule and they are always fiddly to clear :)

It is currently breaking Garden's pipeline (`error: pathspec 'src/github.com/paulcwarren/spec' did not match any file(s) known to git.`) since Concourse's git resource has [started being more precise](https://github.com/concourse/git-resource/blob/master/assets/in#L133-L153) about the submodule paths they init.
