### PR TITLE
Check BBS port is available

### DIFF
--- a/jobs/bbs/templates/post-start.erb
+++ b/jobs/bbs/templates/post-start.erb
@@ -2,18 +2,27 @@
 
 log_dir=/var/vcap/sys/log/bbs
 
-address=<%= p("diego.bbs.health_addr") %>
+health_address=<%= p("diego.bbs.health_addr") %>
+listen_address=<%= p("diego.bbs.health_addr") %>
+bbs_port=$(echo ${listen_address} | cut -d":" -f2)
 start=`date +%s`
 i=0
 
 # wait up to 25 seconds
 while [ $(( $(date +%s) - 25 )) -lt $start ]; do
   i=$((i + 1))
-  if curl --fail --silent http://$address/ping 1>/dev/null 2>&1
+  if curl --fail --silent http://${health_address}/ping 1>/dev/null 2>&1
   then
-    exit 0
+    # validate BBS port is reserved for BBS
+    command=$(lsof -n -i :${bbs_port} -sTCP:LISTEN |awk 'NR > 1 {print $1}')
+    if [ "${command}" = "bbs" ] || [ -z "${command}" ]
+    then
+      exit 0
+    fi
+    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): Another command is listening on BBS port: ${command}"
+    exit 1
   fi
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): Failed 'curl --fail --silent http://$address/ping' on attempt $i"
+  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): Failed 'curl --fail --silent http://${health_address}/ping' on attempt $i"
   sleep 1
 done
 


### PR DESCRIPTION
BBS only starts listening on a port when it acquires the lock. During rolling deploy BBS instances get restarted and fail to acquire lock. In case if other process claims the port operators don't get feedback that BBS fails to start until all BBS instances are rolled. This results in the deployment without any working BBS instances. We want to get faster feedback and fail on the first BBS instance if another bosh job claims BBS port. 

We explored an option of listening on port and returning 503s but HTTP clients treat 503s differently from connection refused errors. When getting connection refused HTTP clients go down BOSH dns list for (bbs.service.cf.internal) and try different BBS instance thus finding the one that has active lock. With 503s they just returning that as a response.

In this solution, BBS post-start script validates that either BBS is listening on this port or no one is listening on it.