### PR TITLE
Enable rfc3339 logging for routing-api when run in route-emitter tests

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/runners/routingapi.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/runners/routingapi.go
@@ -98,6 +98,7 @@ func (runner *RoutingAPIRunner) Run(signals <-chan os.Signal, ready chan<- struc
 		"-ip", "localhost",
 		"-config", runner.configPath,
 		"-logLevel=debug",
+		"-timeFormat=rfc3339",
 		"-devMode=" + strconv.FormatBool(runner.Config.DevMode),
 	}
 	r := ginkgomon.New(ginkgomon.Config{


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Better logs in test failures

Backward Compatibility
---------------
Breaking Change? no