### PR TITLE
set cell suite test case timeout to 30 s

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/cell_suite_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/cell_suite_test.go
@@ -31,6 +31,9 @@ import (
 	"code.cloudfoundry.org/inigo/world"
 )
 
+const cellSuiteEventuallyTestTimeout = 30 * time.Second
+const cellSuiteEventuallyPollingTimeout = 1 * time.Second
+
 var (
 	componentMaker world.ComponentMaker
 

--- a/src/code.cloudfoundry.org/inigo/cell/converger_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/converger_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 					It("eventually brings it up", func() {
 						Eventually(runningLRPsPoller).Should(HaveLen(1))
-						Eventually(helloWorldInstancePoller).Should(Equal([]string{"0"}))
+						Eventually(helloWorldInstancePoller, cellSuiteEventuallyTestTimeout, cellSuiteEventuallyPollingTimeout).Should(Equal([]string{"0"}))
 					})
 				})
 			})

--- a/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/instance_identity_test.go
@@ -429,7 +429,10 @@ var _ = Describe("InstanceIdentity", func() {
 			JustBeforeEach(func() {
 				err := bbsClient.DesireLRP(lgr, "", lrp)
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGUID, nil)).Should(Equal(models.ActualLRPStateRunning))
+				Eventually(func() func() string {
+					return helpers.LRPStatePoller(lgr, bbsClient, processGUID, nil)
+				},
+					cellSuiteEventuallyTestTimeout, cellSuiteEventuallyPollingTimeout).Should(Equal(models.ActualLRPStateRunning))
 
 				address = getContainerInternalAddress(bbsClient, processGUID, 8080, true)
 			})

--- a/src/code.cloudfoundry.org/inigo/cell/ssh_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/ssh_test.go
@@ -174,9 +174,9 @@ var _ = Describe("SSH", func() {
 			return lrps
 		}).Should(HaveLen(2))
 
-		Eventually(
-			helpers.LRPInstanceStatePoller(logger, bbsClient, processGuid, 0, nil),
-		).Should(Equal(models.ActualLRPStateRunning))
+		Eventually(func() func() string {
+			return helpers.LRPInstanceStatePoller(logger, bbsClient, processGuid, 0, nil)
+		}, cellSuiteEventuallyTestTimeout, cellSuiteEventuallyPollingTimeout).Should(Equal(models.ActualLRPStateRunning))
 
 		Eventually(
 			helpers.LRPInstanceStatePoller(logger, bbsClient, processGuid, 1, nil),


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
certain test cases fails at the eventually block with default 60s. Hence increasing default to 120s.
https://ci.funtime.lol/teams/wg-arp-diego/pipelines/diego-release/jobs/inigo-mysql-linux/builds/543


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
