### PR TITLE
fix(`cfdot`): adjust broken link to documentation

### DIFF
--- a/docs/040-cfdot-setup.md
+++ b/docs/040-cfdot-setup.md
@@ -12,4 +12,4 @@ The BOSH release for Diego contains a `cfdot` job template that deploys `cfdot` 
 
 1. Run `source /var/vcap/jobs/cfdot/bin/setup` to add the `cfdot` and `jq` executables to your PATH as well as to set environment variables for communication to the BBS API server.
 
-See the [`cfdot` documentation](https://github.com/cloudfoundry/cfdot) for more information on how to use the tool or run `cfdot --help` to show usage.
+See the [`cfdot` documentation](/src/code.cloudfoundry.org/cfdot/docs) for more information on how to use the tool or run `cfdot --help` to show usage.


### PR DESCRIPTION
# Problem
The `cfdot` documentation link is still pointing to the archived repo https://github.com/cloudfoundry/cfdot 

# Solution
Fix link to point to the `docs` folder of `cfdot` in this repo here.