### PR TITLE
Add buildpackapplifecycle to windows unit tests

### DIFF
--- a/scripts/ci/run_unit_windows.ps1
+++ b/scripts/ci/run_unit_windows.ps1
@@ -55,7 +55,8 @@ go run github.com/onsi/ginkgo/ginkgo -r -keepGoing -trace -randomizeAllSpecs -pr
   operationq `
   rep `
   routing-info `
-  workpool
+  workpool `
+  buildpackapplifecycle
 
 if ($LastExitCode -ne 0) {
   Write-Host "Diego unit tests failed"


### PR DESCRIPTION
Signed-off-by: David Sabeti <sabetid@vmware.com>

Depends on first merging https://github.com/cloudfoundry/buildpackapplifecycle/pull/55 and bumping that submodule in Diego release
