### PR TITLE
fix: Make the application of an ulimit to open fds configurable.

### DIFF
--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -80,6 +80,10 @@ properties:
   loggregator.key:
     description: "Private key for the SSH-proxy metron client certificate."
 
+  set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true
+
   set_kernel_parameters:
     description: "Enable tuning /proc/sys kernel parameters. NOTE: set this property to 'false' when deploying to BOSH-Lite or other containerized BOSH clouds."
     default: true

--- a/jobs/file_server/templates/file_server_ctl.erb
+++ b/jobs/file_server/templates/file_server_ctl.erb
@@ -20,8 +20,10 @@ case $1 in
 
     $bin_dir/set-file-server-kernel-params
 
+<% if p("set_ulimit_fds") %>
     # Allowed number of open file descriptors
     ulimit -n 100000
+<% end %>
 
     exec chpst -u vcap:vcap bash -c '/var/vcap/jobs/file_server/bin/file_server_as_vcap'
 

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -325,6 +325,10 @@ properties:
     description: "Enable tuning /proc/sys kernel parameters. NOTE: set this property to 'false' when deploying to BOSH-Lite or other containerized BOSH clouds."
     default: true
 
+  set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true
+
   containers.proxy.configuration_reload_duration:
     description: "Duration of time in seconds that the rep grants the container Envoy proxy to reload its listener configuration when shutting down a container gracefully so that TLS-verifying clients will stop making connections. After this time duration, the rep will shut down other processes in the container."
     default: 5s

--- a/jobs/rep/templates/rep_ctl.erb
+++ b/jobs/rep/templates/rep_ctl.erb
@@ -39,8 +39,10 @@ case $1 in
     $bin_dir/set-rep-kernel-params
     $bin_dir/setup_mounted_data_dirs
 
+<% if p("set_ulimit_fds") %>
     # Allowed number of open file descriptors
     ulimit -n 100000
+<% end %>
 
     exec chpst -u vcap:vcap /var/vcap/jobs/rep/bin/rep_as_vcap
 


### PR DESCRIPTION
New property `set_ulimit_fds` to disable ulimiting.
Defaults to true, activating the ulimit for standard behaviour.

The change allows SUSE to disable the application of the limit in their containerization (where it interferes) without having to patch system sources. After the change this can be done properly via ops files changing the relevant properties.
    
Origin ticket: cloudfoundry-incubator/kubecf#504
Origin ticket: cloudfoundry-incubator/kubecf#505
See also https://github.com/cloudfoundry/capi-release/pull/172
