### PR TITLE
force azure zone logs into json format with timestamps

### DIFF
--- a/jobs/rep/templates/rep.erb
+++ b/jobs/rep/templates/rep.erb
@@ -9,7 +9,7 @@ set +e
   if [ 0 -eq $? ]; then
     zone_flag="-zone=z${azure_fd}"
   else
-    echo "Warning: Failed to curl azure metadata endpoint for fault domain"
+    echo "{\"timestamp\":\"$(date --rfc-3339=ns | sed 's/ /T/' | sed 's/+00:00/Z/')\",\"level\":\"info\",\"source\":\"rep\",\"message\":\"Warning: Failed to curl azure metadata endpoint for fault domain\"}"
   fi
   azure_zone=$(curl -f --max-time 5 --silent -H Metadata:true "http://169.254.169.254/metadata/instance/compute/zone?api-version=2017-12-01&format=text")
   if [ 0 -eq $? ]; then
@@ -17,7 +17,7 @@ set +e
       zone_flag=""
     fi
   else
-    echo "Warning: Failed to curl azure metadata endpoint for availability zone"
+  echo "{\"timestamp\":\"$(date --rfc-3339=ns | sed 's/ /T/' | sed 's/+00:00/Z/')\",\"level\":\"info\",\"source\":\"rep\",\"message\":\"Warning: Failed to curl azure metadata endpoint for availability zone\"}"
   fi
 set -e
 <% end %>


### PR DESCRIPTION
**BEFORE**
```
{"timestamp":"2024-08-21T20:27:04.277145579Z","level":"error","source":"rep","message":"rep.failed-to-initialize-metron-client","data":{"error":"context deadline exceeded"}}
2024-08-21 20:27:16+0000 Warning: Failed to curl azure metadata endpoint for fault domain
2024-08-21 20:27:16+0000 Warning: Failed to curl azure metadata endpoint for availability zone
{"timestamp":"2024-08-21T20:27:16.490624811Z","level":"info","source":"rep","message":"rep.wait-for-garden.ping-garden","data":{"initialTime:":"2024-08-21T20:27:16.490556255Z","session":"1","wait-time-ns:":67451}}
```

**AFTER**
```
{"timestamp":"2024-08-21T20:54:52.999994951Z","level":"error","source":"rep","message":"rep.failed-to-initialize-metron-client","data":{"error":"context deadline exceeded"}}
{"timestamp":"2024-08-21T20:55:05.024195434Z","level":"info","source":"rep","message":"Warning: Failed to curl azure metadata endpoint for fault domain"}
{"timestamp":"2024-08-21T20:55:05.040002342Z","level":"info","source":"rep","message":"Warning: Failed to curl azure metadata endpoint for availability zone"}
{"timestamp":"2024-08-21T20:55:05.073875102Z","level":"info","source":"rep","message":"rep.wait-for-garden.ping-garden","data":{"initialTime:":"2024-08-21T20:55:05.073819249Z","session":"1","wait-time-ns:":52730}}
```



It's hacky, but it works.