### PR TITLE
Remove replace directive for go-datadog-api

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -11,8 +11,6 @@ replace (
 	code.cloudfoundry.org/idmapper => ../idmapper
 	github.com/buildpacks/lifecycle => github.com/buildpacks/lifecycle v0.19.7
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.2
-
-	github.com/zorkian/go-datadog-api => github.com/zorkian/go-datadog-api v0.0.0-20150915071709-8f1192dcd661
 )
 
 require (

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -1271,4 +1271,3 @@ gopkg.in/yaml.v3
 # code.cloudfoundry.org/idmapper => ../idmapper
 # github.com/buildpacks/lifecycle => github.com/buildpacks/lifecycle v0.19.7
 # github.com/moby/buildkit => github.com/moby/buildkit v0.13.2
-# github.com/zorkian/go-datadog-api => github.com/zorkian/go-datadog-api v0.0.0-20150915071709-8f1192dcd661


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR removes the `replace` directive for `go-datadog-api`


Backward Compatibility
---------------
Breaking Change? **No**