### PR TITLE
Update vizzini to handled go autobumping

### DIFF
--- a/jobs/vizzini/templates/run.erb
+++ b/jobs/vizzini/templates/run.erb
@@ -5,7 +5,7 @@ log_dir=/var/vcap/sys/log/vizzini
 set -e -x
 
 cd /var/vcap/packages/vizzini
-source /var/vcap/packages/golang-1-linux/bosh/runtime.env
+source /var/vcap/packages/golang-*-linux/bosh/runtime.env
 
 export CF_COLOR=false
 


### PR DESCRIPTION
Vizzini scripts were not updated to handle the autobumping of go.  