### PR TITLE
deprecate aws sdk v1 modules

### DIFF
--- a/src/code.cloudfoundry.org/ecrhelper/ecrhelper.go
+++ b/src/code.cloudfoundry.org/ecrhelper/ecrhelper.go
@@ -1,17 +1,17 @@
 package ecrhelper
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"                    //lint:ignore SA1019 - need tot bump to aws-sdk-go-v2
-	"github.com/aws/aws-sdk-go/aws/credentials"        //lint:ignore SA1019 - need tot bump to aws-sdk-go-v2
-	"github.com/aws/aws-sdk-go/aws/endpoints"          //lint:ignore SA1019 - need tot bump to aws-sdk-go-v2
-	awssession "github.com/aws/aws-sdk-go/aws/session" //lint:ignore SA1019 - need tot bump to aws-sdk-go-v2
-	"github.com/aws/aws-sdk-go/service/ecr"            //lint:ignore SA1019 - need tot bump to aws-sdk-go-v2
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrapi "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 )
 
@@ -53,30 +53,19 @@ func (h ecrHelper) GetECRCredentials(registryURL string, username string, passwo
 	if err != nil {
 		return "", "", err
 	}
-
-	awsSession, err := awssession.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(username, password, ""),
-	})
+	cfg, err := config.LoadDefaultConfig(
+		context.TODO(), config.WithRegion(registry.Region),
+		config.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(username, password, "")),
+	)
 	if err != nil {
 		return "", "", err
 	}
 
-	awsConfig := &aws.Config{Region: aws.String(registry.Region)}
-	if registry.FIPS {
-		resolver := endpoints.DefaultResolver()
-		endpoint, err := resolver.EndpointFor("ecr-fips", registry.Region, func(opts *endpoints.Options) {
-			opts.ResolveUnknownService = true
-		})
-		if err != nil {
-			return "", "", err
-		}
-		awsConfig = awsConfig.WithEndpoint(endpoint.URL)
-	}
-
-	ecrClient := ecr.New(awsSession, awsConfig)
+	ecrClient := ecr.NewFromConfig(cfg)
 
 	input := &ecr.GetAuthorizationTokenInput{}
-	output, err := ecrClient.GetAuthorizationToken(input)
+	output, err := ecrClient.GetAuthorizationToken(context.TODO(), input)
 	if err != nil {
 		return "", "", err
 	}
@@ -86,8 +75,8 @@ func (h ecrHelper) GetECRCredentials(registryURL string, username string, passwo
 
 	for _, authData := range output.AuthorizationData {
 		if authData.ProxyEndpoint != nil && authData.AuthorizationToken != nil {
-			token := aws.StringValue(authData.AuthorizationToken)
-			decodedToken, err := base64.StdEncoding.DecodeString(token)
+			token := authData.AuthorizationToken
+			decodedToken, err := base64.StdEncoding.DecodeString(*token)
 			if err != nil {
 				return "", "", err
 			}


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
deprecate aws sdk v1 modules in ecr helper
```
~/workspace/diego-release |TNZ-53529 U:12| 
$ docker exec -it a65 /bin/bash
root@a658f6f3c914:/# ./repo/scripts/docker/test.bash ecrhelper
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/ecrhelper
go version go1.25.3 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/ecrhelper
Verifying: verify_govet repo/src/code.cloudfoundry.org/ecrhelper
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/ecrhelper
booting mysql............connection established to mysql
Running Suite: Ecrhelper Suite - /repo/src/code.cloudfoundry.org/ecrhelper
==========================================================================
Random Seed: 1760976360 - will randomize all specs

Will run 5 of 5 specs
Running in parallel across 7 processes
••S•S

Ran 3 of 5 Specs in 0.056 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 2 Skipped


Ginkgo ran 1 suite in 56.955740542s
Test Suite Passed
root@a658f6f3c914:/# exit
exit

bosh: null | cf:  (tpcf-runtime-vm-karthick) 
~/workspace/diego-release |TNZ-53529 U:12| 
$ git log --oneline
7cb3fb25a (HEAD -> TNZ-53529, origin/TNZ-53529) deprecate aws sdk v1 modules
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
