### PR TITLE
Remove systemcerts from sync-submodule-config

### DIFF
--- a/scripts/sync-submodule-config
+++ b/scripts/sync-submodule-config
@@ -34,7 +34,6 @@ code.cloudfoundry.org/rep
 code.cloudfoundry.org/route-emitter
 code.cloudfoundry.org/routing-api
 code.cloudfoundry.org/routing-info
-code.cloudfoundry.org/systemcerts
 code.cloudfoundry.org/vendor
 code.cloudfoundry.org/vizzini
 code.cloudfoundry.org/volman


### PR DESCRIPTION
This is a follow up to: https://github.com/cloudfoundry/diego-release/pull/808

We don't need to sync code.cloudfoundry.org/systemcerts anymore because we removed it.

Fixes:
```
+ ./scripts/sync-submodule-config
+ export PATH=/tmp/build/a22dd28d/diego-release/bin:/root/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/build/a22dd28d/diego-release/bin
+ PATH=/tmp/build/a22dd28d/diego-release/bin:/root/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/build/a22dd28d/diego-release/bin
+ mkdir -p bin
+ cd src/gosub
+ go build -o ../../bin/gosub .
+ FORCE_SUBMODULE_HTTPS=true
+ rm -rf /tmp/packages
+ cat
+ cat /tmp/packages
+ xargs -s 1048576 gosub sync --force-https=true
failed to get dependency repo: chdir /tmp/build/a22dd28d/diego-release/src/code.cloudfoundry.org/systemcerts: no such file or directory
```

[#184870112](https://www.pivotaltracker.com/story/show/184870112)