### PR TITLE
Deprecate start and evacuate_running endpoints

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -153,6 +153,8 @@ The [BBS API docs](https://github.com/cloudfoundry/bbs/tree/master/doc) and [rou
 | `/v1/actual_lrp_groups/list`                          | v2.31.0    | N/A     | Use `/v1/actual_lrps/list` instead. Will be removed in v4.0.0        |
 | `/v1/actual_lrp_groups/list_by_process_guid`          | v2.31.0    | N/A     | Use `/v1/actual_lrps/list` instead. Will be removed in v4.0.0        |
 | `/v1/actual_lrp_groups/get_by_process_guid_and_index` | v2.31.0    | N/A     | Use `/v1/actual_lrps/list` instead. Will be removed in v4.0.0        |
+| `/v1/actual_lrps/start`                               | v2.59.0    | N/A     | Use `/v1/actual_lrps/start.r1` instead.                              |
+| `/v1/actual_lrps/evacuate_running`                    | v2.59.0    | N/A     | Use `/v1/actual_lrps/evacuate_running.r1` instead.                   |
 
 #### Fields
 


### PR DESCRIPTION
They have been superceded by the `.r1` versions

Thank you for submitting a pull request to the diego-release repository. We appreciate the contribution. To help us with getting better context for the pull request please follow these guidelines:

## Please make sure to complete the following steps

* [x] Before PR Submission, Submit an issue for either an [Enhancement](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=enhancement_request.md&title=) or [Bug](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=bug_report.md&title=)
* [x] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [x] Make sure a pull request is done against the `develop` branch.

## Issue Link

https://github.com/cloudfoundry/diego-release/issues/588
https://github.com/cloudfoundry/diego-release/issues/587

Thank you!
