### PR TITLE
add sidecar_rootfs option

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -52,7 +52,10 @@ properties:
   diego.rep.preloaded_rootfses:
     description: "Array of name:absolute_path pairs representing root filesystems preloaded onto the underlying garden"
   diego.rep.sidecar_rootfs_path:
-    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/var/vcap/packages/cflinuxfs4/rootfs.tar'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
+    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/var/vcap/packages/cflinuxfs4/rootfs.tar'). Must be one of the preloaded_rootfses paths. If provided, this value will take precidence over diego.rep.sidecar_rootfs. If this property is set to an empty string and diego.rep.sidecar_rootfs is set to an empty string, then rep will then select the first of the preloaded_rootfses."
+    default: ""
+  diego.rep.sidecar_rootfs:
+    description: "Name of the stack to use for sidecar processes. The rep will prefer stacks in the diego.rep.extra_root_fs_dir location over those provided via diego.rep.preloaded_rootfses. If diego.rep.sidecar_rootfs_path is provided, then this property is ignored.  If this property is set to an empty string and diego.rep.sidecar_rootfs_path is set to an empty string, then rep will then select the first of the preloaded_rootfses."
     default: ""
   diego.rep.extra_root_fs_dir:
     description: "dir to scan for extra rootfs to be loaded by rep"

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -98,6 +98,7 @@
     polling_interval: "#{p("diego.rep.polling_interval_in_seconds")}s",
     preloaded_root_fs: p("diego.rep.preloaded_rootfses"),
     sidecar_root_fs_path: p("diego.rep.sidecar_rootfs_path"),
+    sidecar_root_fs: p("diego.rep.sidecar_rootfs"),
     read_work_pool_size: p("diego.executor.read_work_pool_size"),
     skip_cert_verify: p("diego.ssl.skip_cert_verify"),
     supported_providers: p("diego.rep.rootfs_providers"),

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -46,7 +46,10 @@ properties:
     default:
       - windows2012R2:/tmp/windows2012R2
   diego.rep.sidecar_rootfs_path:
-    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/tmp/windows2012R2'). Must be one of the preloaded_rootfses paths. Leaving the default empty string is ok, as it will then select the first of he preloaded_rootfses"
+    description: "absolute_path representing the root filesystem used for sidecar processes (ie. '/tmp/windows2012R2'). Must be one of the preloaded_rootfses paths. If provided, this value will take precidence over diego.rep.sidecar_rootfs. If this property is set to an empty string and diego.rep.sidecar_rootfs is set to an empty string, then rep will then select the first of the preloaded_rootfses."
+    default: ""
+  diego.rep.sidecar_rootfs:
+    description: "Name of the stack to use for sidecar processes. The rep will prefer stacks in the diego.rep.extra_root_fs_dir location over those provided via diego.rep.preloaded_rootfses. If diego.rep.sidecar_rootfs_path is provided, then this property is ignored.  If this property is set to an empty string and diego.rep.sidecar_rootfs_path is set to an empty string, then rep will then select the first of the preloaded_rootfses."
     default: ""
   diego.rep.extra_root_fs_dir:
     description: "dir to scan for extra rootfs to be loaded by rep"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -98,6 +98,7 @@
     polling_interval: "#{p("diego.rep.polling_interval_in_seconds")}s",
     preloaded_root_fs: p("diego.rep.preloaded_rootfses"),
     sidecar_root_fs_path: p("diego.rep.sidecar_rootfs_path"),
+    sidecar_root_fs: p("diego.rep.sidecar_rootfs"),
     read_work_pool_size: p("diego.executor.read_work_pool_size"),
     skip_cert_verify: p("diego.ssl.skip_cert_verify"),
     supported_providers: p("diego.rep.rootfs_providers"),

--- a/spec/rep_windows_template_spec.rb
+++ b/spec/rep_windows_template_spec.rb
@@ -8,7 +8,7 @@ require 'bosh/template/test'
 describe 'rep' do
   let(:release_path) { File.join(File.dirname(__FILE__), '..') }
   let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
-  let(:job) { release.job('rep') }
+  let(:job) { release.job('rep_windows') }
 
   let(:deployment_manifest_fragment) do
     {
@@ -121,32 +121,6 @@ describe 'rep' do
       it 'is configurable' do
         deployment_manifest_fragment['diego']['rep']['sidecar_rootfs'] = 'cflinuxfs4'
         expect(JSON.parse(rendered_template)['sidecar_root_fs']).to eq('cflinuxfs4')
-      end
-    end
-  end
-
-  describe 'setup_mounted_data_dirs.erb' do
-    let(:template) { job.template('bin/setup_mounted_data_dirs') }
-   
-    context 'checks the max_containers value' do 
-      it 'raises an error if max_containers is <= 0' do
-        deployment_manifest_fragment['diego']['rep']['max_containers'] = -10
-        expect do 
-          rendered_template
-        end.to raise_error(/The max_containers prop should be a positive integer/)
-      end
-    end
-  end
-
-  describe 'volume_mounted_files.erb' do
-    let(:template) { job.template('bin/volume_mounted_files') }
-
-    context 'checks the max_containers value' do
-      it 'raises an error if max_containers is <= 0' do
-        deployment_manifest_fragment['diego']['rep']['max_containers'] = -10
-        expect do
-          rendered_template
-        end.to raise_error(/The max_containers prop should be a positive integer/)
       end
     end
   end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* this will allow the sidecar_rootfs to match on stacks name on either the preloaded dir or the extra dir
* the sidecar_rootfs_path will always take precidence for backwards compatibility
* Related PR: https://github.com/cloudfoundry/rep/pull/76


Backward Compatibility
---------------
Breaking Change? No
