### PR TITLE
Remove blobs without object_id

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,13 +1,7 @@
-jq/jq-1.7.1-linux-amd64.tgz:
-  size: 991585
-  sha: sha256:31f0791bdbcb944c64da5b629b166530ce73cc6ad1b277245ec27152e03dd850
 proxy/envoy-0de8b2b94c75dbe8c2f897058e16d23d959783fa-1.28.1.tgz:
   size: 24002360
   object_id: 217bbd54-3b07-47ba-69a2-831560c50062
   sha: sha256:97d0b397fd55e96ec221d6fbd715b549a1cadf374047a3c64679b4511291a14c
-tar/tar-1705951671.tgz:
-  size: 535764
-  sha: sha256:f0b77facec8510b4e78061a764ed265e5db5aef3077d9c68e0fdde261ac21103
 winpty/winpty-0.4.3.tgz:
   size: 461815
   object_id: a81bcf72-3eac-4899-74c5-f6176b4a9d5b


### PR DESCRIPTION
job that updated this blob had the `bosh upload-blobs` commented. It's fixed now
(https://github.com/cloudfoundry/wg-app-platform-runtime-ci/commit/b4e87b8e79420501b614185aed96a0c179114e79) but the blobs without object_id has remained in config/blobs.yml
