### PR TITLE
provide minimum conntrack value of 65k for BBS nodes regardless of memory

### DIFF
--- a/jobs/bbs/templates/set-bbs-kernel-params.erb
+++ b/jobs/bbs/templates/set-bbs-kernel-params.erb
@@ -19,3 +19,7 @@ echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
 echo "Not setting /proc/sys/ parameters"
 <% end %>
 
+# nf_conntrack_max
+# Sets this to 65535 (the default when using 2gb+ of memory), so that if a BBS node has <2gb of memory,
+# it does not suffer from severe networking slowness when BBS handles many apps/cells, but on limited memory.
+echo 65535 > /proc/sys/net/netfilter/nf_conntrack_max


### PR DESCRIPTION
- [z] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
On BBS nodes with <2GB of ram, conntrack maxes out at 7680 records by default. Bumping this to 64k allows it to handle more network connections when smaller memory is allocated to BBS VMs.

Backward Compatibility
---------------
Breaking Change? no