### PR TITLE
Add locket client keepalive time and timeout to jobs

### DIFF
--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -93,7 +93,7 @@ properties:
     default: 10
   diego.auctioneer.locket.client_keepalive_timeout: 
     description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
-    default: 10
+    default: 20
     
   locks.locket.enabled:
     description: When set, the auctioneer attempts to claim a lock from the Locket API.

--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -88,7 +88,13 @@ properties:
   diego.auctioneer.locket.api_location:
     description: "Hostname and port of the Locket server. When set, the auctioneer attempts to claim a lock from the Locket API."
     default: locket.service.cf.internal:8891
-
+  diego.auctioneer.locket.client_keepalive_time: 
+    description: "Period in seconds after which the locket gRPC client sends keepalive ping requests to the locket server it is connected to."
+    default: 10
+  diego.auctioneer.locket.client_keepalive_timeout: 
+    description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
+    default: 10
+    
   locks.locket.enabled:
     description: When set, the auctioneer attempts to claim a lock from the Locket API.
     default: true

--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -73,6 +73,14 @@
     config[:locket_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
   end
 
+  if_p("diego.auctioneer.locket.client_keepalive_time") do |value|
+    config[:locket_client_keepalive_time] = value
+  end
+
+  if_p("diego.auctioneer.locket.client_keepalive_timeout") do |value|
+    config[:locket_client_keepalive_timeout] = value
+  end
+
   config[:loggregator]={}
   config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
   if p("loggregator.use_v2_api") == true

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -145,7 +145,7 @@ properties:
     default: 10
   diego.bbs.locket.client_keepalive_timeout: 
     description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
-    default: 10
+    default: 20
     
   limits.open_files:
     description: Maximum number of files (including sockets) the BBS process may have open.

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -140,7 +140,13 @@ properties:
   diego.bbs.locket.api_location:
     description: "Hostname and port of the Locket server. When set, the BBS attempts to claim a lock from the Locket API and will detect Diego cells registered with the Locket API."
     default: locket.service.cf.internal:8891
-
+  diego.bbs.locket.client_keepalive_time: 
+    description: "Period in seconds after which the locket gRPC client sends keepalive ping requests to the locket server it is connected to."
+    default: 10
+  diego.bbs.locket.client_keepalive_timeout: 
+    description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
+    default: 10
+    
   limits.open_files:
     description: Maximum number of files (including sockets) the BBS process may have open.
     default: 100000

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -168,6 +168,14 @@
     config[:locket_client_key_file] = "#{conf_dir}/certs/server.key"
   end
 
+  if_p("diego.bbs.locket.client_keepalive_time") do |value|
+    config[:locket_client_keepalive_time] = value
+  end
+
+  if_p("diego.bbs.locket.client_keepalive_timeout") do |value|
+    config[:locket_client_keepalive_timeout] = value
+  end
+
   config[:loggregator]={}
   config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
   if p("loggregator.use_v2_api") == true

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -222,7 +222,7 @@ properties:
     default: 10
   diego.rep.locket.client_keepalive_timeout: 
     description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
-    default: 10
+    default: 20
     
   enable_declarative_healthcheck:
     description: "When set, enables the rep to prefer the LRP CheckDefinition to healthcheck instances over the Monitor action. Requires Garden-Runc v1.10.0+"

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -217,7 +217,13 @@ properties:
   diego.rep.locket.api_location:
     description: "Hostname and port of the Locket server. When set, the cell rep will establish its cell registration in the Locket API."
     default: locket.service.cf.internal:8891
-
+  diego.rep.locket.client_keepalive_time: 
+    description: "Period in seconds after which the locket gRPC client sends keepalive ping requests to the locket server it is connected to."
+    default: 10
+  diego.rep.locket.client_keepalive_timeout: 
+    description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
+    default: 10
+    
   enable_declarative_healthcheck:
     description: "When set, enables the rep to prefer the LRP CheckDefinition to healthcheck instances over the Monitor action. Requires Garden-Runc v1.10.0+"
     default: false

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -157,6 +157,14 @@
     config[:locket_address] = value
   end
 
+  if_p("diego.rep.locket.client_keepalive_time") do |value|
+    config[:locket_client_keepalive_time] = value
+  end
+
+  if_p("diego.rep.locket.client_keepalive_timeout") do |value|
+    config[:locket_client_keepalive_timeout] = value
+  end
+
   config[:locket_ca_cert_file]     = "#{conf_dir}/certs/tls_ca.crt"
   config[:locket_client_cert_file] = "#{conf_dir}/certs/tls.crt"
   config[:locket_client_key_file]  = "#{conf_dir}/certs/tls.key"

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -232,7 +232,7 @@ properties:
     default: 10
   diego.rep.locket.client_keepalive_timeout: 
     description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
-    default: 10
+    default: 20
     
   enable_declarative_healthcheck:
     description: "When set, enables the rep to prefer the LRP CheckDefinition to healthcheck instances over the Monitor action."

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -227,7 +227,13 @@ properties:
   diego.rep.locket.api_location:
     description: "Hostname and port of the locket server"
     default: locket.service.cf.internal:8891
-
+  diego.rep.locket.client_keepalive_time: 
+    description: "Period in seconds after which the locket gRPC client sends keepalive ping requests to the locket server it is connected to."
+    default: 10
+  diego.rep.locket.client_keepalive_timeout: 
+    description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
+    default: 10
+    
   enable_declarative_healthcheck:
     description: "When set, enables the rep to prefer the LRP CheckDefinition to healthcheck instances over the Monitor action."
     default: false

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -157,6 +157,14 @@
     config[:locket_address] = value
   end
 
+  if_p("diego.rep.locket.client_keepalive_time") do |value|
+    config[:locket_client_keepalive_time] = value
+  end
+
+  if_p("diego.rep.locket.client_keepalive_timeout") do |value|
+    config[:locket_client_keepalive_timeout] = value
+  end
+
   config[:locket_ca_cert_file]     = "#{conf_dir}/certs/tls_ca.crt"
   config[:locket_client_cert_file] = "#{conf_dir}/certs/tls.crt"
   config[:locket_client_key_file]  = "#{conf_dir}/certs/tls.key"


### PR DESCRIPTION
As discussed in this issue https://github.com/cloudfoundry/diego-release/issues/627, with this PR we add a keepalive timeout to the locket client, which will improve its performance. The "Time" property of the gRPC client is also added to the locket client config, so operators can configure both of them depending on their needs. Here is the PR in the locket repo:  https://github.com/cloudfoundry/locket/pull/12
