### PR TITLE
Update packaging to accommodate the auto-bumping of golang packages

### DIFF
--- a/packages/auctioneer/packaging
+++ b/packages/auctioneer/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 export GOBIN=${BOSH_INSTALL_TARGET}/bin

--- a/packages/bbs/packaging
+++ b/packages/bbs/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 export GOBIN=${BOSH_INSTALL_TARGET}/bin

--- a/packages/buildpack_app_lifecycle/packaging
+++ b/packages/buildpack_app_lifecycle/packaging
@@ -8,7 +8,7 @@ mv ${BOSH_INSTALL_TARGET}/src .
 DEST="$PWD/bin"
 mkdir -p ${DEST}
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 pushd src/code.cloudfoundry.org
 

--- a/packages/certsplitter/packaging
+++ b/packages/certsplitter/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 export GOBIN=${BOSH_INSTALL_TARGET}/bin

--- a/packages/cfdot/packaging
+++ b/packages/cfdot/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 export GOBIN=${BOSH_INSTALL_TARGET}/bin

--- a/packages/diego-sshd/packaging
+++ b/packages/diego-sshd/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 pushd src/code.cloudfoundry.org
 CGO_ENABLED=0 go build -o ${BOSH_INSTALL_TARGET}/diego-sshd -a -installsuffix static code.cloudfoundry.org/diego-ssh/cmd/sshd

--- a/packages/docker_app_lifecycle/packaging
+++ b/packages/docker_app_lifecycle/packaging
@@ -8,7 +8,7 @@ mv ${BOSH_INSTALL_TARGET}/src .
 DEST="$PWD/bin"
 mkdir -p ${DEST}
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 pushd src/code.cloudfoundry.org
 CGO_ENABLED=0 go build -o ${DEST}/builder  -a -installsuffix static code.cloudfoundry.org/dockerapplifecycle/builder

--- a/packages/file_server/packaging
+++ b/packages/file_server/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src/code.cloudfoundry.org

--- a/packages/healthcheck/packaging
+++ b/packages/healthcheck/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 pushd src/code.cloudfoundry.org
 CGO_ENABLED=0 go build -o ${BOSH_INSTALL_TARGET}/healthcheck -a -installsuffix static code.cloudfoundry.org/healthcheck/cmd/healthcheck

--- a/packages/locket/packaging
+++ b/packages/locket/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src/code.cloudfoundry.org

--- a/packages/rep/packaging
+++ b/packages/rep/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src/code.cloudfoundry.org

--- a/packages/route_emitter/packaging
+++ b/packages/route_emitter/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src/code.cloudfoundry.org

--- a/packages/ssh_proxy/packaging
+++ b/packages/ssh_proxy/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src/code.cloudfoundry.org

--- a/packages/vizzini/packaging
+++ b/packages/vizzini/packaging
@@ -4,7 +4,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 cp -a . ${BOSH_INSTALL_TARGET}/src
 
 pushd "${BOSH_INSTALL_TARGET}"
-  source /var/vcap/packages/golang-1-linux/bosh/compile.env
+  source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
   pushd src/code.cloudfoundry.org
       go install github.com/onsi/ginkgo/v2/ginkgo

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -8,7 +8,7 @@ mv ${BOSH_INSTALL_TARGET}/src .
 DEST="$PWD/bin"
 mkdir -p ${DEST}
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 
 pushd src/code.cloudfoundry.org
 GOOS=windows CGO_ENABLED=0 go build -o ${DEST}/builder.exe -tags=windows2012R2 -a -installsuffix static code.cloudfoundry.org/buildpackapplifecycle/builder


### PR DESCRIPTION
The golang packages are now being autobumped and we can no longer count on the path for the package to be consistent. By modifying the path to use a wildcard we can match all possible version of the go lang package for now.