### PR TITLE
allow configuration of nats-tls hostname

### DIFF
--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -59,6 +59,8 @@ properties:
   diego.route_emitter.nats.tls.enabled:
     description: "Enable connecting to NATS server via TLS."
     default: false
+  diego.route_emitter.nats.tls.hostname:
+    description: "Hostname of the NATS cluster."
   diego.route_emitter.nats.tls.client_cert:
     description: "PEM-encoded certificate for the route-emitter to present to NATS for verification when connecting via TLS."
   diego.route_emitter.nats.tls.client_key:

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -32,6 +32,9 @@
   if_link('nats-tls') do |nats_link|
     if p("diego.route_emitter.nats.tls.enabled")
       nats_machines = nats_link.instances.map { |instance| instance.address }
+      if_p("diego.route_emitter.nats.tls.hostname") do | prop |
+        nats_machines = [prop]
+      end
       nats_port = nats_link.p("nats.port")
       nats_user = nats_link.p("nats.user")
       nats_password = nats_link.p("nats.password")

--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -49,6 +49,8 @@ properties:
   diego.route_emitter.nats.tls.enabled:
     description: "Enable connecting to NATS server via TLS."
     default: false
+  diego.route_emitter.nats.tls.hostname:
+    description: "Hostname of the NATS cluster."
   diego.route_emitter.nats.tls.client_cert:
     description: "PEM-encoded certificate for the route-emitter to present to NATS for verification when connecting via TLS."
   diego.route_emitter.nats.tls.client_key:

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -32,6 +32,9 @@
   if_link('nats-tls') do |nats_link|
     if p("diego.route_emitter.nats.tls.enabled")
       nats_machines = nats_link.instances.map { |instance| instance.address }
+      if_p("diego.route_emitter.nats.tls.hostname") do | prop |
+        nats_machines = [prop]
+      end
       nats_port = nats_link.p("nats.port")
       nats_user = nats_link.p("nats.user")
       nats_password = nats_link.p("nats.password")


### PR DESCRIPTION
Prefer a locally specified hostname in the route-emitter and route-emitter
windows spec over the use of the nats-tls link instances.address.

This is required if specifying a bosh-dns-alias for nats-tls. It is
helpful to have a bosh-dns-alias when connecting to a host using TLS for
hostname verification.

[#170956876](https://www.pivotaltracker.com/story/show/170956876)

Co-authored-by: Aidan Obley <aobley@pivotal.io>
Co-authored-by: Clay Kauzlaric <ckauzlaric@pivotal.io>

Thank you for submitting a pull request to the diego-release repository. We appreciate the contribution. To help us with getting better context for the pull request please follow these guidelines:

## Please make sure to complete the following steps

* [x] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [x] Make sure a pull request is done against the `develop` branch.
* [ ] Please [open an issue](https://github.com/cloudfoundry/diego-release/issues/new) to request review and response to your pull request.

## Please provide the following information when submitting pull request:

### What is this change about?

> This change allows an operator to configure the hostname for connections to nats-tls

### What problem it is trying to solve?

> This is required if specifying a bosh-dns-alias for nats-tls and for us to integrate route-emitter-windows with nats-tls. We use the bosh-dns-alias on our certificate.

### What is the impact if the change is not made?

> We are not able to currently able to use TLS between route-emitter-windows and nats-tls without this.

### How should this change be described in diego-release release notes?

> Operator can configure a nats-tls hostname for route-emitter and route-emitter windows.

### Please provide any contextual information.

> https://www.pivotaltracker.com/story/show/170956876

### Tag your pair, your PM, and/or team!

> @cloudfoundry/cf-networking @KauzClay @flawedmatrix 

Thank you!
