### PR TITLE
Add default timeout for declarative healthcheck in rep spec

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -215,6 +215,9 @@ properties:
   diego.executor.max_log_lines_per_second:
     description: "EXPERIMENTAL: Maximum log lines allowed per second per app instance. Default value of 0 will disable rate limiting. Minimum recommended value is 100."
     default: 0
+  diego.executor.declarative_healthcheck_default_timeout:
+    description: "Default timeout for declarative healthcheck. This value is used when the LRP spec does not specify a timeout. Only used if 'enable_declarative_healthcheck' is set to true."
+    default: "1s"
 
   diego.rep.bbs.api_location:
     description: "Address of the BBS server"

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -110,6 +110,7 @@
     max_data_string_length: p("logging.max_data_string_length"),
     max_log_lines_per_second: p("diego.executor.max_log_lines_per_second"),
     volume_mounted_files: "#{volume_mounted_files}",
+    declarative_healthcheck_default_timeout: p("diego.executor.declarative_healthcheck_default_timeout"),
   }
 
   if p("containers.graceful_shutdown_interval_in_seconds") < 10


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add the option to configure the default timeout for declarative healthcheck in rep spec. 


Backward Compatibility
---------------
Breaking Change? **No**

If not configured, the same default of 1s is used.
