### PR TITLE
Configurable db connection timeout settings

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -103,13 +103,13 @@ properties:
     default: 200
   diego.bbs.sql.connection_timeout: 
     description: "Timeout in seconds for a db client to wait for a connection to be established."
-    default: 600
+    default: "30s"
   diego.bbs.sql.read_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be received from the server."
-    default: 600
+    default: "600s"
   diego.bbs.sql.write_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be sent to the server."
-    default: 600
+    default: "600s"
   diego.bbs.sql.require_ssl:
     description: "Whether to require SSL for BBS communication to the SQL backend"
     default: false

--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -101,6 +101,15 @@ properties:
   diego.bbs.sql.max_idle_connections:
     description: "Maximum number of idle connections to the SQL database"
     default: 200
+  diego.bbs.sql.connection_timeout: 
+    description: "Timeout in seconds for a db client to wait for a connection to be established."
+    default: 600
+  diego.bbs.sql.read_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be received from the server."
+    default: 600
+  diego.bbs.sql.write_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be sent to the server."
+    default: 600
   diego.bbs.sql.require_ssl:
     description: "Whether to require SSL for BBS communication to the SQL backend"
     default: false

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -122,6 +122,18 @@
     config[:max_idle_database_connections] = value
   end
 
+  if_p("diego.bbs.sql.connection_timeout") do |value|
+    config[:db_connection_timeout] = value
+  end
+
+  if_p("diego.bbs.sql.read_timeout") do |value|
+    config[:db_read_timeout] = value
+  end
+
+  if_p("diego.bbs.sql.write_timeout") do |value|
+    config[:db_write_timeout] = value
+  end
+
   if_p("diego.bbs.sql.db_driver") do |value|
     config[:database_driver] = value
   end

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -92,6 +92,25 @@ describe 'bbs' do
       end
     end
 
+    describe 'Database timeout configurations' do 
+      it 'includes db timeout settings when specified' do 
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45s' 
+        rendered_template_json = JSON.parse(rendered_template) 
+        expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
+        expect(rendered_template_json['db_read_timeout']).to eq('60s') 
+        expect(rendered_template_json['db_write_timeout']).to eq('45s') 
+      end
+
+      it 'uses default timeout values when not specified' do 
+        rendered_template_json = JSON.parse(rendered_template) 
+        expect(rendered_template_json['db_connection_timeout']).to be_nil 
+        expect(rendered_template_json['db_read_timeout']).to be_nil 
+        expect(rendered_template_json['db_write_timeout']).to be_nil 
+      end 
+    end 
+
     describe 'Advanced Metrics' do
       it 'check if bbs.json doesn\'t include \'advanced_metrics\' on \'enabled\' value equal to false' do
         # if diego.bbs.metrics.advanced_metrics misses diego.bbs.metrics.advanced_metrics.enabled defaults to false

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -94,9 +94,9 @@ describe 'bbs' do
 
     describe 'Database timeout configurations' do 
       it 'includes db timeout settings when specified' do 
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30s' 
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60s' 
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['connection_timeout'] = '30s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['read_timeout'] = '60s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['write_timeout'] = '45s' 
         rendered_template_json = JSON.parse(rendered_template) 
         expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
         expect(rendered_template_json['db_read_timeout']).to eq('60s') 
@@ -105,9 +105,9 @@ describe 'bbs' do
 
       it 'uses default timeout values when not specified' do 
         rendered_template_json = JSON.parse(rendered_template) 
-        expect(rendered_template_json['db_connection_timeout']).to be_nil 
-        expect(rendered_template_json['db_read_timeout']).to be_nil 
-        expect(rendered_template_json['db_write_timeout']).to be_nil 
+        expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
+        expect(rendered_template_json['db_read_timeout']).to eq('600s') 
+        expect(rendered_template_json['db_write_timeout']).to eq('600s')  
       end 
     end 
 

--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -483,8 +483,13 @@ func (maker commonComponentMaker) SQL(argv ...string) ifrit.Runner {
 		defer GinkgoRecover()
 
 		logger := lagertest.NewTestLogger("component-maker")
-
-		db, err := helpers.Connect(logger, maker.dbDriverName, maker.dbBaseConnectionString, "", false)
+		dbParams := &helpers.BBSDBParam{
+			DriverName:                    maker.dbDriverName,
+			DatabaseConnectionString:      maker.dbBaseConnectionString,
+			SqlCACertFile:                 "",
+			SqlEnableIdentityVerification: false,
+		}
+		db, err := helpers.Connect(logger, dbParams)
 		Expect(err).NotTo(HaveOccurred())
 		defer db.Close()
 
@@ -497,7 +502,8 @@ func (maker commonComponentMaker) SQL(argv ...string) ifrit.Runner {
 		Expect(err).NotTo(HaveOccurred())
 
 		dbWithDatabaseNameConnectionString := fmt.Sprintf("%s%s", maker.dbBaseConnectionString, sqlDBName)
-		db, err = helpers.Connect(logger, maker.dbDriverName, dbWithDatabaseNameConnectionString, "", false)
+		dbParams.DatabaseConnectionString = dbWithDatabaseNameConnectionString
+		db, err = helpers.Connect(logger, dbParams)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(db.Ping).Should(Succeed())
 
@@ -506,7 +512,7 @@ func (maker commonComponentMaker) SQL(argv ...string) ifrit.Runner {
 		close(ready)
 
 		<-signals
-		db, err = helpers.Connect(logger, maker.dbDriverName, maker.dbBaseConnectionString, "", false)
+		db, err = helpers.Connect(logger, dbParams)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(db.Ping).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Configurable db connection timeout settings

https://github.com/cloudfoundry/bbs/pull/122


Template tests:
```
~/workspace/diego-release |TNZ-60737-1 U:8?:1| 
$ ./scripts/test-in-docker.bash bbs
Succeeded
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:b0fe8a374283af4b3d8d225ccd32a4e50fb58234a4572a25438985b13ed06084
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
diego-release-mysql-docker-container
d0c6c07b3d3653729574545daf922f3fc3921701f8abd2b5c1a70ae5848fca22
go version go1.25.2 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-884B /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching ast 2.4.2
Fetching semi_semantic 1.2.0
Installing ast 2.4.2
Installing semi_semantic 1.2.0
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
............................

Finished in 0.1857 seconds (files took 0.13669 seconds to load)
28 examples, 0 failures

```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
