### PR TITLE
Clean up inigo test suite directory after all nodes have completed

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/cell_suite_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/cell_suite_test.go
@@ -112,11 +112,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	componentMaker.Setup()
 })
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
 	if componentMaker != nil {
 		componentMaker.Teardown()
 	}
-
+}, func() {
 	os.RemoveAll(suiteTempDir)
 })
 

--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -1567,7 +1567,7 @@ func (maker v1ComponentMaker) RepN(n int, modifyConfigFuncs ...func(*repconfig.R
 			DeleteWorkPoolSize:                   32,
 			ReadWorkPoolSize:                     64,
 			MetricsWorkPoolSize:                  8,
-			HealthCheckWorkPoolSize:              1,
+			HealthCheckWorkPoolSize:              64,
 			MaxConcurrentDownloads:               5,
 			GardenHealthcheckInterval:            durationjson.Duration(10 * time.Minute),
 			GardenHealthcheckEmissionInterval:    durationjson.Duration(30 * time.Second),


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Clean up inigo test suite directory after all nodes have completed


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
