### PR TITLE
Bump envoy to 3504d40f75

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ jq/jq-1.6-linux64.tgz:
   size: 1710406
   object_id: 903cbcb6-fc74-4434-4efc-e8ab36ea03bd
   sha: df0513a1ed80d8522d4a04dd03817e11de03d56e
-proxy/envoy-3504d40f752eb5c20bc2883053547717bcb92fd8.tgz:
-  size: 11796651
-  object_id: 3785696e-7882-4241-41d6-efa3d65b7cca
-  sha: 7bd7d987523057e32cafea1e1d86b3ffe40c4ece
+proxy/envoy-1a0363c885c2dbb1e48b03847dbd706d1ba43eba.tgz:
+  size: 11796590
+  object_id: 228c5698-d005-492b-7d2c-fbb45f72f5ba
+  sha: 18e30e17276879460e447ecbfaad409a261dde51
 tar/tar-1503683828.tgz:
   size: 457686
   object_id: 2bf800f2-09ae-4b3a-4d9d-896dcee551ac

--- a/packages/proxy/packaging
+++ b/packages/proxy/packaging
@@ -2,5 +2,5 @@ set -e
 
 # Install envoy binary
 cd proxy
-tar -xzf envoy-3504d40f752eb5c20bc2883053547717bcb92fd8.tgz
+tar -xzf envoy-1a0363c885c2dbb1e48b03847dbd706d1ba43eba.tgz
 mv envoy ${BOSH_INSTALL_TARGET}

--- a/packages/proxy/spec
+++ b/packages/proxy/spec
@@ -4,4 +4,4 @@ name: proxy
 dependencies: []
 
 files:
-  - proxy/envoy-3504d40f752eb5c20bc2883053547717bcb92fd8.tgz
+  - proxy/envoy-1a0363c885c2dbb1e48b03847dbd706d1ba43eba.tgz


### PR DESCRIPTION
Bump envoy from [3504d40f752eb5c20bc2883053547717bcb92fd8]("https://github.com/envoyproxy/envoy/commit/3504d40f752eb5c20bc2883053547717bcb92fd8") to [3504d40f752eb5c20bc2883053547717bcb92fd8]("https://github.com/envoyproxy/envoy/commit/3504d40f752eb5c20bc2883053547717bcb92fd8")