### PR TITLE
Set healthcheck pool to 1 to avoid race conditions in inigo

### DIFF
--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -1567,7 +1567,7 @@ func (maker v1ComponentMaker) RepN(n int, modifyConfigFuncs ...func(*repconfig.R
 			DeleteWorkPoolSize:                   32,
 			ReadWorkPoolSize:                     64,
 			MetricsWorkPoolSize:                  8,
-			HealthCheckWorkPoolSize:              64,
+			HealthCheckWorkPoolSize:              1,
 			MaxConcurrentDownloads:               5,
 			GardenHealthcheckInterval:            durationjson.Duration(10 * time.Minute),
 			GardenHealthcheckEmissionInterval:    durationjson.Duration(30 * time.Second),


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Set healthcheck pool to 1 to avoid race conditions in inigo


Backward Compatibility
---------------
Breaking Change? **No**
