### PR TITLE
Update contribution instructions to use consul 0.7.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,9 +87,9 @@ To be able to run unit tests, you'll also need to install the following binaries
 
     # Install consul
     if uname -a | grep Darwin; then os=darwin; else os=linux; fi
-    curl -L -o $TMPDIR/consul-0.7.0.zip "https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_${os}_amd64.zip"
-    unzip $TMPDIR/consul-0.7.0.zip -d $GOPATH/bin
-    rm $TMPDIR/consul-0.7.0.zip
+    curl -L -o $TMPDIR/consul-0.7.1.zip "https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_${os}_amd64.zip"
+    unzip $TMPDIR/consul-0.7.1.zip -d $GOPATH/bin
+    rm $TMPDIR/consul-0.7.1.zip
 
 To be able to run the integration test suite ("inigo"), you'll need to have a local [Concourse](http://concourse.ci) VM. Follow the instructions on the Concourse [README](https://github.com/concourse/concourse/blob/master/README.md) to set it up locally using [vagrant](https://www.vagrantup.com/). Download the fly CLI as instructed and move it somewhere visible to your `$PATH`.
 


### PR DESCRIPTION
Consul 0.7.0 segfaults on OSX
```
  No future change is possible.  Bailing out early after 0.010s.
  Expected
      <int>: 139
  to match exit code:
      <int>: 0

  /Users/scottschulthess/workspace/diego-release/src/code.cloudfoundry.org/consuladapter/consulrunner/clusterrunner.go:81
```
```
➜  diego-release git:(develop) ✗ consul --version
[1]    36334 segmentation fault  consul --version
```
Consul 0.7.1 works
```
➜  diego-release git:(develop) ✗ consul --version
Consul v0.7.1
```
Thank you for submitting a pull request to the diego-release repository. We appreciate the contribution. To help us with getting better context for the pull request please follow these guidelines:

## Please make sure to complete the following steps

Fixes 
* [x] Before PR Submission, Submit an issue for either an [Enhancement](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=enhancement_request.md&title=) or [Bug](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=bug_report.md&title=)
* [x] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [x] Make sure a pull request is done against the `develop` branch.

## Issue Link

#548 

Thank you!
