### PR TITLE
Remove old property: locks.locket.enabled - Diego release

### DIFF
--- a/jobs/auctioneer/spec
+++ b/jobs/auctioneer/spec
@@ -89,10 +89,6 @@ properties:
     description: "Timeout in seconds to receive a response to the keepalive ping. If a response is not received within this time, the locket client will reconnect to another server."
     default: 22
 
-  locks.locket.enabled:
-    description: When set, the auctioneer attempts to claim a lock from the Locket API.
-    default: true
-
   loggregator.use_v2_api:
     description: "True to use local metron agent gRPC v2 API. False to use UDP v1 API."
     default: false

--- a/jobs/auctioneer/templates/auctioneer.json.erb
+++ b/jobs/auctioneer/templates/auctioneer.json.erb
@@ -23,7 +23,6 @@
     lock_ttl: "15s",
     debug_address: p("diego.auctioneer.debug_addr"),
     listen_address: p("diego.auctioneer.listen_addr"),
-    locks_locket_enabled: p("locks.locket.enabled"),
     log_level: p("diego.auctioneer.log_level"),
     rep_client_session_cache_size: p("diego.auctioneer.rep.client_session_cache_size"),
     cell_state_timeout: p("diego.auctioneer.cell_state_timeout"),

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -163,9 +163,6 @@ properties:
     description: "Length in bytes above which logged strings will be truncated. If set to 0, turns off truncation."
     default: 640
 
-  locks.locket.enabled:
-    description: When set, the BBS attempts to claim a lock from the Locket API.
-    default: true
   cell_registrations.locket.enabled:
     description: When set, the BBS will detect Diego cells registered with the Locket API.
     default: true

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -36,7 +36,6 @@
     log_level: p("diego.bbs.log_level"),
     active_key_label: p("diego.bbs.active_key_label"),
     debug_address: p("diego.bbs.debug_addr"),
-    locks_locket_enabled: p("locks.locket.enabled"),
     cell_registrations_locket_enabled: p("cell_registrations.locket.enabled"),
     max_task_retries: p("tasks.max_retries"),
     max_data_string_length: p("logging.max_data_string_length"),

--- a/jobs/route_emitter/spec
+++ b/jobs/route_emitter/spec
@@ -146,9 +146,6 @@ properties:
     description: "Cert used to communicate with local metron agent over gRPC"
   loggregator.key:
     description: "Key used to communicate with local metron agent over gRPC"
-  locks.locket.enabled:
-    description: "Whether the route-emitter in global mode should attempt to claim its activity lock via the Locket API."
-    default: true
   locks.locket.hostname:
     description: "Hostname at which to discover the Locket API server. The route-emitter will use its BBS client credentials to authenticate to the Locket API."
     default: "locket.service.cf.internal"

--- a/jobs/route_emitter/templates/route_emitter.json.erb
+++ b/jobs/route_emitter/templates/route_emitter.json.erb
@@ -99,15 +99,12 @@
 
   config[:time_format] = "rfc3339"
 
-  if p("locks.locket.enabled")
-    config[:locket_enabled] = true
-    config[:locket_session_name] = "route-emitter"
-    config[:locket_address] = "#{p("locks.locket.hostname")}:#{p("locks.locket.port")}"
-    config[:uuid] = spec.id
-    config[:locket_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
-    config[:locket_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"
-    config[:locket_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
-  end
+  config[:locket_session_name] = "route-emitter"
+  config[:locket_address] = "#{p("locks.locket.hostname")}:#{p("locks.locket.port")}"
+  config[:uuid] = spec.id
+  config[:locket_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
+  config[:locket_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"
+  config[:locket_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
 
   config[:bbs_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
   config[:bbs_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"

--- a/jobs/route_emitter_windows/templates/route_emitter.json.erb
+++ b/jobs/route_emitter_windows/templates/route_emitter.json.erb
@@ -98,15 +98,12 @@
 
   config[:time_format] = "rfc3339"
 
-  if p("locks.locket.enabled")
-    config[:locket_enabled] = true
-    config[:locket_session_name] = "route-emitter"
-    config[:locket_address] = "#{p("locks.locket.hostname")}:#{p("locks.locket.port")}"
-    config[:uuid] = spec.id
-    config[:locket_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
-    config[:locket_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"
-    config[:locket_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
-  end
+  config[:locket_session_name] = "route-emitter"
+  config[:locket_address] = "#{p("locks.locket.hostname")}:#{p("locks.locket.port")}"
+  config[:uuid] = spec.id
+  config[:locket_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
+  config[:locket_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"
+  config[:locket_client_key_file] = "#{conf_dir}/certs/bbs/client.key"
 
   config[:bbs_ca_cert_file] = "#{conf_dir}/certs/bbs/ca.crt"
   config[:bbs_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: locks.locket.enabled - Diego release

https://github.com/cloudfoundry/auctioneer/pull/24
https://github.com/cloudfoundry/bbs/pull/115
https://github.com/cloudfoundry/route-emitter/pull/52


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
