### PR TITLE
Retry failed auctioneer client calls 3x

### DIFF
--- a/src/code.cloudfoundry.org/auctioneer/client.go
+++ b/src/code.cloudfoundry.org/auctioneer/client.go
@@ -19,6 +19,8 @@ type Client interface {
 	RequestTaskAuctions(logger lager.Logger, traceID string, tasks []*TaskStartRequest) error
 }
 
+const ClientRetryCount = 3
+
 type auctioneerClient struct {
 	httpClient         *http.Client
 	insecureHTTPClient *http.Client
@@ -107,27 +109,44 @@ func (c *auctioneerClient) RequestTaskAuctions(logger lager.Logger, traceID stri
 }
 
 func (c *auctioneerClient) createRequest(logger lager.Logger, traceID string, route string, params rata.Params, payload []byte) (*http.Response, error) {
-	resp, err := c.doRequest(c.httpClient, traceID, false, route, params, payload)
+	resp, err := c.doRequest(logger, c.httpClient, traceID, false, route, params, payload)
 	if err != nil {
 		// Fall back to HTTP and try again if we do not require TLS
 		if !c.requireTLS && c.insecureHTTPClient != nil {
 			logger.Error("retrying-on-http", err)
-			return c.doRequest(c.insecureHTTPClient, traceID, true, route, params, payload)
+			return c.doRequest(logger, c.insecureHTTPClient, traceID, true, route, params, payload)
 		}
 	}
 	return resp, err
 }
 
-func (c *auctioneerClient) doRequest(client *http.Client, traceID string, useHttp bool, route string, params rata.Params, payload []byte) (*http.Response, error) {
-	req, err := c.reqGen.CreateRequest(route, params, bytes.NewBuffer(payload))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Vcap-Request-Id", traceID)
+func (c *auctioneerClient) doRequest(logger lager.Logger, client *http.Client, traceID string, useHttp bool, route string, params rata.Params, payload []byte) (*http.Response, error) {
+	logger = logger.Session("do-request")
+	var resp *http.Response
+	var err error
+	for attempts := range ClientRetryCount {
+		logger.Debug("creating-request", lager.Data{"attempt": attempts + 1, "request_name": route})
+		var req *http.Request
+		req, err = c.reqGen.CreateRequest(route, params, bytes.NewBuffer(payload))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Vcap-Request-Id", traceID)
 
-	if useHttp {
-		req.URL.Scheme = "http"
+		if useHttp {
+			req.URL.Scheme = "http"
+		}
+
+		logger.Debug("doing-request", lager.Data{"attempt": attempts + 1, "request_path": req.URL.Path})
+		resp, err = client.Do(req)
+		if err != nil {
+			logger.Error("failed-doing-request", err)
+			time.Sleep(500 * time.Millisecond)
+		} else {
+			logger.Debug("complete", lager.Data{"request_path": req.URL.Path})
+			break
+		}
 	}
-	return client.Do(req)
+	return resp, err
 }

--- a/src/code.cloudfoundry.org/auctioneer/client_test.go
+++ b/src/code.cloudfoundry.org/auctioneer/client_test.go
@@ -28,12 +28,13 @@ var _ = Describe("Auctioneer Client", func() {
 		BeforeEach(func() {
 			fakeAuctioneerServer = ghttp.NewServer()
 
-			fakeAuctioneerServer.AppendHandlers(ghttp.CombineHandlers(
+			reqHandler := ghttp.CombineHandlers(
 				func(rw http.ResponseWriter, r *http.Request) {
 					time.Sleep(2 * time.Second)
 				},
-				ghttp.RespondWith(http.StatusAccepted, nil),
-			))
+				ghttp.RespondWith(http.StatusAccepted, nil))
+
+			fakeAuctioneerServer.AppendHandlers(reqHandler, reqHandler, reqHandler)
 
 			dummyLogger = lagertest.NewTestLogger("client_test")
 		})
@@ -68,6 +69,15 @@ var _ = Describe("Auctioneer Client", func() {
 			err := c.RequestLRPAuctions(dummyLogger, traceID, []*auctioneer.LRPStartRequest{})
 			Expect(err.Error()).To(ContainSubstring(context.DeadlineExceeded.Error()))
 		})
+		Context("on failures", func() {
+			It("retries 3 times", func() {
+				c := auctioneer.NewClient(fakeAuctioneerServer.URL(), 1*time.Second)
+
+				err := c.RequestLRPAuctions(dummyLogger, traceID, []*auctioneer.LRPStartRequest{})
+				Expect(err.Error()).To(ContainSubstring(context.DeadlineExceeded.Error()))
+				Expect(fakeAuctioneerServer.ReceivedRequests()).To(HaveLen(3))
+			})
+		})
 	})
 
 	Describe("NewSecureClient", func() {
@@ -97,12 +107,14 @@ var _ = Describe("Auctioneer Client", func() {
 			fakeAuctioneerServer.HTTPTestServer.TLS = tlsConfig
 			fakeAuctioneerServer.HTTPTestServer.StartTLS()
 
-			fakeAuctioneerServer.AppendHandlers(ghttp.CombineHandlers(
-				func(rw http.ResponseWriter, r *http.Request) {
-					time.Sleep(2 * time.Second)
-				},
-				ghttp.RespondWith(http.StatusAccepted, nil),
-			))
+			reqHandler :=
+				ghttp.CombineHandlers(
+					func(rw http.ResponseWriter, r *http.Request) {
+						time.Sleep(2 * time.Second)
+					},
+					ghttp.RespondWith(http.StatusAccepted, nil))
+
+			fakeAuctioneerServer.AppendHandlers(reqHandler, reqHandler, reqHandler)
 
 			dummyLogger = lagertest.NewTestLogger("client_test")
 		})
@@ -149,6 +161,16 @@ var _ = Describe("Auctioneer Client", func() {
 			It("returns an error", func() {
 				_, err := auctioneer.NewSecureClient(fakeAuctioneerServer.URL(), caFile, certFile, keyFile, true, time.Second)
 				Expect(err.Error()).To(MatchRegexp("failed to load keypair.*"))
+			})
+		})
+		Context("on failures", func() {
+			It("retries 3 times", func() {
+				c, err := auctioneer.NewSecureClient(fakeAuctioneerServer.URL(), caFile, certFile, keyFile, true, time.Second)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = c.RequestLRPAuctions(dummyLogger, traceID, []*auctioneer.LRPStartRequest{})
+				Expect(err.Error()).To(ContainSubstring(context.DeadlineExceeded.Error()))
+				Expect(fakeAuctioneerServer.ReceivedRequests()).To(HaveLen(3))
 			})
 		})
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Provides 3 retries for http failures with auctioner clients to assist bbs in recovering from intermittent issues without requiring another round of convergence


Backward Compatibility
---------------
Breaking Change? no