### PR TITLE
Bump jq to 1.7

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-jq/jq-1.6-linux64.tgz:
-  size: 1710406
-  object_id: 903cbcb6-fc74-4434-4efc-e8ab36ea03bd
-  sha: df0513a1ed80d8522d4a04dd03817e11de03d56e
+jq/jq-1.7-linux-amd64.tgz:
+  size: 992924
+  object_id: b37343a2-e1ac-4aa4-5843-e63b730f90c6
+  sha: sha256:6c640db360b3a989a4a5f49dfb38128b9f11726da2f8295455e67917e1aa2e32
 proxy/envoy-7b2609e12147377b0420bfa4453762e377f218f3-1.25.9.tgz:
   size: 89106955
   object_id: 0577b82c-c88f-4a48-6cf6-e4e7c6605d01

--- a/packages/cfdot/spec
+++ b/packages/cfdot/spec
@@ -5,10 +5,10 @@ dependencies:
   - golang-1.21-linux
 
 files:
+  - jq/jq-1.7-linux-amd64.tgz
   - code.cloudfoundry.org/go.mod
   - code.cloudfoundry.org/go.sum
   - code.cloudfoundry.org/vendor/modules.txt
-  - jq/jq-1.6-linux64.tgz
   - code.cloudfoundry.org/bbs/*.go # gosub
   - code.cloudfoundry.org/bbs/encryption/*.go # gosub
   - code.cloudfoundry.org/bbs/events/*.go # gosub


### PR DESCRIPTION
Bump the included `jq` binary in the `cfdot` package to version `1.7`.

jq release notes: https://github.com/jqlang/jq/releases/tag/jq-1.7

[#186151598](https://www.pivotaltracker.com/story/show/186151598)

