### PR TITLE
add seconds as unit for timeout setting

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -103,13 +103,13 @@ properties:
     default: 200
   diego.bbs.sql.db_connection_timeout: 
     description: "Timeout in seconds for a db client to wait for a connection to be established"
-    default: "30s"
+    default: "30"
   diego.bbs.sql.db_read_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be received from the server"
-    default: "600s"
+    default: "600"
   diego.bbs.sql.db_write_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be sent to the server"
-    default: "600s"
+    default: "600"
   diego.bbs.sql.require_ssl:
     description: "Whether to require SSL for BBS communication to the SQL backend"
     default: false

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -94,9 +94,9 @@ describe 'bbs' do
 
     describe 'Database timeout configurations' do 
       it 'includes db timeout settings when specified' do 
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30s'
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60s'
-        deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45s'
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30'
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60'
+        deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45'
         rendered_template_json = JSON.parse(rendered_template) 
         expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
         expect(rendered_template_json['db_read_timeout']).to eq('60s') 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
add seconds as unit for timeout setting

```
~/workspace/diego-release |connection-timeunit U:7?:1| 
$ ./scripts/test-in-docker.bash rep
Succeeded
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:c237dd224deacf2d998e2c47110ef110a0556dddaee1d88fe6016de552cd4274
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
diego-release-mysql-docker-container
eb09ce00221df6768843e5e3aa9a933aecf673370c3ff4c163141e5b5228b3c9
go version go1.25.3 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-aINI /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching ast 2.4.2
Fetching semi_semantic 1.2.0
Installing ast 2.4.2
Installing semi_semantic 1.2.0
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
............................

Finished in 0.18572 seconds (files took 0.13184 seconds to load)
28 examples, 0 failures

```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
