### PR TITLE
Check diego port from diego listen address

### DIFF
--- a/jobs/bbs/templates/post-start.erb
+++ b/jobs/bbs/templates/post-start.erb
@@ -3,7 +3,7 @@
 log_dir=/var/vcap/sys/log/bbs
 
 health_address=<%= p("diego.bbs.health_addr") %>
-listen_address=<%= p("diego.bbs.health_addr") %>
+listen_address=<%= p("diego.bbs.listen_addr") %>
 bbs_port=$(echo ${listen_address} | cut -d":" -f2)
 start=`date +%s`
 i=0


### PR DESCRIPTION
This change is a follow up fix for https://github.com/cloudfoundry/diego-release/pull/878 

We want to validate listen address and not health address when checking bbs port. Health address will always be up no matter if BBS holds the lock or not.