### PR TITLE
add template rendering checks for ips with leading zeros for diego jobs

### DIFF
--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -1,6 +1,20 @@
 <%=
   conf_dir = "/var/vcap/jobs/auctioneer/config"
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  parse_ip(p('diego.auctioneer.debug_addr'), 'diego.auctioneer.debug_addr')
+  parse_ip(p('diego.auctioneer.listen_addr'), 'diego.auctioneer.listen_addr')
+
   config = {
     auction_runner_workers: 1000,
     communication_timeout: "10s",

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -4,6 +4,21 @@
   conf_dir = "/var/vcap/jobs/bbs/config"
   log_dir = "/var/vcap/sys/log/bbs"
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  parse_ip(p('diego.bbs.debug_addr'), 'diego.bbs.debug_addr')
+  parse_ip(p('diego.bbs.listen_addr'), 'diego.bbs.listen_addr')
+  parse_ip(p('diego.bbs.health_addr'), 'diego.bbs.health_addr')
+
   config = {
     session_name: "bbs",
     require_ssl: true,

--- a/jobs/file_server/templates/file_server.json.erb
+++ b/jobs/file_server/templates/file_server.json.erb
@@ -1,6 +1,21 @@
 <%=
   conf_dir = "/var/vcap/jobs/file_server/config"
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  parse_ip(p('diego.file_server.debug_addr'), 'diego.file_server.debug_addr')
+  parse_ip(p('diego.file_server.listen_addr'), 'diego.file_server.listen_addr')
+  parse_ip(p('https_listen_addr'), 'https_listen_addr')
+
   config = {
     server_address: p("diego.file_server.listen_addr"),
     consul_cluster: "http://127.0.0.1:8500",

--- a/jobs/locket/templates/locket.json.erb
+++ b/jobs/locket/templates/locket.json.erb
@@ -3,6 +3,20 @@ require 'uri'
 
 conf_dir = "/var/vcap/jobs/locket/config"
 
+def parse_ip (ip, var_name)
+  unless ip.empty?
+    ip = ip.split(":")[0]
+  begin
+    parsed = IPAddr.new ip
+  rescue  => e
+    raise "Invalid #{var_name} '#{ip}': #{e}"
+  end
+  end
+end
+
+parse_ip(p('diego.locket.debug_addr'), 'diego.locket.debug_addr')
+parse_ip(p('diego.locket.listen_addr'), 'diego.locket.listen_addr')
+
 config = {
   report_interval: "1m",
   ca_file: "#{conf_dir}/certs/ca.crt",

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -10,6 +10,24 @@
     zone = value
   end
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  parse_ip(p('diego.rep.debug_addr'), 'diego.rep.debug_addr')
+  parse_ip(p('diego.rep.listen_addr_admin'), 'diego.rep.listen_addr_admin')
+  parse_ip(p('diego.rep.listen_addr_securable'), 'diego.rep.listen_addr_securable')
+  if p("diego.executor.garden.network") == "tcp"
+    parse_ip(p('diego.executor.garden.address'), 'diego.executor.garden.address')
+  end
+
   config = {
     communication_timeout: p("diego.rep.bbs.request_timeout"),
     lock_retry_interval: "5s",

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -10,6 +10,24 @@
     zone = value
   end
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  parse_ip(p('diego.rep.debug_addr'), 'diego.rep.debug_addr')
+  parse_ip(p('diego.rep.listen_addr_admin'), 'diego.rep.listen_addr_admin')
+  parse_ip(p('diego.rep.listen_addr_securable'), 'diego.rep.listen_addr_securable')
+  if p("diego.executor.garden.network") == "tcp"
+    parse_ip(p('diego.executor.garden.address'), 'diego.executor.garden.address')
+  end
+
   config = {
     communication_timeout: p("diego.rep.bbs.request_timeout"),
     lock_retry_interval: "5s",

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -1,6 +1,20 @@
 <%=
   conf_dir = "/var/vcap/jobs/#{p("diego.route_emitter.job_name")}/config"
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+    begin
+      parsed = IPAddr.new ip
+    rescue  => e
+      raise "Invalid #{var_name} '#{ip}': #{e}"
+    end
+    end
+  end
+
+  parse_ip(p('diego.route_emitter.debug_addr'), 'diego.route_emitter.debug_addr')
+  parse_ip(p('diego.route_emitter.healthcheck_addr'), 'diego.route_emitter.healthcheck_addr')
+
   nats_machines = nil
   if_p('diego.route_emitter.nats.machines') do |ips|
     nats_machines = ips.compact

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -1,6 +1,20 @@
 <%=
   conf_dir = "/var/vcap/jobs/#{p("diego.route_emitter.job_name")}/config"
 
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+    begin
+      parsed = IPAddr.new ip
+    rescue  => e
+      raise "Invalid #{var_name} '#{ip}': #{e}"
+    end
+    end
+  end
+
+  parse_ip(p('diego.route_emitter.debug_addr'), 'diego.route_emitter.debug_addr')
+  parse_ip(p('diego.route_emitter.healthcheck_addr'), 'diego.route_emitter.healthcheck_addr')
+
   nats_machines = nil
   if_p('diego.route_emitter.nats.machines') do |ips|
     nats_machines = ips.compact

--- a/jobs/ssh_proxy/templates/ssh_proxy.json.erb
+++ b/jobs/ssh_proxy/templates/ssh_proxy.json.erb
@@ -1,4 +1,20 @@
 <%=
+
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+    begin
+      parsed = IPAddr.new ip
+    rescue  => e
+      raise "Invalid #{var_name} '#{ip}': #{e}"
+    end
+    end
+  end
+
+  parse_ip(p('diego.ssh_proxy.debug_addr'), 'diego.ssh_proxy.debug_addr')
+  parse_ip(p('diego.ssh_proxy.healthcheck_listen_addr'), 'diego.ssh_proxy.healthcheck_listen_addr')
+  parse_ip(p('diego.ssh_proxy.listen_addr'), 'diego.ssh_proxy.listen_addr')
+
   config = {
     address: p("diego.ssh_proxy.listen_addr"),
     health_check_address: p("diego.ssh_proxy.healthcheck_listen_addr"),


### PR DESCRIPTION
Guards against operators specifying IP addresses that now fail to parse after diego components have been compiled with go 1.17.