### PR TITLE
add missing default params for linters

### DIFF
--- a/scripts/docker/lint.bash
+++ b/scripts/docker/lint.bash
@@ -5,6 +5,7 @@ set -o pipefail
 
 . <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/lint-repo/linux.yml)
 
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/lint-repo/linux.yml"
 pushd / > /dev/null
 /ci/shared/tasks/lint-repo/task.bash
 popd > /dev/null


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add missing DEFAULT_PARAMS so that all linters in CI is ran

Backward Compatibility
---------------
Breaking Change? **No**
