### PR TITLE
Pin runc to 1.2.4

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -14,6 +14,7 @@ replace (
 	// We have to pin this dep to v0.12.0 to remain compatible with Enovy 1.28 until Xenial is out of support
 	// https://www.pivotaltracker.com/n/projects/2477027/stories/186946795
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.12.0
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.2.4 // indirect
 )
 
 require (


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Pin runc to 1.2.4


Backward Compatibility
---------------
Breaking Change? **No**
