### PR TITLE
Revert "Add tcp.enable_tls to route-emitter (#935)"

### DIFF
--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -112,9 +112,6 @@ properties:
   tcp.enabled:
     description: "Enable the route-emitter in cell-local mode to emit TCP routes for instances to the Routing API."
     default: false
-  tcp.enable_tls:
-    description: "When enabled route-emitter will include TLS port and instance GUID when emitting TCP routes."
-    default: false
   routing_api.url:
     description: "Routing API uri to be used by the tcp route-emitter"
     default: http://routing-api.service.cf.internal

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -133,7 +133,6 @@
 
   config[:enable_internal_emitter] = p("internal_routes.enabled")
   config[:enable_tcp_emitter] = p("tcp.enabled")
-  config[:tcp_enable_tls] = p("tcp.enable_tls")
   config[:routing_api] = {}
   if_p("routing_api.url") do |value|
     config[:routing_api][:url] = value

--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -112,9 +112,6 @@ properties:
   tcp.enabled:
     description: "Enable the route-emitter in cell-local mode to emit TCP routes for instances to the Routing API."
     default: false
-  tcp.enable_tls:
-    description: "When enabled route-emitter will include TLS port and instance GUID when emitting TCP routes."
-    default: false
   routing_api.url:
     description: "Routing API uri to be used by the tcp route-emitter"
     default: http://routing-api.service.cf.internal

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -132,7 +132,6 @@
 
   config[:enable_internal_emitter] = p("internal_routes.enabled")
   config[:enable_tcp_emitter] = p("tcp.enabled")
-  config[:tcp_enable_tls] = p("tcp.enable_tls")
   config[:routing_api] = {}
   if_p("routing_api.url") do |value|
     config[:routing_api][:url] = value

--- a/spec/route_emitter_template_spec.rb
+++ b/spec/route_emitter_template_spec.rb
@@ -30,7 +30,7 @@ describe 'route_emitter' do
               'machines' => {
                 'nats_addresses' => '1.2.3.4'
               }
-            }
+            },
           }
         },
         'enable_consul_service_registration' => 'false',
@@ -78,20 +78,6 @@ describe 'route_emitter' do
         expect do
           rendered_template
         end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
-      end
-    end
-
-    context 'tcp.enable_tls' do
-      it 'is false by default' do
-        json_data = JSON.parse(rendered_template)
-        expect(json_data['tcp_enable_tls']).to eq(false)
-      end
-
-      it 'can be configured to true' do
-        deployment_manifest_fragment['tcp'] = {}
-        deployment_manifest_fragment['tcp']['enable_tls'] = true
-        json_data = JSON.parse(rendered_template)
-        expect(json_data['tcp_enable_tls']).to eq(true)
       end
     end
   end

--- a/spec/route_emitter_windows_template_spec.rb
+++ b/spec/route_emitter_windows_template_spec.rb
@@ -82,19 +82,5 @@ describe 'route_emitter' do
         end.to raise_error(/diego.route_emitter.jitter_factor must be a float between 0.0 and 1.0/)
       end
     end
-
-    context 'tcp.enable_tls' do
-      it 'is false by default' do
-        json_data = JSON.parse(rendered_template)
-        expect(json_data['tcp_enable_tls']).to eq(false)
-      end
-
-      it 'can be configured to true' do
-        deployment_manifest_fragment['tcp'] = {}
-        deployment_manifest_fragment['tcp']['enable_tls'] = true
-        json_data = JSON.parse(rendered_template)
-        expect(json_data['tcp_enable_tls']).to eq(true)
-      end
-    end
   end
 end


### PR DESCRIPTION
This reverts commit 7432edc53e8f6f715d56e599295343b441541af7.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Reverts the property for route emitter to enable tls tcp route advertisements

Backward Compatibility
---------------
Breaking Change? no