### PR TITLE
Remove old property: bpm.enabled in diego-release

### DIFF
--- a/jobs/auctioneer/monit
+++ b/jobs/auctioneer/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process auctioneer
   with pidfile /var/vcap/sys/run/bpm/auctioneer/auctioneer.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start auctioneer"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop auctioneer"
   group vcap
-<% else %>
-check process auctioneer
-  with pidfile /var/vcap/sys/run/auctioneer/auctioneer.pid
-  start program "/var/vcap/jobs/auctioneer/bin/auctioneer_ctl start"
-  stop program "/var/vcap/jobs/auctioneer/bin/auctioneer_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -26,9 +26,6 @@ packages:
   - auctioneer
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the auctioneer process."
-    default: false
   diego.auctioneer.ca_cert:
     description: "REQUIRED: PEM-encoded CA certificate for the auctioneer API server."
   diego.auctioneer.server_cert:

--- a/jobs/auctioneer/templates/drain.erb
+++ b/jobs/auctioneer/templates/drain.erb
@@ -2,51 +2,6 @@
 
 set -e
 
-<% if p("bpm.enabled") %>
 /var/vcap/jobs/bpm/bin/bpm stop auctioneer 1>&2 || true
 echo "0"
 exit 0
-<% else %>
-run_dir=/var/vcap/sys/run/auctioneer
-pidfile=$run_dir/auctioneer.pid
-log_dir=/var/vcap/sys/log/auctioneer
-logfile=$log_dir/drain.log
-
-mkdir -p $log_dir
-
-exec 3>&1
-
-source /var/vcap/packages/pid_utils/pid_utils.sh
-
-exec 1>> $logfile
-exec 2>> $logfile
-
-output_for_bosh() {
-  exit_code=$?
-
-  if [ $exit_code -eq 0 ]; then
-    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): auctioneer exited"
-  else
-    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain failed"
-  fi
-
-  echo $exit_code >&3
-}
-
-trap output_for_bosh EXIT
-
-if [ ! -f $pidfile ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): pidfile does not exist"
-  exit 0
-fi
-
-pid=$(cat $pidfile)
-
-if [ ! -e /proc/$pid ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): auctioneer process not running"
-  exit 0
-fi
-
-echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain triggered"
-kill_and_wait $pidfile
-<% end %>

--- a/jobs/bbs/monit
+++ b/jobs/bbs/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process bbs
   with pidfile /var/vcap/sys/run/bpm/bbs/bbs.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start bbs"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop bbs"
   group vcap
-<% else %>
-check process bbs
-  with pidfile /var/vcap/sys/run/bbs/bbs.pid
-  start program "/var/vcap/jobs/bbs/bin/bbs_ctl start"
-  stop program "/var/vcap/jobs/bbs/bin/bbs_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -30,10 +30,6 @@ packages:
   - bbs
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the BBS process."
-    default: false
-
   tasks.max_retries:
     description: "The number of times task placement should be retried after pre-execution task failure."
     default: 3

--- a/jobs/bbs/templates/drain.erb
+++ b/jobs/bbs/templates/drain.erb
@@ -2,51 +2,6 @@
 
 set -e
 
-<% if p("bpm.enabled") %>
 /var/vcap/jobs/bpm/bin/bpm stop bbs 1>&2 || true
 echo "0"
 exit 0
-<% else %>
-run_dir=/var/vcap/sys/run/bbs
-pidfile=$run_dir/bbs.pid
-log_dir=/var/vcap/sys/log/bbs
-logfile=$log_dir/drain.log
-
-mkdir -p $log_dir
-
-exec 3>&1
-
-source /var/vcap/packages/pid_utils/pid_utils.sh
-
-exec 1>> $logfile
-exec 2>> $logfile
-
-output_for_bosh() {
-  exit_code=$?
-
-  if [ $exit_code -eq 0 ]; then
-    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): bbs exited"
-  else
-    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain failed"
-  fi
-
-  echo $exit_code >&3
-}
-
-trap output_for_bosh EXIT
-
-if [ ! -f $pidfile ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): pidfile does not exist"
-  exit 0
-fi
-
-pid=$(cat $pidfile)
-
-if [ ! -e /proc/$pid ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): bbs process not running"
-  exit 0
-fi
-
-echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain triggered"
-kill_and_wait $pidfile
-<% end %>

--- a/jobs/file_server/monit
+++ b/jobs/file_server/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process file_server
   with pidfile /var/vcap/sys/run/bpm/file_server/file_server.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start file_server"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop file_server"
   group vcap
-<% else %>
-check process file_server
-  with pidfile /var/vcap/sys/run/file_server/file_server.pid
-  start program "/var/vcap/jobs/file_server/bin/file_server_ctl start"
-  stop program "/var/vcap/jobs/file_server/bin/file_server_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -30,9 +30,6 @@ provides:
   - https_url
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the file-server process."
-    default: false
   diego.file_server.listen_addr:
     description: "Address of interface on which to serve files"
     default: "0.0.0.0:8080"

--- a/jobs/locket/monit
+++ b/jobs/locket/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process locket
   with pidfile /var/vcap/sys/run/bpm/locket/locket.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start locket"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop locket"
   group vcap
-<% else %>
-check process locket
-  with pidfile /var/vcap/sys/run/locket/locket.pid
-  start program "/var/vcap/jobs/locket/bin/locket_ctl start"
-  stop program "/var/vcap/jobs/locket/bin/locket_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -22,9 +22,6 @@ packages:
   - locket
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the Locket process."
-    default: false
   tls.ca_cert:
     description: "ca cert for locket server mutual auth tls"
   tls.cert:

--- a/jobs/rep/monit
+++ b/jobs/rep/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process rep
   with pidfile /var/vcap/sys/run/bpm/rep/rep.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start rep"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop rep"
   group vcap
-<% else %>
-check process rep
-  with pidfile /var/vcap/sys/run/rep/rep.pid
-  start program "/var/vcap/jobs/rep/bin/rep_ctl start"
-  stop program "/var/vcap/jobs/rep/bin/rep_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -32,9 +32,6 @@ packages:
   - certsplitter
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the cell rep process."
-    default: false
   diego.rep.debug_addr:
     description: "address at which to serve debug info"
     default: "127.0.0.1:17008"

--- a/jobs/rep/templates/drain.erb
+++ b/jobs/rep/templates/drain.erb
@@ -46,7 +46,6 @@ output_for_bosh() {
 
 trap output_for_bosh EXIT
 
-<% if p("bpm.enabled") %>
 if ! /var/vcap/jobs/bpm/bin/bpm pid rep >/dev/null 2>&1; then
   echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): rep process not running"
   exit 0
@@ -64,29 +63,3 @@ if evacuate; then
 else
   exit 1
 fi
-<% else %>
-
-if [ ! -f $pidfile ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): pidfile does not exist"
-  exit 0
-fi
-
-pid=$(cat $pidfile)
-
-if [ ! -e /proc/$pid ]; then
-  echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): rep process not running"
-  exit 0
-fi
-
-echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain triggered"
-if evacuate; then
-  while heartbeat; do
-    sleep 5
-    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): waiting"
-  done
-
-  kill_and_wait $pidfile
-else
-  exit 1
-fi
-<% end %>

--- a/jobs/route_emitter/monit
+++ b/jobs/route_emitter/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process route_emitter
   with pidfile /var/vcap/sys/run/bpm/route_emitter/route_emitter.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start route_emitter"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop route_emitter"
   group vcap
-<% else %>
-check process route_emitter
-  with pidfile /var/vcap/sys/run/route_emitter/route_emitter.pid
-  start program "/var/vcap/jobs/route_emitter/bin/route_emitter_ctl start"
-  stop program "/var/vcap/jobs/route_emitter/bin/route_emitter_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -38,9 +38,6 @@ consumes:
   optional: true
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the route-emitter process."
-    default: false
   register_direct_instance_routes:
     description: "Use the container IP address and internal port instead of the host IP address and external port when registering route endpoints. Suitable only for deployments in which the gorouters and TCP routers can route directly to the container IP of instances."
     default: false

--- a/jobs/ssh_proxy/monit
+++ b/jobs/ssh_proxy/monit
@@ -1,13 +1,5 @@
-<% if p("bpm.enabled") %>
 check process ssh_proxy
   with pidfile /var/vcap/sys/run/bpm/ssh_proxy/ssh_proxy.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start ssh_proxy"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop ssh_proxy"
   group vcap
-<% else %>
-check process ssh_proxy
-  with pidfile /var/vcap/sys/run/ssh_proxy/ssh_proxy.pid
-  start program "/var/vcap/jobs/ssh_proxy/bin/ssh_proxy_ctl start"
-  stop program "/var/vcap/jobs/ssh_proxy/bin/ssh_proxy_ctl stop"
-  group vcap
-<% end %>

--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -32,10 +32,6 @@ consumes:
   optional: true
 
 properties:
-  bpm.enabled:
-    description: "use the BOSH Process Manager to manage the ssh-proxy process."
-    default: false
-
   backends.tls.enabled:
     default: false
     description: "Whether to enable TLS-proxied connections to target backend instances."


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Remove old property: bpm.enabled in diego-release

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
