### PR TITLE
Bin pack first fit

### DIFF
--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -48,6 +48,9 @@ properties:
   diego.auctioneer.cell_state_timeout:
     description: "Timeout applied to HTTP requests to the Cell State endpoint."
     default: "10s"
+  diego.auctioneer.bin_pack_first_fit_weight:
+    description: "Factor to bias against BOSH instance index number of a cell. Instead of spreading containers equally accross all cells, cells with a lower index number will be deployed to first when this setting is > 0. (0.0 - 1.0)"
+    default: 0.0
   diego.auctioneer.starting_container_weight:
     description: "Factor to bias against cells with starting containers (0.0 - 1.0)"
     default: 0.25

--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -16,6 +16,7 @@
     rep_client_session_cache_size: p("diego.auctioneer.rep.client_session_cache_size"),
     rep_require_tls: p("diego.auctioneer.rep.require_tls"),
     cell_state_timeout: p("diego.auctioneer.cell_state_timeout"),
+    bin_pack_first_fit_weight: p("diego.auctioneer.bin_pack_first_fit_weight"),
     starting_container_weight: p("diego.auctioneer.starting_container_weight"),
     starting_container_count_maximum: p("diego.auctioneer.starting_container_count_maximum"),
   }

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -29,6 +29,7 @@
     auto_disk_capacity_overhead_mb: p("diego.executor.auto_disk_capacity_overhead_mb"),
     cache_path: "#{download_cache_dir}",
     cell_id: spec.id,
+    cell_index: spec.index,
     cell_registrations_locket_enabled: p("cell_registrations.locket.enabled"),
     container_inode_limit: p("diego.executor.container_inode_limit"),
     container_max_cpu_shares: p("diego.executor.container_max_cpu_shares"),


### PR DESCRIPTION
This PR is part of multiple PRs across [rep](https://github.com/cloudfoundry/rep), [auctioneer](https://github.com/cloudfoundry/auctioneer) and [auction](https://github.com/cloudfoundry/auction) to add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs.

PRs/issues involved:
* [rep#30](https://github.com/cloudfoundry/rep/pull/30)
* [auctioneer#8](https://github.com/cloudfoundry/auctioneer/pull/8)
* [auction#8](https://github.com/cloudfoundry/auction/pull/8)
* [diego-release#448](https://github.com/cloudfoundry/diego-release/pull/448)

### What is this change about?

These PRs combined introduce a new setting for auctioneer:
```
diego.auctioneer.bin_pack_first_fit_weight
  description: "Factor to bias against BOSH instance index number of a cell. Instead of spreading containers equally across all cell
s, cells with a lower index number will be deployed to first when this setting is > 0. (0.0 - 1.0)"
  default: 0.0
```

When `bin_pack_first_fit_weight` is set to a value > 0, it will make diego-cells with a lower BOSH instance index number more attractive to deploy LRPs to by adding "weight x diego-cell index" to the score of a diego-cell. Diego-cells will be filled up more instead spreading the LRPs across all diego-cells equally.

Setting `bin_pack_first_fit_weight` to 0.0 (the default) will effectively disable the optional weighted bin pack first fit component. Everything still keeps working as it was previously.

### What problem it is trying to solve?

With the current deployment algorithm in diego it spreads the LRPs across all diego-cell instances equally. At Mendix we have 64GB memory diego-cells. We need to have the possibility for our customers to deploy 16G containers at all times. This means that we need to have at least 1 diego-cell with 16G memory available at all times. When the LRPs are spread equally you end up with a situation where on average 25% (16/64) of the memory on all our diego-cells is not used.

### What is the impact if the change is not made?

In our case 25% of our diego-cell resources are wasted. We have been running a diego-release with these changes on top for the past months in our production Cloud Foundry foundations. We are saving ten-thousands of $$ monthly on AWS EC2 costs.

### How should this change be described in diego-release release notes?

auctioneer
* Add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs

### Please provide any contextual information.

Blog post with more information: https://cloud-infra.engineer/saving-costs-with-a-new-scheduler-in-cloud-foundry-diego/

### Tag your pair, your PM, and/or team!

I'm not sure who to tag.