### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -99,10 +99,6 @@ properties:
     description: When set, the auctioneer attempts to claim a lock from the Locket API.
     default: true
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   loggregator.use_v2_api:
     description: "True to use local metron agent gRPC v2 API. False to use UDP v1 API."
     default: false

--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -37,13 +37,7 @@
   config[:bbs_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"
   config[:bbs_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
   config[:bbs_address] = "https://#{p("diego.auctioneer.bbs.api_location")}"
-
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
+  config[:time_format] ="rfc3339" 
 
   if_p("diego.auctioneer.bbs.client_session_cache_size") do |value|
     config[:bbs_client_session_cache_size] = value

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -163,10 +163,6 @@ properties:
     description: Maximum number of files (including sockets) the BBS process may have open.
     default: 100000
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   logging.max_data_string_length:
     description: "Length in bytes above which logged strings will be truncated. If set to 0, turns off truncation."
     default: 640

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -144,13 +144,7 @@
     config[:kick_task_duration] = "#{value}s" # add time unit
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
-
+  config[:time_format] = "rfc3339"
   config[:advertise_url] = advertise_url "https"
   config[:ca_file] = "#{conf_dir}/certs/ca.crt"
   config[:cert_file] = "#{conf_dir}/certs/server.crt"

--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -60,10 +60,6 @@ properties:
   tls.key:
     description: "PEM-encoded tls key"
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   loggregator.use_v2_api:
     description: "Whether component should use the v2 loggregator API when sending data to the metron agent instead of the 'legacy' v1 API."
     default: false

--- a/jobs/file_server/templates/file_server.json.erb
+++ b/jobs/file_server/templates/file_server.json.erb
@@ -37,13 +37,7 @@
     raise "tls.cert and tls.key are required if https_server_enabled is set to true"
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
-
+  config[:time_format] = "rfc3339"
   config[:loggregator]={}
   config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
   if p("loggregator.use_v2_api") == true

--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -67,10 +67,6 @@ properties:
   diego.locket.sql.ca_cert:
     description: "Bundle of CA certificates for the Locket to verify the SQL server SSL certificate when connecting via SSL"
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   loggregator.use_v2_api:
     description: "True to use local metron agent gRPC v2 API. False to use UDP v1 API."
     default: false

--- a/jobs/locket/templates/locket.json.erb
+++ b/jobs/locket/templates/locket.json.erb
@@ -66,13 +66,7 @@ if p("diego.locket.sql.require_ssl")
    config[:sql_enable_identity_verification] = p("database.tls.enable_identity_verification")
 end
 
-if_p("logging.format.timestamp") do |format|
-  if format != "unix-epoch" and format != "rfc3339"
-    raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-  end
-  config[:time_format] = format
-end
-
+config[:time_format] = "rfc3339"
 config[:loggregator]={}
 config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
 if p("loggregator.use_v2_api") == true

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -332,10 +332,6 @@ properties:
     default: []
     example: [ "169.254.0.2:15001" ]
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   logging.max_data_string_length:
     description: "Length in bytes above which logged strings will be truncated. If set to 0, turns off truncation."
     default: 640

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -219,12 +219,7 @@
     end
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
+  config[:time_format] = "rfc3339"
 
   if_p("containers.layering_mode") do |mode|
     if mode != "single-layer" and mode != "two-layer"

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -61,10 +61,6 @@ properties:
     description: "Add more permissive ACLs to directories that are bind mounted into containers. Required for Windows 2016 cells"
     default: false
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   logging.max_data_string_length:
     description: "Length in bytes above which logged strings will be truncated. If set to 0, turns off truncation."
     default: 640

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -219,12 +219,7 @@
     end
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
+  config[:time_format] = "rfc3339"
 
   if_p("containers.layering_mode") do |mode|
     if mode != "single-layer" and mode != "two-layer"

--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -105,10 +105,6 @@ properties:
     description: "Experimental: Enable the route-emitter to emit registrations for internal DNS-based service discovery."
     default: false
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   tcp.enabled:
     description: "Enable the route-emitter in cell-local mode to emit TCP routes for instances to the Routing API."
     default: false

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -97,12 +97,7 @@
     config[:jitter_factor] = value
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
+config[:time_format] = "rfc3339"
 
   if p("locks.locket.enabled")
     config[:locket_enabled] = true

--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -91,10 +91,6 @@ properties:
     description: "The name of the Diego job referenced by this spec (DO NOT override)"
     default: "route_emitter_windows"
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   syslog_daemon_config.address:
     description: "Syslog host"
     default: ""

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -96,12 +96,7 @@
     config[:jitter_factor] = value
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
+  config[:time_format] = "rfc3339"
 
   if p("locks.locket.enabled")
     config[:locket_enabled] = true

--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -120,10 +120,6 @@ properties:
     description: "Connect directly to container IP instead of to the host IP and external port. Suitable only for deployments in which the gorouters and TCP routers can route directly to the container IP of instances."
     default: false
 
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"
-
   loggregator.use_v2_api:
     description: "True to use local metron agent gRPC v2 API. False to use UDP v1 API."
     default: false

--- a/jobs/ssh_proxy/templates/ssh_proxy.json.erb
+++ b/jobs/ssh_proxy/templates/ssh_proxy.json.erb
@@ -83,13 +83,7 @@
     config[:bbs_max_idle_conns_per_host] = value
   end
 
-  if_p("logging.format.timestamp") do |format|
-    if format != "unix-epoch" and format != "rfc3339"
-      raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'"
-    end
-    config[:time_format] = format
-  end
-
+  config[:time_format] = "rfc3339"
   config[:loggregator]={}
   config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
   if p("loggregator.use_v2_api") == true


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Cleanup logging time format property and set value as rfc3339.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->

Test evidence:

```
{"timestamp":"1749141197.235670090","source":"auctioneer","message":"auctioneer.started","log_level":1,"data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/sys/log/auctioneer#
**After:**
{"timestamp":"2025-06-05T17:11:51.038735664Z","level":"info","source":"auctioneer","message":"auctioneer.started","data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/data/sys/log/auctioneer#


{"timestamp":"1749141728.306036472","source":"bbs","message":"bbs.executing-convergence.converge-lrps-done","log_level":1,"data":{"session":"158"}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/sys/log/bbs#
**After:**
{"timestamp":"2025-06-05T17:19:18.504494633Z","level":"info","source":"bbs","message":"bbs.executing-convergence.converge-lrps-done","data":{"session":"152"}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/data/sys/log/bbs#

{"timestamp":"1749141199.308348417","source":"file-server","message":"file-server.ready","log_level":1,"data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/sys/log/file_server#
**After:**
{"timestamp":"2025-06-05T17:11:52.944608246Z","level":"info","source":"file-server","message":"file-server.ready","data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/data/sys/log/file_server#

{"timestamp":"1749141587.447796583","source":"locket","message":"locket.lock.lock.acquired-lock","log_level":1,"data":{"key":"4cd7edd3-0f6a-4d28-a93f-b61c6d619d6f","owner":"663c13b9-3cf5-42c8-7190-72187d09852b","request-uuid":"ef3708fc-888d-4381-6acb-1683b996227f","session":"1962.1","type-code":2}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/sys/log/locket#
**After:**
{"timestamp":"2025-06-05T17:14:12.398027284Z","level":"info","source":"locket","message":"locket.lock.lock.acquired-lock","data":{"key":"routing_api_lock","owner":"1d8b08cc-29d3-4818-b3c6-5cb4acd66385","request-uuid":"10e21cae-aa3d-47f8-4474-66da29c6c24b","session":"540.1","type-code":1}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/data/sys/log/locket#

{"timestamp":"1749141200.406981945","source":"ssh-proxy","message":"ssh-proxy.started","log_level":1,"data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/sys/log/ssh_proxy#
**After:**
{"timestamp":"2025-06-05T17:11:54.498199250Z","level":"info","source":"ssh-proxy","message":"ssh-proxy.started","data":{}}
control/1d8b08cc-29d3-4818-b3c6-5cb4acd66385:/var/vcap/data/sys/log/ssh_proxy#

{"timestamp":"1749142039.427988291","source":"route-emitter","message":"route-emitter.route-broadcast-scheduler.emitting-routes","log_level":1,"data":{"name":"router","session":"2"}}
compute/4cd7edd3-0f6a-4d28-a93f-b61c6d619d6f:/var/vcap/data/sys/log/route_emitter#
**After:**
{"timestamp":"2025-06-05T18:59:04.994224016Z","level":"info","source":"route-emitter","message":"route-emitter.watcher.sync.complete","data":{"session":"8.62"}}
compute/4cd7edd3-0f6a-4d28-a93f-b61c6d619d6f:/var/vcap/sys/log/route_emitter$

rep:
{"timestamp":"2025-06-05T19:02:42.569816267Z","level":"info","source":"rep","message":"rep.running-bulker.sync.finished","data":{"session":"14.27"}}
compute/4cd7edd3-0f6a-4d28-a93f-b61c6d619d6f:/var/vcap/sys/log/rep$```
