### PR TITLE
Remove go.version, no longer updated

### DIFF
--- a/docs/go.version
+++ b/docs/go.version
@@ -1,2 +1,0 @@
-This file was updated by CI on 2023-10-10 17:41:27
-go1.21.3


### PR DESCRIPTION
This file is no longer updated, no need to have a confusion