### PR TITLE
fix locket property lint and order of test scripts

### DIFF
--- a/jobs/route_emitter_windows/spec
+++ b/jobs/route_emitter_windows/spec
@@ -149,9 +149,6 @@ properties:
     description: "Cert used to communicate with local metron agent over gRPC"
   loggregator.key:
     description: "Key used to communicate with local metron agent over gRPC"
-  locks.locket.enabled:
-    description: "Whether the route-emitter in global mode should attempt to claim its activity lock via the Locket API."
-    default: true
   locks.locket.hostname:
     description: "Hostname at which to discover the Locket API server. The route-emitter will use its BBS client credentials to authenticate to the Locket API."
     default: "locket.service.cf.internal"

--- a/scripts/test-in-docker.bash
+++ b/scripts/test-in-docker.bash
@@ -2,7 +2,7 @@
 
 set -eu
 
-THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+THIS_FILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
 . "$CI/shared/helpers/git-helpers.bash"
 REPO_NAME=$(git_get_remote_name)
@@ -16,5 +16,5 @@ DB="${DB}" "${THIS_FILE_DIR}/create-docker-container.bash" -d
 
 docker exec $CONTAINER_NAME '/repo/scripts/docker/build-binaries.bash'
 docker exec $CONTAINER_NAME '/repo/scripts/docker/tests-templates.bash'
-docker exec $CONTAINER_NAME '/repo/scripts/docker/test.bash' "$@"
 docker exec $CONTAINER_NAME '/repo/scripts/docker/lint.bash'
+docker exec $CONTAINER_NAME '/repo/scripts/docker/test.bash' "$@"


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

fix locket property lint and order of test scripts

```~/workspace/diego-release |fix-lint-locket S:1?:16| 
$ ./scripts/test-in-docker.bash
Succeeded
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:9f8e955c74221f3257b3b3ccb3900ceb98d7763c6db0543471bbf966c9adc26f
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
Error response from daemon: No such container: diego-release-mysql-docker-container
10382386897fa6fc104a4aed195c57859ae6e940069e879b6e2c3806a08254c1
go version go1.24.4 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-r0es /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching ast 2.4.2
Fetching semi_semantic 1.2.0
Installing semi_semantic 1.2.0
Installing ast 2.4.2
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
..........................

Finished in 0.28442 seconds (files took 0.22965 seconds to load)
26 examples, 0 failures

Running ./ci/diego-release/linters/sync-package-specs.bash for-diego-release with-exit-on-error=true

Running ./ci/diego-release/linters/sync-submodule-config.bash for-diego-release with-exit-on-error=true
syncing src/code.cloudfoundry.org/bbs
syncing src/code.cloudfoundry.org/buildpackapplifecycle
syncing src/code.cloudfoundry.org/ecrhelper
syncing src/code.cloudfoundry.org/fileserver
syncing src/code.cloudfoundry.org/vendor
syncing src/grootfs
syncing src/code.cloudfoundry.org/cacheddownloader
syncing src/code.cloudfoundry.org/cfdot
syncing src/code.cloudfoundry.org/rep
syncing src/code.cloudfoundry.org/volman
syncing src/code.cloudfoundry.org/credhub-cli
syncing src/code.cloudfoundry.org/inigo
syncing src/code.cloudfoundry.org/locket
syncing src/code.cloudfoundry.org/diego-ssh
syncing src/code.cloudfoundry.org/dockerapplifecycle
syncing src/code.cloudfoundry.org/localdriver
syncing src/code.cloudfoundry.org/routing-api
syncing src/code.cloudfoundry.org/routing-info
syncing src/code.cloudfoundry.org/vizzini
syncing src/guardian
syncing src/idmapper
syncing src/code.cloudfoundry.org/healthcheck
syncing src/garden
syncing src/code.cloudfoundry.org/auction
syncing src/code.cloudfoundry.org/auctioneer
syncing src/code.cloudfoundry.org/executor
syncing src/code.cloudfoundry.org/route-emitter
syncing src/code.cloudfoundry.org/operationq
syncing src/code.cloudfoundry.org/workpool
syncing src/cnbapplifecycle
Running ./ci/shared/linters/match-golang-os-package-versions.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-envoy-versions.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-for-windows-drift.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-proto-files.bash for-diego-release with-exit-on-error=true```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
