### PR TITLE
locket - configurable db time out settings

### DIFF
--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -58,6 +58,15 @@ properties:
   diego.locket.sql.db_driver:
     description: "Database driver to use for SQL backend (for example: mysql,postgres)"
     default: mysql
+  diego.locket.sql.db_connection_timeout: 
+    description: "Timeout in seconds for a db client to wait for a connection to be established"
+    default: "30"
+  diego.locket.sql.db_read_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be received from the server"
+    default: "600"
+  diego.locket.sql.db_write_timeout: 
+    description: "Timeout in seconds for a db client to wait for data to be sent to the server"
+    default: "600"
   diego.locket.sql.require_ssl:
     description: "Whether to require SSL for Locket communication to the SQL backend"
     default: false

--- a/jobs/locket/templates/locket.json.erb
+++ b/jobs/locket/templates/locket.json.erb
@@ -66,6 +66,18 @@ if p("diego.locket.sql.require_ssl")
    config[:sql_enable_identity_verification] = p("database.tls.enable_identity_verification")
 end
 
+  if_p("diego.locket.sql.db_connection_timeout") do |value|
+    config[:db_connection_timeout] = "#{value}s" # add time unit
+  end
+
+  if_p("diego.locket.sql.db_read_timeout") do |value|
+    config[:db_read_timeout] = "#{value}s" # add time unit
+  end
+
+  if_p("diego.locket.sql.db_write_timeout") do |value|
+    config[:db_write_timeout] = "#{value}s" # add time unit
+  end
+
 config[:time_format] = "rfc3339"
 config[:loggregator]={}
 config[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
locket - configurable db time out settings


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
