### PR TITLE
Bug: Updating the grace file location to match current GCP bucket

### DIFF
--- a/jobs/vizzini/spec
+++ b/jobs/vizzini/spec
@@ -80,7 +80,7 @@ properties:
 
   grace_tarball_url:
     description: "URL for the grace test asset"
-    default: "https://storage.googleapis.com/diego-assets-bucket/grace.tar.gz"
+    default: "https://storage.googleapis.com/diego-assets/grace.tar.gz"
 
   grace_tarball_checksum:
     description: "grace test asset sha1 checksum"


### PR DESCRIPTION
Updating the location of the grace_tarball file to reflect to new bucket that is being used.


Co-written with @mariash 