### PR TITLE
Add property to configure max lifetime of database connections for bbs

### DIFF
--- a/jobs/bbs/spec
+++ b/jobs/bbs/spec
@@ -101,6 +101,9 @@ properties:
   diego.bbs.sql.max_idle_connections:
     description: "Maximum number of idle connections to the SQL database"
     default: 200
+  diego.bbs.sql.max_connection_lifetime:
+    description: "Maximum lifetime of connections to the SQL database before connections are recreated"
+    default: 90
   diego.bbs.sql.db_connection_timeout: 
     description: "Timeout in seconds for a db client to wait for a connection to be established"
     default: "30"

--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -118,6 +118,8 @@
     config[:max_open_database_connections] = value
   end
 
+  config[:max_database_connection_lifetime] = "#{p("diego.bbs.sql.max_connection_lifetime")}s"
+
   if_p("diego.bbs.sql.max_idle_connections") do |value|
     config[:max_idle_database_connections] = value
   end

--- a/spec/bbs_template_spec.rb
+++ b/spec/bbs_template_spec.rb
@@ -110,6 +110,18 @@ describe 'bbs' do
       end 
     end 
 
+    describe 'database connection lifetime' do 
+      it 'sets the db connection lifetime when specified' do
+        deployment_manifest_fragment['diego']['bbs']['sql']['max_connection_lifetime'] = '10'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['max_database_connection_lifetime']).to eq('10s')
+      end
+      it 'sets the db connection lifetime when specified' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['max_database_connection_lifetime']).to eq('90s')
+      end
+    end
+
     describe 'Advanced Metrics' do
       it 'check if bbs.json doesn\'t include \'advanced_metrics\' on \'enabled\' value equal to false' do
         # if diego.bbs.metrics.advanced_metrics misses diego.bbs.metrics.advanced_metrics.enabled defaults to false


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds a bosh property to configure the new max db connection lifetime parameter added in https://github.com/cloudfoundry/bbs/pull/131

Backward Compatibility
---------------
Breaking Change? no