### PR TITLE
add time unit for db timeout params

### DIFF
--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -123,15 +123,15 @@
   end
 
   if_p("diego.bbs.sql.db_connection_timeout") do |value|
-    config[:db_connection_timeout] = value
+    config[:db_connection_timeout] = "#{value}s" # add time unit
   end
 
   if_p("diego.bbs.sql.db_read_timeout") do |value|
-    config[:db_read_timeout] = value
+    config[:db_read_timeout] = "#{value}s" # add time unit
   end
 
   if_p("diego.bbs.sql.db_write_timeout") do |value|
-    config[:db_write_timeout] = value
+    config[:db_write_timeout] = "#{value}s" # add time unit
   end
 
   if_p("diego.bbs.sql.db_driver") do |value|


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
add time unit for db timeout params


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
