### PR TITLE
Use 2s retry interval for BBS

### DIFF
--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -25,7 +25,7 @@
     communication_timeout: "10s",
     desired_lrp_creation_timeout: "1m",
     lock_ttl: "15s",
-    lock_retry_interval: "5s",
+    lock_retry_interval: "2s",
     report_interval: "1m",
     convergence_workers: 20,
     update_workers: 1000,


### PR DESCRIPTION
To be consistent with the value we used before

- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Since we switched to using configured values and not the hard coded values, we want to be consistent with values we used before.


Backward Compatibility
---------------
Breaking Change? **No**
