### PR TITLE
add connection timeout to locket client

### DIFF
--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -1104,7 +1104,7 @@ func (maker commonComponentMaker) BBSServiceClient(logger lager.Logger) servicec
 	locketClient, err := locket.NewClient(logger, maker.locketClientConfig())
 	Expect(err).NotTo(HaveOccurred())
 
-	return serviceclient.NewServiceClient(locketClient)
+	return serviceclient.NewServiceClient(locketClient, time.Duration(30)*time.Second)
 }
 
 func (maker commonComponentMaker) BBSURL() string {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
add connection timeout to locket client


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
