### PR TITLE
Bump envoy to e98e41a8e1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ jq/jq-1.6-linux64.tgz:
   size: 1710406
   object_id: 903cbcb6-fc74-4434-4efc-e8ab36ea03bd
   sha: df0513a1ed80d8522d4a04dd03817e11de03d56e
-proxy/envoy-0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c-1.16.1.tgz:
-  size: 13884450
-  object_id: ba642ebe-441a-47d2-60cb-67df53659664
-  sha: 3340dc730fca9641c4cdf456fb45cfae615bf11a
+proxy/envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz:
+  size: 13884607
+  object_id: a4dc2242-3dba-437f-7fc0-f42089a8c22c
+  sha: f4c65180d18df2ddec52465d5afeb421005ef27f
 tar/tar-1503683828.tgz:
   size: 457686
   object_id: 2bf800f2-09ae-4b3a-4d9d-896dcee551ac

--- a/packages/proxy/packaging
+++ b/packages/proxy/packaging
@@ -2,5 +2,5 @@ set -e
 
 # Install envoy binary
 cd proxy
-tar -xzf envoy-0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c-1.16.1.tgz
+tar -xzf envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz
 mv envoy ${BOSH_INSTALL_TARGET}

--- a/packages/proxy/spec
+++ b/packages/proxy/spec
@@ -4,4 +4,4 @@ name: proxy
 dependencies: []
 
 files:
-  - proxy/envoy-0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c-1.16.1.tgz
+  - proxy/envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz


### PR DESCRIPTION
Bump envoy from [0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c-1.16.1]("https://github.com/envoyproxy/envoy/commit/0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c-1.16.1") to [e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2]("https://github.com/envoyproxy/envoy/commit/e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2")