### PR TITLE
Use major/minor version only

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org
 
-go 1.21.6
+go 1.21
 
 replace (
 	code.cloudfoundry.org/garden => ../garden


### PR DESCRIPTION
This is causing windows test to fail when version of go is a different version of patch