### PR TITLE
rename configurable db timeout props

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -101,14 +101,14 @@ properties:
   diego.bbs.sql.max_idle_connections:
     description: "Maximum number of idle connections to the SQL database"
     default: 200
-  diego.bbs.sql.connection_timeout: 
-    description: "Timeout in seconds for a db client to wait for a connection to be established."
+  diego.bbs.sql.db_connection_timeout: 
+    description: "Timeout in seconds for a db client to wait for a connection to be established"
     default: "30s"
-  diego.bbs.sql.read_timeout: 
-    description: "Timeout in seconds for a db client to wait for data to be received from the server."
+  diego.bbs.sql.db_read_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be received from the server"
     default: "600s"
-  diego.bbs.sql.write_timeout: 
-    description: "Timeout in seconds for a db client to wait for data to be sent to the server."
+  diego.bbs.sql.db_write_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be sent to the server"
     default: "600s"
   diego.bbs.sql.require_ssl:
     description: "Whether to require SSL for BBS communication to the SQL backend"

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -122,15 +122,15 @@
     config[:max_idle_database_connections] = value
   end
 
-  if_p("diego.bbs.sql.connection_timeout") do |value|
+  if_p("diego.bbs.sql.db_connection_timeout") do |value|
     config[:db_connection_timeout] = value
   end
 
-  if_p("diego.bbs.sql.read_timeout") do |value|
+  if_p("diego.bbs.sql.db_read_timeout") do |value|
     config[:db_read_timeout] = value
   end
 
-  if_p("diego.bbs.sql.write_timeout") do |value|
+  if_p("diego.bbs.sql.db_write_timeout") do |value|
     config[:db_write_timeout] = value
   end
 

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -94,9 +94,9 @@ describe 'bbs' do
 
     describe 'Database timeout configurations' do 
       it 'includes db timeout settings when specified' do 
-        deployment_manifest_fragment['diego']['bbs']['sql']['connection_timeout'] = '30s' 
-        deployment_manifest_fragment['diego']['bbs']['sql']['read_timeout'] = '60s' 
-        deployment_manifest_fragment['diego']['bbs']['sql']['write_timeout'] = '45s' 
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30s'
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60s'
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45s'
         rendered_template_json = JSON.parse(rendered_template) 
         expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
         expect(rendered_template_json['db_read_timeout']).to eq('60s') 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
rename the connection timeout params to align with the tas job property names

https://github.gwd.broadcom.net/TNZ/tas/pull/5768 - tas changes for ref.

```
~/workspace/diego-release |bbs-db-tas-params U:6?:1| 
$ ./scripts/test-in-docker.bash rep
Succeeded
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-postgres
Digest: sha256:f64afc01a1e63b8c93d05cb820bb3739db6ed94c4f839b4c9e8e6787851259ab
Status: Image is up to date for cloudfoundry/tas-runtime-postgres:latest
docker.io/cloudfoundry/tas-runtime-postgres:latest
diego-release-postgres-docker-container
9e23b3d331a3d5495bc02a576af6b843fd3f94c5598e10e534169341d78517f5
go version go1.25.3 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-ITuo /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching ast 2.4.2
Fetching semi_semantic 1.2.0
Installing semi_semantic 1.2.0
Installing ast 2.4.2
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
............................

Finished in 0.15583 seconds (files took 0.11461 seconds to load)
28 examples, 0 failures


```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
