### PR TITLE
Fix enable_container_proxy boolean value

### DIFF
--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -59,7 +59,7 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: "/var/vcap/packages/healthcheck",
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
-    enable_container_proxy: "true",
+    enable_container_proxy: true,
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -59,7 +59,7 @@
     disk_mb: p("diego.executor.disk_capacity_mb").to_s,
     declarative_healthcheck_path: p("declarative_healthcheck_path"),
     enable_healthcheck_metrics: p("enable_healthcheck_metrics"),
-    enable_container_proxy: "true",
+    enable_container_proxy: true,
     container_proxy_require_and_verify_client_certs: p("containers.proxy.require_and_verify_client_certificates"),
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes: json: cannot unmarshal string into Go struct field RepConfig.ExecutorConfig.enable_container_proxy of type bool

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
