### PR TITLE
Add the sidecar rootfs path to the windows rep

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -55,7 +55,7 @@ properties:
   diego.rep.preloaded_rootfses:
     description: "Array of name:absolute_path pairs representing root filesystems preloaded onto the underlying garden"
   diego.rep.sidecar_rootfs_path:
-    description: "absolute_path representing the root filesystem used for sidecar processes (ie. "/var/vcap/packages/cflinuxfs4/rootfs.tar"). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
+    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/var/vcap/packages/cflinuxfs4/rootfs.tar'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
     default: ""
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -45,6 +45,9 @@ properties:
     description: "Array of name:absolute_path pairs representing root filesystems preloaded onto the underlying garden"
     default:
       - windows2012R2:/tmp/windows2012R2
+  diego.rep.sidecar_rootfs_path:
+    description: "absolute_path representing the root filesystem used for sidecar processes (ie. "/tmp/windows2012R2"). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
+    default: ""
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"
     default: []

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -46,7 +46,7 @@ properties:
     default:
       - windows2012R2:/tmp/windows2012R2
   diego.rep.sidecar_rootfs_path:
-    description: "absolute_path representing the root filesystem used for sidecar processes (ie. "/tmp/windows2012R2"). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
+    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/tmp/windows2012R2'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
     default: ""
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -95,6 +95,7 @@
     placement_tags: p("diego.rep.placement_tags"),
     polling_interval: "#{p("diego.rep.polling_interval_in_seconds")}s",
     preloaded_root_fs: p("diego.rep.preloaded_rootfses"),
+    sidecar_root_fs_path: p("diego.rep.sidecar_rootfs_path"),
     read_work_pool_size: p("diego.executor.read_work_pool_size"),
     skip_cert_verify: p("diego.ssl.skip_cert_verify"),
     supported_providers: p("diego.rep.rootfs_providers"),


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are used in a consistent way. We have added a SidecarRootFS that will store the FS to be used for the envoy & healthchecks. This PR is an addition to the previous one, fixing the windows drift

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just making sure the fses are used in a consistent way
<!---