### PR TITLE
Remove old property: proxy.enabled - Diego release

### DIFF
--- a/docs/060-envoy-proxy-configuration.md
+++ b/docs/060-envoy-proxy-configuration.md
@@ -21,8 +21,6 @@ This document describes how to enable the per-container [Envoy proxy](https://gi
 
 ## <a name="enabling-per-container-envoy-proxy"/> Enabling Per-Container Envoy Proxy
 
-A deployment operator enables the Linux cell reps to run an Envoy proxy process for each container by setting the `containers.proxy.enabled` property on the `rep` job to `true`.
-
 [Instance Identity Credentials](https://docs.cloudfoundry.org/adminguide/instance-identity.html) must also be enabled on the Diego cell rep so that it can configure the Envoy proxy process with the required TLS configuration.
 
 

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -256,9 +256,6 @@ properties:
     description: "time in seconds between signalling a container to shutdown gracefully and stopping it forcefully. Should not be less than 10."
     default: 10
 
-  containers.proxy.enabled:
-    description: "Enable envoy proxy on garden containers. Requires valid TLS credentials in diego.executor.instance_identity_ca_cert and diego.executor.instance_identity_key."
-    default: false
   containers.proxy.additional_memory_allocation_mb:
     description: "Additional memory allocated to each container for the envoy proxy. This value must not be negative"
     default: 32

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -265,7 +265,7 @@ properties:
 
   containers.proxy.require_and_verify_client_certificates:
     default: false
-    description: "whether the per-container proxy should require and verify a TLS certificate from a client connecting to one of its ingress listeners. Proxy will trust the set of CA certificates supplied in the containers.proxy.trusted_ca_certificates property. Requires containers.proxy.enabled to be set to true to enable."
+    description: "whether the per-container proxy should require and verify a TLS certificate from a client connecting to one of its ingress listeners. Proxy will trust the set of CA certificates supplied in the containers.proxy.trusted_ca_certificates property."
 
   containers.proxy.trusted_ca_certificates:
     default: []
@@ -296,7 +296,7 @@ properties:
 
   containers.proxy.enable_unproxied_port_mappings:
     default: true
-    description: "EXPERIMENTAL: whether the cell should still map host ports directly to the unproxied container ports. Setting to false requires containers.proxy.enabled to be set to true."
+    description: "EXPERIMENTAL: whether the cell should still map host ports directly to the unproxied container ports." 
 
   containers.trusted_ca_certificates:
     description: "List of PEM-encoded CA certificates to make available inside containers in a conventional location. List entries may be individual or concatenated CAs."

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -59,7 +59,6 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: "/var/vcap/packages/healthcheck",
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
-    enable_container_proxy: p("containers.proxy.enabled"),
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
@@ -188,15 +187,11 @@
 
   config[:bbs_address] = "https://#{p("diego.rep.bbs.api_location")}"
 
-  if config[:enable_container_proxy]
-    begin
+  begin
       p("diego.executor.instance_identity_ca_cert")
       p("diego.executor.instance_identity_key")
-    rescue
+  rescue
       raise '"when containers.proxy.enabled is true, diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
-    end
-  elsif !p("containers.proxy.enable_unproxied_port_mappings")
-    raise 'containers.proxy.enabled must be set to true in order to disable the unproxied port mappings'
   end
 
   if config[:container_proxy_require_and_verify_client_certs]

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -203,8 +203,8 @@
 
   if_p("diego.executor.instance_identity_ca_cert",
        "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |cert, key, validity_period|
-    if !(cert.empty? || key.empty? || validity_period < 1)
+       "diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
+    if !(validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"
       config[:instance_identity_cred_dir] = instance_identity_dir

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -59,6 +59,7 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: "/var/vcap/packages/healthcheck",
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
+    enable_container_proxy: "true",
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
@@ -191,7 +192,7 @@
       p("diego.executor.instance_identity_ca_cert")
       p("diego.executor.instance_identity_key")
   rescue
-      raise '"when containers.proxy.enabled is true, diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
+      raise '"diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
   end
 
   if config[:container_proxy_require_and_verify_client_certs]
@@ -201,9 +202,7 @@
       end
   end
 
-  if_p("diego.executor.instance_identity_ca_cert",
-       "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
+  if_p("diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
     if !(validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"

--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -72,7 +72,5 @@ rm -rf "$trusted_certs_dir"
 
 proxy_config_dir=${garden_shared_dir}/proxy_config
 rm -rf "$proxy_config_dir"
-<% if p("containers.proxy.enabled") %>
-  mkdir -p "$proxy_config_dir"
-  chown -R vcap:vcap "$proxy_config_dir"
-<% end %>
+mkdir -p "$proxy_config_dir"
+chown -R vcap:vcap "$proxy_config_dir"

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -273,7 +273,7 @@ properties:
 
   containers.proxy.require_and_verify_client_certificates:
     default: false
-    description: "whether the per-container proxy should require and verify a TLS certificate from a client connecting to one of its ingress listeners. Proxy will trust the set of CA certificates supplied in the containers.proxy.trusted_ca_certificates property. Requires containers.proxy.enabled to be set to true to enable."
+    description: "whether the per-container proxy should require and verify a TLS certificate from a client connecting to one of its ingress listeners. Proxy will trust the set of CA certificates supplied in the containers.proxy.trusted_ca_certificates property. 
 
   containers.proxy.trusted_ca_certificates:
     default: []
@@ -304,7 +304,7 @@ properties:
 
   containers.proxy.enable_unproxied_port_mappings:
     default: true
-    description: "EXPERIMENTAL: whether the cell should still map host ports directly to the unproxied container ports. Setting to false requires containers.proxy.enabled to be set to true."
+    description: "EXPERIMENTAL: whether the cell should still map host ports directly to the unproxied container ports. 
 
   containers.trusted_ca_certificates:
     description: "List of PEM-encoded CA certificates to make available inside containers in a conventional location. List entries may be individual or concatenated CAs."

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -264,9 +264,6 @@ properties:
     description: "time in seconds between signalling a container to shutdown gracefully and stopping it forcefully. Should not be less than 10."
     default: 10
 
-  containers.proxy.enabled:
-    description: "EXPERIMENTAL: Enable envoy proxy on garden containers. Currently doesn't work on windows cells but left here for compatability with the linux Rep"
-    default: false
   containers.proxy.additional_memory_allocation_mb:
     description: "EXPERIMENTAL: Additional memory allocated to each container for the envoy proxy. This must not be negative. Currently doesn't work on windows cells but left here for compatability with the linux Rep"
     default: 32

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -203,8 +203,8 @@
 
   if_p("diego.executor.instance_identity_ca_cert",
        "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |cert, key, validity_period|
-    if !(cert.empty? || key.empty? || validity_period < 1)
+       "diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
+    if !(validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"
       config[:instance_identity_cred_dir] = instance_identity_dir

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -59,6 +59,7 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: p("declarative_healthcheck_path"),
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
+    enable_container_proxy: "true",
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
@@ -191,7 +192,7 @@
       p("diego.executor.instance_identity_ca_cert")
       p("diego.executor.instance_identity_key")
   rescue
-      raise '"when containers.proxy.enabled is true, diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
+      raise '"diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
   end
 
   if config[:container_proxy_require_and_verify_client_certs]
@@ -201,9 +202,7 @@
       end
   end
 
-  if_p("diego.executor.instance_identity_ca_cert",
-       "diego.executor.instance_identity_key",
-       "diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
+  if_p("diego.executor.instance_identity_validity_period_in_hours") do |validity_period|
     if !(validity_period < 1)
       config[:instance_identity_ca_path] = "#{conf_dir}/certs/rep/instance_identity.crt"
       config[:instance_identity_private_key_path] = "#{conf_dir}/certs/rep/instance_identity.key"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -59,7 +59,6 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: p("declarative_healthcheck_path"),
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
-    enable_container_proxy: p("containers.proxy.enabled"),
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -187,15 +187,11 @@
 
   config[:bbs_address] = "https://#{p("diego.rep.bbs.api_location")}"
 
-  if config[:enable_container_proxy]
-    begin
+  begin
       p("diego.executor.instance_identity_ca_cert")
       p("diego.executor.instance_identity_key")
-    rescue
+  rescue
       raise '"when containers.proxy.enabled is true, diego.executor.instance_identity_ca_cert" and "diego.executor.instance_identity_key" must both be set'
-    end
-  elsif !p("containers.proxy.enable_unproxied_port_mappings")
-    raise 'containers.proxy.enabled must be set to true in order to disable the unproxied port mappings'
   end
 
   if config[:container_proxy_require_and_verify_client_certs]

--- a/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
@@ -351,7 +351,6 @@ var _ = Describe("InstanceIdentity", func() {
 		BeforeEach(func() {
 
 			enableContainerProxy = func(config *config.RepConfig) {
-				config.EnableContainerProxy = true
 				config.EnvoyConfigRefreshDelay = durationjson.Duration(time.Second)
 				config.ContainerProxyPath = filepath.Dir(os.Getenv("PROXY_BINARY"))
 

--- a/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
@@ -351,6 +351,7 @@ var _ = Describe("InstanceIdentity", func() {
 		BeforeEach(func() {
 
 			enableContainerProxy = func(config *config.RepConfig) {
+				config.EnableContainerProxy = true
 				config.EnvoyConfigRefreshDelay = durationjson.Duration(time.Second)
 				config.ContainerProxyPath = filepath.Dir(os.Getenv("PROXY_BINARY"))
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: proxy.enabled - Diego release

Backward Compatibility
---------------
Breaking Change? **Yes**

removing rep and executor related changes as the property is still valid to support the apps with no route.

Test results:
```
~/workspace/diego-release |TNZ-46997 ↑·1 ✔| 
$ ./scripts/test-in-docker.bash 
Succeeded
go-1.24.6: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:143a25c52407804ec1e05e0668fe859ccd99339d5d62a3152bde59fd6478f1f1
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:go-1.24.6
docker.io/cloudfoundry/tas-runtime-mysql-8.0:go-1.24.6
diego-release-mysql-docker-container
c70958959fb6a808b2902a02c1142810569e486c106f3e06d208d5f682ae2059
go version go1.24.6 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-Agtn /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching ast 2.4.2
Fetching semi_semantic 1.2.0
Installing semi_semantic 1.2.0
Installing ast 2.4.2
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
..........................

Finished in 0.16801 seconds (files took 0.12754 seconds to load)
26 examples, 0 failures

Running ./ci/diego-release/linters/sync-package-specs.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/sync-submodule-config.bash for-diego-release with-exit-on-error=true
syncing src/idmapper
syncing src/code.cloudfoundry.org/cacheddownloader
syncing src/code.cloudfoundry.org/rep
syncing src/code.cloudfoundry.org/routing-api
syncing src/code.cloudfoundry.org/vendor
syncing src/garden
syncing src/code.cloudfoundry.org/buildpackapplifecycle
syncing src/guardian
syncing src/grootfs
syncing src/code.cloudfoundry.org/credhub-cli
syncing src/code.cloudfoundry.org/executor
syncing src/code.cloudfoundry.org/routing-info
syncing src/cnbapplifecycle
syncing src/code.cloudfoundry.org/bbs
syncing src/code.cloudfoundry.org/locket
Running ./ci/shared/linters/match-golang-os-package-versions.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-envoy-versions.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-for-windows-drift.bash for-diego-release with-exit-on-error=true
Running ./ci/diego-release/linters/check-proto-files.bash for-diego-release with-exit-on-error=true
/tmp/X0Ck-linter-tmp-dir //repo /
--2025-09-22 15:20:28--  https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip
Resolving github.com (github.com)... 140.82.116.3
Connecting to github.com (github.com)|140.82.116.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://release-assets.githubusercontent.com/github-production-release-asset/23357588/20feda00-fa3e-11e9-8e4c-5992b7e6e7c8?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-09-22T16%3A08%3A09Z&rscd=attachment%3B+filename%3Dprotoc-3.10.1-linux-x86_64.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-09-22T15%3A07%3A30Z&ske=2025-09-22T16%3A08%3A09Z&sks=b&skv=2018-11-09&sig=yvRDxv2eIEd3JxaIbaa0v0L9Lj%2FK%2FH6jRBmDeNDE1S0%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc1ODU1NDcyOSwibmJmIjoxNzU4NTU0NDI5LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.8_AvmSLSPoCpskEpP0ircJqYEzQOV9CZMyxop-bmTG4&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.10.1-linux-x86_64.zip&response-content-type=application%2Foctet-stream [following]
--2025-09-22 15:20:28--  https://release-assets.githubusercontent.com/github-production-release-asset/23357588/20feda00-fa3e-11e9-8e4c-5992b7e6e7c8?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-09-22T16%3A08%3A09Z&rscd=attachment%3B+filename%3Dprotoc-3.10.1-linux-x86_64.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-09-22T15%3A07%3A30Z&ske=2025-09-22T16%3A08%3A09Z&sks=b&skv=2018-11-09&sig=yvRDxv2eIEd3JxaIbaa0v0L9Lj%2FK%2FH6jRBmDeNDE1S0%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc1ODU1NDcyOSwibmJmIjoxNzU4NTU0NDI5LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.8_AvmSLSPoCpskEpP0ircJqYEzQOV9CZMyxop-bmTG4&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.10.1-linux-x86_64.zip&response-content-type=application%2Foctet-stream
Resolving release-assets.githubusercontent.com (release-assets.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to release-assets.githubusercontent.com (release-assets.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1575480 (1.5M) [application/octet-stream]
Saving to: 'protoc-3.10.1-linux-x86_64.zip'

     0K .......... .......... .......... .......... ..........  3% 17.0M 0s
    50K .......... .......... .......... .......... ..........  6% 37.5M 0s
   100K .......... .......... .......... .......... ..........  9% 35.6M 0s
   150K .......... .......... .......... .......... .......... 12% 44.0M 0s
   200K .......... .......... .......... .......... .......... 16% 34.7M 0s
   250K .......... .......... .......... .......... .......... 19% 90.1M 0s
   300K .......... .......... .......... .......... .......... 22% 79.5M 0s
   350K .......... .......... .......... .......... .......... 25% 28.7M 0s
   400K .......... .......... .......... .......... .......... 29% 40.7M 0s
   450K .......... .......... .......... .......... .......... 32% 63.5M 0s
   500K .......... .......... .......... .......... .......... 35% 39.8M 0s
   550K .......... .......... .......... .......... .......... 38% 60.0M 0s
   600K .......... .......... .......... .......... .......... 42% 31.8M 0s
   650K .......... .......... .......... .......... .......... 45% 78.2M 0s
   700K .......... .......... .......... .......... .......... 48% 29.5M 0s
   750K .......... .......... .......... .......... .......... 51% 24.4M 0s
   800K .......... .......... .......... .......... .......... 55% 69.9M 0s
   850K .......... .......... .......... .......... .......... 58% 25.1M 0s
   900K .......... .......... .......... .......... .......... 61% 48.9M 0s
   950K .......... .......... .......... .......... .......... 64% 53.9M 0s
  1000K .......... .......... .......... .......... .......... 68% 64.7M 0s
  1050K .......... .......... .......... .......... .......... 71% 39.0M 0s
  1100K .......... .......... .......... .......... .......... 74% 40.7M 0s
  1150K .......... .......... .......... .......... .......... 77% 48.5M 0s
  1200K .......... .......... .......... .......... .......... 81% 27.6M 0s
  1250K .......... .......... .......... .......... .......... 84% 98.6M 0s
  1300K .......... .......... .......... .......... .......... 87% 35.0M 0s
  1350K .......... .......... .......... .......... .......... 90% 72.1M 0s
  1400K .......... .......... .......... .......... .......... 94% 27.0M 0s
  1450K .......... .......... .......... .......... .......... 97%  132M 0s
  1500K .......... .......... .......... ........             100%  352M=0.04s

2025-09-22 15:20:28 (41.6 MB/s) - 'protoc-3.10.1-linux-x86_64.zip' saved [1575480/1575480]

Archive:  protoc-3.10.1-linux-x86_64.zip
   creating: protoc/include/
   creating: protoc/include/google/
   creating: protoc/include/google/protobuf/
  inflating: protoc/include/google/protobuf/type.proto  
  inflating: protoc/include/google/protobuf/duration.proto  
  inflating: protoc/include/google/protobuf/empty.proto  
  inflating: protoc/include/google/protobuf/wrappers.proto  
  inflating: protoc/include/google/protobuf/field_mask.proto  
   creating: protoc/include/google/protobuf/compiler/
  inflating: protoc/include/google/protobuf/compiler/plugin.proto  
  inflating: protoc/include/google/protobuf/struct.proto  
  inflating: protoc/include/google/protobuf/any.proto  
  inflating: protoc/include/google/protobuf/descriptor.proto  
  inflating: protoc/include/google/protobuf/source_context.proto  
  inflating: protoc/include/google/protobuf/timestamp.proto  
  inflating: protoc/include/google/protobuf/api.proto  
   creating: protoc/bin/
  inflating: protoc/bin/protoc       
  inflating: protoc/readme.txt       
//repo /
/repo/src/code.cloudfoundry.org/bbs/models /repo/src/code.cloudfoundry.org/bbs/models
/repo/src/code.cloudfoundry.org/bbs/models
/repo/src/code.cloudfoundry.org/locket/models /repo/src/code.cloudfoundry.org/locket/models
/repo/src/code.cloudfoundry.org/locket/models
Running ./ci/diego-release/linters/check-metrics-documentation.bash for-diego-release with-exit-on-error=true
Running ./ci/shared/linters/check-expiring-certs.bash for-diego-release with-exit-on-error=true
Checking for expiring certs...
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/auction
go version go1.24.6 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/auction
Verifying: verify_govet repo/src/code.cloudfoundry.org/auction
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/auction
booting mysql.............connection established to mysql
2025/09/22 15:22:01 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
[1758554521] Auctionrunner Suite - 103/103 spec
```
