### PR TITLE
proxy_healthcheck_interval must be a string

### DIFF
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -137,8 +137,8 @@ properties:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false
   diego.executor.proxy_healthcheck_interval:
-    description: "Interval that checks envoy responsiveness every 30s."
-    default: 30
+    description: "Interval that checks envoy responsiveness."
+    default: "30s"
   diego.executor.enable_container_proxy_healthcheck:
     description: "When set, enables the liveness health check for the envoy proxy in the container."
     default: false


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
When rep uses executor to initialize the config it fails parsing since the initializer is expecting a string (e.g. "30s") instead of the number 30 for default.  Also brings the default in line with other specified "interval" defaults that are not "interval_in_seconds".


Backward Compatibility
---------------
Breaking Change? **No**
