### PR TITLE
Add configuration plumbing for debug_lrp_start_heartbeats in bbs

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -59,6 +59,9 @@ properties:
   diego.bbs.log_level:
     description: "Log level"
     default: "info"
+  diego.bbs.debug_lrp_start_heartbeats:
+    description: "When this property is set to 'true', container heartbeat log messages are issued at a debug level, which reduces log volume. When this property is set to 'false', container heartbeat log messages issued at an info level."
+    default: false
   diego.bbs.enable_access_log:
     description: "Enable access log, i.e. log every request made to the bbs"
     default: false

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -34,6 +34,7 @@
     health_address: p("diego.bbs.health_addr"),
     rep_client_session_cache_size: p("diego.bbs.rep.client_session_cache_size"),
     log_level: p("diego.bbs.log_level"),
+    debug_lrp_start_heartbeats: p("diego.bbs.debug_lrp_start_heartbeats"),
     active_key_label: p("diego.bbs.active_key_label"),
     debug_address: p("diego.bbs.debug_addr"),
     cell_registrations_locket_enabled: p("cell_registrations.locket.enabled"),

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -91,24 +91,61 @@ describe 'bbs' do
       end
     end
 
-    describe 'Database timeout configurations' do 
-      it 'includes db timeout settings when specified' do 
+    describe 'Database timeout configurations' do
+      it 'includes db timeout settings when specified' do
         deployment_manifest_fragment['diego']['bbs']['sql']['db_connection_timeout'] = '30'
         deployment_manifest_fragment['diego']['bbs']['sql']['db_read_timeout'] = '60'
         deployment_manifest_fragment['diego']['bbs']['sql']['db_write_timeout'] = '45'
-        rendered_template_json = JSON.parse(rendered_template) 
-        expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
-        expect(rendered_template_json['db_read_timeout']).to eq('60s') 
-        expect(rendered_template_json['db_write_timeout']).to eq('45s') 
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_connection_timeout']).to eq('30s')
+        expect(rendered_template_json['db_read_timeout']).to eq('60s')
+        expect(rendered_template_json['db_write_timeout']).to eq('45s')
       end
 
-      it 'uses default timeout values when not specified' do 
-        rendered_template_json = JSON.parse(rendered_template) 
-        expect(rendered_template_json['db_connection_timeout']).to eq('30s') 
-        expect(rendered_template_json['db_read_timeout']).to eq('600s') 
-        expect(rendered_template_json['db_write_timeout']).to eq('600s')  
-      end 
-    end 
+      it 'uses default timeout values when not specified' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_connection_timeout']).to eq('30s')
+        expect(rendered_template_json['db_read_timeout']).to eq('600s')
+        expect(rendered_template_json['db_write_timeout']).to eq('600s')
+      end
+    end
+
+    describe 'logging' do
+      context 'log level' do
+        it 'sets the default log level' do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['log_level']).to eq('info')
+        end
+
+        context 'when log level is specified' do
+          before do
+            deployment_manifest_fragment['diego']['bbs']['log_level']= 'debug'
+          end
+          it do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['log_level']).to eq('debug')
+          end
+        end
+      end
+
+      context 'debug_lrp_start_heartbeats' do
+        it 'sets the debug_lrp_start_heartbeats off by default' do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['debug_lrp_start_heartbeats']).to be false
+        end
+
+        context 'when log level is specified' do
+          before do
+            deployment_manifest_fragment['diego']['bbs']['debug_lrp_start_heartbeats'] = true
+          end
+          it do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['debug_lrp_start_heartbeats']).to be true
+          end
+        end
+      end
+    end
+
 
     describe 'Advanced Metrics' do
       it 'check if bbs.json doesn\'t include \'advanced_metrics\' on \'enabled\' value equal to false' do


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Plumbs a bosh property for bbs's debug_lrp_start_heartbeats config. See https://github.com/cloudfoundry/bbs/pull/129


Backward Compatibility
---------------
Breaking Change? no