### PR TITLE
Exclude cpu entitlement metric by default

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -81,7 +81,8 @@ properties:
     description: "Key used to communicate with local metron agent over gRPC"
   loggregator.app_metric_exclusion_filter:
     description: "Array of application metrics to not emit"
-    default: []
+    default:
+    - cpu_entitlement
 
   diego.rep.listen_addr_admin:
     description: "serve (insecure) ping and evacuate requests on this address and port"

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -75,6 +75,10 @@ properties:
     description: "Cert used to communicate with local metron agent over gRPC"
   loggregator.key:
     description: "Key used to communicate with local metron agent over gRPC"
+  loggregator.app_metric_exclusion_filter:
+    description: "Array of application metrics to not emit"
+    default:
+    - cpu_entitlement
 
   diego.rep.advertise_domain:
     description: "base domain at which the rep should advertise its secure API"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -228,7 +228,7 @@
 
   config[:loggregator]={}
   config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
-  if p("loggregator.use_v2_api") == true
+  if p("loggregator.use_v2_api")
     config[:loggregator][:loggregator_api_port] = p("loggregator.v2_api_port")
     config[:loggregator][:loggregator_ca_path] = "#{conf_dir}/certs/loggregator/ca.crt"
     config[:loggregator][:loggregator_cert_path] = "#{conf_dir}/certs/loggregator/client.crt"
@@ -240,6 +240,7 @@
     config[:loggregator][:loggregator_job_origin] = "rep"
     config[:loggregator][:loggregator_source_id] = "rep"
     config[:loggregator][:loggregator_instance_id] = spec.id
+    config[:loggregator][:loggregator_app_metric_exclusion_filter] = p("loggregator.app_metric_exclusion_filter")
   end
 
   config.to_json

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -80,6 +80,12 @@ describe 'rep' do
         end.to raise_error(/The locket client keepalive time property should not be larger than the timeout/)
       end
     end
+
+    it 'excludes the newer cpu_entitlement metric by default for backwards compatibility' do
+      deployment_manifest_fragment['loggregator']['use_v2_api'] = true
+      expect(JSON.parse(rendered_template)['loggregator']['loggregator_app_metric_exclusion_filter']).to eq(%w[cpu_entitlement])
+    end
+
     context 'when specific app metrics are configured to be excluded' do
       it 'configures the rep to exclude them' do
         deployment_manifest_fragment['loggregator']['use_v2_api'] = true


### PR DESCRIPTION
* Exclude the `cpu_entitlement` metric from being emitted by default for backwards compatibility.
* Windows rep can configure app_metric_exclusion_filter

* [X] Before PR Submission, Submit an issue for either an [Enhancement](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=enhancement_request.md&title=) or [Bug](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=bug_report.md&title=)
* [X] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests in diego-release.
* [X] Make sure a pull request is done against the `develop` branch.

## Issue Link

https://github.com/cloudfoundry/diego-release/issues/897

Thank you!

CC @mkocher 
