### PR TITLE
remove exclusive xargs options appearing in the logs

### DIFF
--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -12,7 +12,7 @@ if mount | grep -q $old_instance_identity_dir; then
 fi
 
 old_shared_data_dir=${old_data_dir}/shared_data
-mount | grep $old_shared_data_dir | cut -d' ' -f3 | awk -F"/" '{print NF " " $0}' | sort -n -r | cut -d ' ' -f 2 | xargs -n1 -I {} umount -f {}
+mount | grep $old_shared_data_dir | cut -d' ' -f3 | awk -F"/" '{print NF " " $0}' | sort -n -r | cut -d ' ' -f 2 | xargs -I {} umount -f {}
 
 rm -rf "${old_instance_identity_dir}"
 rm -rf "${old_data_dir}/trusted_certs"


### PR DESCRIPTION
This patch intend to fix the warning appearing in rep.stderr.log:
> xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value

As per [xargs(1p)](https://man7.org/linux/man-pages/man1/xargs.1p.html): The -I, -L, and -n options are mutually-exclusive.

Thank you for submitting a pull request to the diego-release repository. We appreciate the contribution. To help us with getting better context for the pull request please follow these guidelines:

## Please make sure to complete the following steps

* [x] Before PR Submission, Submit an issue for either an [Enhancement](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=enhancement_request.md&title=) or [Bug](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=bug_report.md&title=)
* [x] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [x] Make sure a pull request is done against the `develop` branch.

## Issue Link

#688