### PR TITLE
Bump envoy to c4b7ab805f

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ jq/jq-1.6-linux64.tgz:
   size: 1710406
   object_id: 903cbcb6-fc74-4434-4efc-e8ab36ea03bd
   sha: df0513a1ed80d8522d4a04dd03817e11de03d56e
-proxy/envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz:
-  size: 13884607
-  object_id: a4dc2242-3dba-437f-7fc0-f42089a8c22c
-  sha: f4c65180d18df2ddec52465d5afeb421005ef27f
+proxy/envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz:
+  size: 13886834
+  object_id: e974e697-8881-4d9b-6cf8-f3f6d76e7d76
+  sha: c08678495f541b699c32d690b23fef88885db079
 tar/tar-1503683828.tgz:
   size: 457686
   object_id: 2bf800f2-09ae-4b3a-4d9d-896dcee551ac

--- a/packages/proxy/packaging
+++ b/packages/proxy/packaging
@@ -2,5 +2,5 @@ set -e
 
 # Install envoy binary
 cd proxy
-tar -xzf envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz
+tar -xzf envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz
 mv envoy ${BOSH_INSTALL_TARGET}

--- a/packages/proxy/spec
+++ b/packages/proxy/spec
@@ -4,4 +4,4 @@ name: proxy
 dependencies: []
 
 files:
-  - proxy/envoy-e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2.tgz
+  - proxy/envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz


### PR DESCRIPTION
Bump envoy from [e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2]("https://github.com/envoyproxy/envoy/commit/e98e41a8e168af7acae8079fc0cd68155f699aa3-1.16.2") to [c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3]("https://github.com/envoyproxy/envoy/commit/c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3")