### PR TITLE
Revert "[REP] Make max_containers configurable (#868)"

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -30,11 +30,6 @@ packages:
   - proxy
   - certsplitter
 
-consumes:
-- name: max_containers
-  type: max_containers
-  optional: true
-
 properties:
   bpm.enabled:
     description: "use the BOSH Process Manager to manage the cell rep process."

--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -24,18 +24,7 @@ rm -rf "${old_shared_data_dir}"
 # add another 4096 to account for the temp files used to do atomic replacement #141163257
 instance_cert_and_key_size=10240
 instance_ca_size=$(wc -c ${conf_dir}/certs/rep/instance_identity.crt | cut -d' ' -f1)
-
-<%
-  _max_containers = 250
-  if_link("max_containers") do |max_containers_link|
-    _max_containers = max_containers_link.p('garden.max_containers')
-  end
-  if _max_containers.nil?
-    _max_containers = 250
-  end
-%>
-max_containers=<%= _max_containers %>
-
+max_containers=250
 instance_tmpfs_size=$((($instance_ca_size + $instance_cert_and_key_size) * $max_containers))
 
 instance_identity_dir=${garden_shared_dir}/instance_identity

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -79,28 +79,4 @@ describe 'rep' do
       end
     end
   end
-
-  describe 'setup_mounted_data_dirs.erb' do
-    let(:template) { job.template('bin/setup_mounted_data_dirs') }
-    let(:properties) {{}}
-  
-    context('checks if the proper value from the bosh link is set') do
-      let(:max_containers_link) do
-        Bosh::Template::Test::Link.new(
-          name: 'max_containers',
-          instances: [Bosh::Template::Test::LinkInstance.new()],
-          properties: {
-            'garden' => {
-              "max_containers"=> 300
-            }
-          }
-        )
-      end
-
-      let(:rendered_template) { template.render(properties, consumes: [max_containers_link]) }
-      it('confirms that max_containers is set correctly') do
-        expect(rendered_template).to include("max_containers=300")
-      end
-    end
-  end  
 end


### PR DESCRIPTION
This reverts commit 01c3536ae2285dc60f7542c9b3c956dfa9554057.

Reverting this change to [address issues with cf-deployment](https://cloudfoundry.slack.com/archives/C02FM2BPE/p1702069406637829)

Further notes will be within https://github.com/cloudfoundry/diego-release/issues/867