### PR TITLE
Add extra_root_fs_dir property for rep

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -57,6 +57,9 @@ properties:
   diego.rep.sidecar_rootfs_path:
     description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/var/vcap/packages/cflinuxfs4/rootfs.tar'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
     default: ""
+  diego.rep.extra_root_fs_dir:
+    description: "dir to scan for extra rootfs to be loaded by rep"
+    default: "/var/vcap/store/rootfses"
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"
     default:

--- a/jobs/rep/templates/bpm.yml.erb
+++ b/jobs/rep/templates/bpm.yml.erb
@@ -11,3 +11,4 @@ processes:
     - path: <%= p("diego.executor.volman.driver_paths") %>
     - path : /var/vcap/data/garden
       writable: true
+    - path: <%= p("diego.rep.extra_root_fs_dir") %>

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -73,6 +73,7 @@
     container_proxy_config_path: "/var/vcap/data/rep/shared/garden/proxy_config",
     evacuation_polling_interval: "#{p("diego.rep.evacuation_polling_interval_in_seconds")}s",
     evacuation_timeout: "#{p("diego.rep.evacuation_timeout_in_seconds")}s",
+    extra_root_fs_dir: "#{p("diego.rep.extra_root_fs_dir")}",
     garden_addr: p("diego.executor.garden.address"),
     garden_healthcheck_command_retry_pause: p("diego.executor.garden_healthcheck.command_retry_pause"),
     garden_healthcheck_interval: p("diego.executor.garden_healthcheck.interval"),

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -48,6 +48,9 @@ properties:
   diego.rep.sidecar_rootfs_path:
     description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/tmp/windows2012R2'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
     default: ""
+  diego.rep.extra_root_fs_dir:
+    description: "dir to scan for extra rootfs to be loaded by rep"
+    default: "/var/vcap/store/rootfses"
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"
     default: []

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -73,6 +73,7 @@
     container_proxy_config_path: "/var/vcap/data/rep/shared/garden/proxy_config",
     evacuation_polling_interval: "#{p("diego.rep.evacuation_polling_interval_in_seconds")}s",
     evacuation_timeout: "#{p("diego.rep.evacuation_timeout_in_seconds")}s",
+    extra_root_fs_dir: "#{p("diego.rep.extra_root_fs_dir")}",
     garden_addr: p("diego.executor.garden.address"),
     garden_healthcheck_command_retry_pause: p("diego.executor.garden_healthcheck.command_retry_pause"),
     garden_healthcheck_interval: p("diego.executor.garden_healthcheck.interval"),


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
this will allow to load a rootfs from a location on disk outside of rep.json preloaded_rootfses

### Related PRs:
- [ ] https://github.com/cloudfoundry/rep/pull/68
- [ ] https://github.com/cloudfoundry/inigo/pull/51
- [ ] https://github.com/cloudfoundry/executor/pull/118

Backward Compatibility
---------------
Breaking Change? **No**
