### PR TITLE
Add jitterFactor default value 

### DIFF
--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -93,6 +93,10 @@ properties:
   diego.route_emitter.bbs.max_idle_conns_per_host:
     description: "maximum number of idle http connections"
 
+  diego.route_emitter.jitter_factor:
+    description: "The jitter factor is the percentage of register interval used in determining the jitter interval (the time for which the emitter sleeps)"
+    default: 0.2
+
   diego.route_emitter.job_name:
     description: "The name of the Diego job referenced by this spec (DO NOT override)"
     default: "route_emitter"

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -90,6 +90,13 @@
     unregistration_send_count: 20,
   }
 
+  if_p("diego.route_emitter.jitter_factor") do |value|
+    if !value.instance_of?(Float) or value < 0.0 or value > 1.0
+      raise "diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0"
+    end
+    config[:jitter_factor] = value
+  end
+
   if_p("logging.format.timestamp") do |format|
     if format != "unix-epoch" and format != "rfc3339"
       raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"

--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -83,6 +83,10 @@ properties:
   diego.route_emitter.bbs.max_idle_conns_per_host:
     description: "maximum number of idle http connections"
 
+  diego.route_emitter.jitter_factor:
+    description: "The jitter factor is the percentage of register interval used in determining the jitter interval (the time for which the emitter sleeps)"
+    default: 0.2
+
   diego.route_emitter.job_name:
     description: "The name of the Diego job referenced by this spec (DO NOT override)"
     default: "route_emitter_windows"

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -89,6 +89,13 @@
     unregistration_send_count: 20,
   }
 
+  if_p("diego.route_emitter.jitter_factor") do |value|
+    if !value.instance_of?(Float) or value < 0.0 or value > 1.0
+      raise "diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0"
+    end
+    config[:jitter_factor] = value
+  end
+
   if_p("logging.format.timestamp") do |format|
     if format != "unix-epoch" and format != "rfc3339"
       raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"

--- a/spec/route_emitter_template_spec.rb
+++ b/spec/route_emitter_template_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# rubocop: disable Metrics/BlockLength
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+
+describe 'route_emitter' do
+  let(:release_path) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
+  let(:job) { release.job('route_emitter') }
+
+  describe 'route_emitter.json.erb' do
+    let(:deployment_manifest_fragment) do
+      {
+        'bpm' => {
+          'enabled' => 'true'
+        },
+        'diego' => {
+          'route_emitter' => {
+            'bbs' => {
+              'ca_cert' => 'CA CERTS',
+              'client_cert' => 'CLIENT CERT',
+              'client_key' => 'CLIENT KEY'
+            },
+            'nats' => {
+              'ca_cert' => 'CA CERTS',
+              'client_cert' => 'CLIENT CERT',
+              'client_key' => 'CLIENT KEY',
+              'machines' => {
+                'nats_addresses' => '1.2.3.4'
+              }
+            },
+          }
+        },
+        'enable_consul_service_registration' => 'false',
+        'loggregator' => 'LOGGREGATOR PROPS',
+        'logging' => {
+          'format' => {
+            'timestamp' => 'rfc3339'
+          }
+        }
+      }
+    end
+
+    let(:template) { job.template('config/route_emitter.json') }
+    let(:rendered_template) { template.render(deployment_manifest_fragment) }
+
+    context 'Check jitter_factor default value' do
+      it 'Defaults to 0.2 if no value is provided' do
+        json_data = JSON.parse(rendered_template)
+        jitter_value = json_data['jitter_factor']
+        expect(jitter_value).to eq(0.2)
+      end
+    end
+
+    context 'Check if jitter_factor value is less than 1.0' do
+      it 'fails if jitter_factor value is greater than 1.0' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = 1.1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+
+    context 'Check if jitter_factor value is greater than 0.0' do
+      it 'fails if jitter_factor value is less than 0.0' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = -0.1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+
+    context 'Check if jitter_factor value type is Float' do
+      it 'fails if jitter_factor value type is not Float' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = 1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+  end
+end

--- a/spec/route_emitter_windows_template_spec.rb
+++ b/spec/route_emitter_windows_template_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# frozen_string_literal: true
+
+# rubocop: disable Metrics/BlockLength
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+
+describe 'route_emitter' do
+  let(:release_path) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
+  let(:job) { release.job('route_emitter_windows') }
+
+  describe 'route_emitter.json.erb' do
+    let(:deployment_manifest_fragment) do
+      {
+        'bpm' => {
+          'enabled' => 'true'
+        },
+        'diego' => {
+          'route_emitter' => {
+            'bbs' => {
+              'ca_cert' => 'CA CERTS',
+              'client_cert' => 'CLIENT CERT',
+              'client_key' => 'CLIENT KEY'
+            },
+            'nats' => {
+              'ca_cert' => 'CA CERTS',
+              'client_cert' => 'CLIENT CERT',
+              'client_key' => 'CLIENT KEY',
+              'machines' => {
+                'nats_addresses' => '1.2.3.4'
+              }
+            }
+          }
+        },
+        'enable_consul_service_registration' => 'false',
+        'loggregator' => 'LOGGREGATOR PROPS',
+        'logging' => {
+          'format' => {
+            'timestamp' => 'rfc3339'
+          }
+        }
+      }
+    end
+
+    let(:template) { job.template('config/route_emitter.json') }
+    let(:rendered_template) { template.render(deployment_manifest_fragment) }
+
+    context 'Check jitter_factor default value' do
+      it 'Defaults to 0.2 if no value is provided' do
+        json_data = JSON.parse(rendered_template)
+        jitter_value = json_data['jitter_factor']
+        expect(jitter_value).to eq(0.2)
+      end
+    end
+
+    context 'Check if jitter_factor value is less than 1.0' do
+      it 'fails if jitter_factor value is greater than 1.0' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = 1.1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+
+    context 'Check if jitter_factor value is greater than 0.0' do
+      it 'fails if jitter_factor value is less than 0.0' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = -0.1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+
+    context 'Check if jitter_factor value type is Float' do
+      it 'fails if jitter_factor value type is not Float' do
+        deployment_manifest_fragment['diego']['route_emitter']['jitter_factor'] = 1
+        expect do
+          rendered_template
+        end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add default value to new `jitterFactor` parameter in route-emitter, introduced and defined in this PR: https://github.com/cloudfoundry/route-emitter/pull/31
The default value is set to original 0.2. 