### PR TITLE
Update container_max_cpu_shares default in rep_windows from 1024 to 10000

### DIFF
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -126,7 +126,7 @@ properties:
     default: 5
   diego.executor.container_max_cpu_shares:
     description: "the maximum number of cpu shares for a container."
-    default: 1024
+    default: 10000
   diego.executor.container_inode_limit:
     description: "the inode limit enforced on each garden container."
     default: 200000


### PR DESCRIPTION
In windows, the CPU share range is: 1 to 10000

https://github.com/Microsoft/hcsshim/blob/b144c605002d4086146ca1c15c79e56bfaadc2a7/interface.go#L77

## Please make sure to complete the following steps

* [ ] Before PR Submission, Submit an issue for either an [Enhancement](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=enhancement_request.md&title=) or [Bug](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=bug_report.md&title=)
* [x] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [x] Make sure a pull request is done against the `develop` branch.

## Issue Link

> Please link the issue you created above for a bug or enhancement.

Thank you!
