### PR TITLE
Address issue with windows packages for autobumping go

### DIFF
--- a/packages/certsplitter_windows/packaging
+++ b/packages/certsplitter_windows/packaging
@@ -13,7 +13,7 @@ if ($LASTEXITCODE -ge 8) {
     Write-Error "robocopy.exe /E ${PWD} src /xd src"
 }
 
-. C:\var\vcap\packages\golang-1-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-*-windows\bosh\compile.ps1
 
 $pkg_name="certsplitter"
 $pkg_path="code.cloudfoundry.org/certsplitter/cmd/certsplitter"

--- a/packages/healthcheck_windows/packaging
+++ b/packages/healthcheck_windows/packaging
@@ -13,7 +13,7 @@ if ($LASTEXITCODE -ge 8) {
     Write-Error "robocopy.exe /E ${PWD} src /xd src"
 }
 
-. C:\var\vcap\packages\golang-1-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-*-windows\bosh\compile.ps1
 
 $pkg_name="healthcheck"
 $pkg_path="code.cloudfoundry.org/healthcheck/cmd/healthcheck"

--- a/packages/rep_windows/packaging
+++ b/packages/rep_windows/packaging
@@ -13,7 +13,7 @@ if ($LASTEXITCODE -ge 8) {
     Write-Error "robocopy.exe /E ${PWD} src /xd src"
 }
 
-. C:\var\vcap\packages\golang-1-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-*-windows\bosh\compile.ps1
 
 $rep_pkg_path="code.cloudfoundry.org/rep/cmd/rep"
 $gocurl_pkg_path="code.cloudfoundry.org/rep/cmd/gocurl"

--- a/packages/route_emitter_windows/packaging
+++ b/packages/route_emitter_windows/packaging
@@ -13,7 +13,7 @@ if ($LASTEXITCODE -ge 8) {
     Write-Error "robocopy.exe /E ${PWD} src /xd src"
 }
 
-. C:\var\vcap\packages\golang-1-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-*-windows\bosh\compile.ps1
 
 $pkg_name="route-emitter"
 $pkg_path="code.cloudfoundry.org/route-emitter/cmd/route-emitter"


### PR DESCRIPTION
The windows packages were using a direct path to the golang packages. With the autobumping of golang packages now part of the diego processes, having a static location for the compilation scripts was not working. 