### PR TITLE
Do a Test-Path before Remove-Item for rep_windows

### DIFF
--- a/jobs/rep_windows/templates/pre-start.ps1.erb
+++ b/jobs/rep_windows/templates/pre-start.ps1.erb
@@ -10,6 +10,13 @@ function allowContainerUsersAccess {
   Set-Acl $directory $acl
 }
 
+function checkAndRemove {
+  param([string] $path)
+  if (Test-Path $path) {
+    Remove-Item -Path $path -Force -Recurse -ErrorAction "Continue"
+  }
+}
+
 Write-Host "Running pre-start"
 
 $port="<%= p("diego.rep.listen_addr_admin").sub(/^127\.0\.0\.1:/, "")%>"
@@ -37,12 +44,12 @@ if (-Not (Get-NetFirewallRule | Where-Object { $_.DisplayName -eq "SecureRepPort
 }
 
 # Remove old data dirs so that disk space isn't wasted. This cleanup can be removed in v4
-Remove-Item -Path "/var/vcap/data/rep/shared/garden/download_cache" -Force -Recurse -ErrorAction "Continue"
-Remove-Item -Path "/var/vcap/data/rep/shared/garden/instance_identity" -Force -Recurse -ErrorAction "Continue"
-Remove-Item -Path "/var/vcap/data/rep/shared/garden/trusted_certs" -Force -Recurse -ErrorAction "Continue"
-Remove-Item -Path "/var/vcap/data/rep/shared/garden/proxy_config" -Force -Recurse -ErrorAction "Continue"
-Remove-Item -Path "/var/vcap/data/rep/shared_data" -Force -Recurse -ErrorAction "Continue"
-Remove-Item -Path "/var/vcap/data/rep/shared/garden/volume_mounted_files" -Force -Recurse -ErrorAction "Continue"
+checkAndRemove "/var/vcap/data/rep/shared/garden/download_cache"
+checkAndRemove "/var/vcap/data/rep/shared/garden/instance_identity"
+checkAndRemove "/var/vcap/data/rep/shared/garden/trusted_certs"
+checkAndRemove "/var/vcap/data/rep/shared/garden/proxy_config"
+checkAndRemove "/var/vcap/data/rep/shared_data"
+checkAndRemove "/var/vcap/data/rep/shared/garden/volume_mounted_files"
 
 $bindmountDirs = @()
 


### PR DESCRIPTION
Windows will fail if the path doesn't exist

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This is causing the uptimer deployment and tests to fail


Backward Compatibility
---------------
Breaking Change? **No**

