### PR TITLE
Update route-emitter for new routing-api

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
@@ -480,8 +480,8 @@ var _ = Describe("Route Emitter", func() {
 			cfgs = append(cfgs, func(cfg *config.RouteEmitterConfig) {
 				cfg.EnableTCPEmitter = true
 			})
-			expectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 5222, "some-ip", 62003, -1, "", nil, 120, apimodels.ModificationTag{})
-			notExpectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 1883, "some-ip-1", 62003, -1, "", nil, 120, apimodels.ModificationTag{})
+			expectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 5222, "some-ip", 62003, -1, "", nil, 120, apimodels.ModificationTag{}, false, "")
+			notExpectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 1883, "some-ip-1", 62003, -1, "", nil, 120, apimodels.ModificationTag{}, false, "")
 			expectedTcpRouteMapping.RouterGroupGuid = routerGUID
 			notExpectedTcpRouteMapping.RouterGroupGuid = routerGUID
 			cellID = ""
@@ -718,7 +718,7 @@ var _ = Describe("Route Emitter", func() {
 							By("unblocking the sync loop")
 							close(blkChannel)
 
-							expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, -1, "", nil, 120, apimodels.ModificationTag{})
+							expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, -1, "", nil, 120, apimodels.ModificationTag{}, false, "")
 
 							Eventually(routingAPIClient.TcpRouteMappings, 5*time.Second).Should(
 								ContainElement(matchTCPRouteMapping(expectedTcpRouteMapping)),
@@ -952,7 +952,7 @@ var _ = Describe("Route Emitter", func() {
 						By("unblocking the sync loop")
 						close(blkChannel)
 
-						expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, -1, "", nil, 120, apimodels.ModificationTag{})
+						expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, -1, "", nil, 120, apimodels.ModificationTag{}, false, "")
 
 						Eventually(routingAPIClient.TcpRouteMappings, 5*time.Second).Should(
 							ContainElement(matchTCPRouteMapping(expectedTcpRouteMapping)),

--- a/src/code.cloudfoundry.org/route-emitter/emitter/routing_api_emitter_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/emitter/routing_api_emitter_test.go
@@ -38,11 +38,11 @@ var _ = Describe("RoutingAPIEmitter", func() {
 		routingAPIEmitter = emitter.NewRoutingAPIEmitter(logger, routingApiClient, uaaTokenFetcher, ttl)
 
 		routingEvents = routingtable.TCPRouteMappings{
-			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{})},
+			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{}, false, "")},
 		}
 
 		expectedRoutingEvents = routingtable.TCPRouteMappings{
-			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{})},
+			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{}, false, "")},
 		}
 
 		token := &oauth2.Token{
@@ -100,10 +100,10 @@ var _ = Describe("RoutingAPIEmitter", func() {
 			Context("and there are unregistration events", func() {
 				BeforeEach(func() {
 					routingEvents = routingtable.TCPRouteMappings{
-						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{})},
+						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{}, false, "")},
 					}
 					expectedRoutingEvents = routingtable.TCPRouteMappings{
-						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 60, apimodels.ModificationTag{})},
+						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 60, apimodels.ModificationTag{}, false, "")},
 					}
 				})
 
@@ -166,7 +166,7 @@ var _ = Describe("RoutingAPIEmitter", func() {
 			BeforeEach(func() {
 				routingApiClient.DeleteTcpRouteMappingsReturns(errors.New("unauthorized"))
 				routingEvents = routingtable.TCPRouteMappings{
-					Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{})},
+					Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{}, false, "")},
 				}
 			})
 

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
@@ -116,6 +116,8 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 		nil,
 		0,
 		tcpmodels.ModificationTag{},
+		false,
+		"",
 	)
 	if e.IsDirectInstanceRoute(directInstanceRoute) {
 		mapping = tcpmodels.NewTcpRouteMapping(
@@ -128,6 +130,8 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 			nil,
 			0,
 			tcpmodels.ModificationTag{},
+			false,
+			"",
 		)
 	}
 	return nil, &mapping, nil

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable_test.go
@@ -563,7 +563,7 @@ var _ = Describe("RoutingTable", func() {
 			Expect(messagesToEmit).To(MatchMessagesToEmit(expectedHTTP))
 
 			Expect(tcpRouteMappings.Unregistrations).Should(ConsistOf(
-				tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}),
+				tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 			))
 		})
 
@@ -626,7 +626,7 @@ var _ = Describe("RoutingTable", func() {
 						Expect(messagesToEmit).To(MatchMessagesToEmit(expectedHTTP))
 
 						Expect(tcpRouteMappings.Unregistrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 					})
 
@@ -644,7 +644,7 @@ var _ = Describe("RoutingTable", func() {
 						Expect(messagesToEmit).To(MatchMessagesToEmit(expectedHTTP))
 
 						Expect(tcpRouteMappings.Registrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 5222, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 					})
 				})
@@ -1167,8 +1167,8 @@ var _ = Describe("RoutingTable", func() {
 			It("returns only the external messages to emit", func() {
 				tcpRouteMappings, messagesToEmit = table.GetExternalRoutingEvents()
 				Expect(tcpRouteMappings.Registrations).Should(ConsistOf(
-					tcpmodels.NewTcpRouteMapping(logGuid, 9999, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}),
-					tcpmodels.NewTcpRouteMapping(logGuid, 9999, endpoint2.Host, uint16(endpoint2.Port), int(endpoint2.TlsProxyPort), "ig-2", nil, 0, tcpmodels.ModificationTag{}),
+					tcpmodels.NewTcpRouteMapping(logGuid, 9999, endpoint1.ContainerIP, uint16(endpoint1.ContainerPort), int(endpoint1.ContainerTlsProxyPort), "ig-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+					tcpmodels.NewTcpRouteMapping(logGuid, 9999, endpoint2.Host, uint16(endpoint2.Port), int(endpoint2.TlsProxyPort), "ig-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 				))
 
 				expected := routingtable.MessagesToEmit{

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
@@ -212,8 +212,8 @@ var _ = Describe("TCPRoutingTable", func() {
 				Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
 
 				Expect(routingEvents.Registrations).Should(ConsistOf(
-					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 				))
 			})
 
@@ -228,8 +228,8 @@ var _ = Describe("TCPRoutingTable", func() {
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "container-ip-1", 5222, 5443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "container-ip-2", 5222, 5443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "container-ip-1", 5222, 5443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "container-ip-2", 5222, 5443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 				})
 
@@ -247,7 +247,7 @@ var _ = Describe("TCPRoutingTable", func() {
 						Expect(routingTable.TCPAssociationsCount()).Should(Equal(1))
 
 						Expect(routingEvents.Registrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 					})
 				})
@@ -324,13 +324,13 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.SetRoutes(logger, nil, desiredLRP)
 
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
@@ -378,10 +378,10 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.SetRoutes(logger, nil, desiredLRP)
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingEvents.Unregistrations).Should(HaveLen(0))
 
@@ -444,17 +444,17 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.SetRoutes(logger, nil, desiredLRP)
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61003, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61003, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61003, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61003, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(4))
@@ -484,13 +484,13 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.SetRoutes(logger, nil, desiredLRP)
 
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-2", 62004, -1, "", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
@@ -546,12 +546,12 @@ var _ = Describe("TCPRoutingTable", func() {
 
 					// Two registration and one unregistration events
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61002, "some-ip-1", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
 				})
@@ -628,11 +628,11 @@ var _ = Describe("TCPRoutingTable", func() {
 						routingEvents, _ := routingTable.SetRoutes(logger, beforeLRP, afterLRP)
 
 						Expect(routingEvents.Registrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 
 						Expect(routingEvents.Unregistrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 					})
 				})
@@ -643,11 +643,11 @@ var _ = Describe("TCPRoutingTable", func() {
 						routingEvents, _ := routingTable.SetRoutes(logger, nil, afterLRP)
 
 						Expect(routingEvents.Registrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 
 						Expect(routingEvents.Unregistrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 
 						Expect(routingTable.TCPAssociationsCount()).Should(Equal(1))
@@ -723,7 +723,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							currentRoutesCount := routingTable.TCPAssociationsCount()
 							routingEvents, _ := routingTable.SetRoutes(logger, beforeLRP, afterLRP)
 							Expect(routingEvents.Registrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62006, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62006, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 
 							Expect(routingEvents.Unregistrations).To(HaveLen(0))
@@ -781,8 +781,8 @@ var _ = Describe("TCPRoutingTable", func() {
 
 							It("emits two registration events", func() {
 								Expect(routingEvents.Registrations).Should(ConsistOf(
-									tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-									tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62005, 62443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+									tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+									tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62005, 62443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 								))
 							})
 						})
@@ -814,7 +814,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							routingEvents, _ := routingTable.SetRoutes(logger, beforeLRP, afterLRP)
 
 							Expect(routingEvents.Registrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62006, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61001, "some-ip-1", 62006, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 							Expect(routingTable.TCPAssociationsCount()).Should(Equal(expectedRoutesCount))
 						})
@@ -832,7 +832,7 @@ var _ = Describe("TCPRoutingTable", func() {
 						afterLRP := getDesiredLRP("process-guid-1", "log-guid-1", newTcpRoutes, newModificationTag)
 						routingEvents, _ := routingTable.SetRoutes(logger, beforeLRP, afterLRP)
 						Expect(routingEvents.Unregistrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 					})
 
@@ -863,7 +863,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							afterLRP := getDesiredLRP("process-guid-1", "log-guid-1", newTcpRoutes, newModificationTag)
 							routingEvents, _ := routingTable.SetRoutes(logger, beforeLRP, afterLRP)
 							Expect(routingEvents.Unregistrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 						})
 
@@ -893,10 +893,10 @@ var _ = Describe("TCPRoutingTable", func() {
 							Expect(routingEvents.Unregistrations).To(HaveLen(1))
 
 							Expect(routingEvents.Registrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62006, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62006, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 							Expect(routingEvents.Unregistrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 						})
 					})
@@ -929,7 +929,7 @@ var _ = Describe("TCPRoutingTable", func() {
 					Expect(routingEvents.Unregistrations).To(HaveLen(1))
 
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 62000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 62000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(1))
 				})
@@ -981,7 +981,7 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.RemoveRoutes(logger, desiredLRP)
 					Expect(routingEvents.Unregistrations).To(HaveLen(1))
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61000, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61000, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(0))
 				})
@@ -1022,7 +1022,7 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.AddEndpoint(logger, actualLRP)
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61104, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61104, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(1))
 				})
@@ -1044,7 +1044,7 @@ var _ = Describe("TCPRoutingTable", func() {
 						actualLRP := getActualLRP("process-guid-1", "instance-guid-3", "some-ip-3", "container-ip-3", 61104, 5222, 61443, 5443, newTag)
 						routingEvents, _ := routingTable.AddEndpoint(logger, actualLRP)
 						Expect(routingEvents.Registrations).Should(ConsistOf(
-							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 61104, 61443, "instance-guid-3", nil, 0, tcpmodels.ModificationTag{}),
+							tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 61104, 61443, "instance-guid-3", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 						))
 						Expect(routingTable.TCPAssociationsCount()).Should(Equal(3))
 					})
@@ -1057,7 +1057,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							actualLRP := getActualLRP("process-guid-1", "instance-guid-1", "some-ip-1", "container-ip-1", 61105, 5222, 61443, 5443, newTag)
 							routingEvents, _ := routingTable.AddEndpoint(logger, actualLRP)
 							Expect(routingEvents.Registrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61105, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 61105, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 							Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
 						})
@@ -1080,11 +1080,11 @@ var _ = Describe("TCPRoutingTable", func() {
 							routingEvents, _ := routingTable.AddEndpoint(logger, newActualLRP)
 
 							Expect(routingEvents.Unregistrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 
 							Expect(routingEvents.Registrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 62443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 62443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 						})
 					})
@@ -1136,7 +1136,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							actualLRP := getActualLRP("process-guid-1", "instance-guid-1", "some-ip-1", "container-ip-1", 62004, 5222, 61443, 5443, newTag)
 							routingEvents, _ := routingTable.RemoveEndpoint(logger, actualLRP)
 							Expect(routingEvents.Unregistrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 
 							Expect(routingTable.TCPAssociationsCount()).Should(Equal(0))
@@ -1148,7 +1148,7 @@ var _ = Describe("TCPRoutingTable", func() {
 							actualLRP := getActualLRP("process-guid-1", "instance-guid-1", "some-ip-1", "container-ip-1", 62004, 5222, 61443, 5443, modificationTag)
 							routingEvents, _ := routingTable.RemoveEndpoint(logger, actualLRP)
 							Expect(routingEvents.Unregistrations).Should(ConsistOf(
-								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+								tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 							))
 							Expect(routingTable.TCPAssociationsCount()).Should(Equal(0))
 						})
@@ -1179,7 +1179,7 @@ var _ = Describe("TCPRoutingTable", func() {
 			It("returns routing events for entries in routing table", func() {
 				routingEvents, _ := routingTable.GetExternalRoutingEvents()
 				Expect(routingEvents.Registrations).Should(ConsistOf(
-					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
+					tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 				))
 				Expect(routingTable.TCPAssociationsCount()).Should(Equal(1))
 			})
@@ -1218,13 +1218,13 @@ var _ = Describe("TCPRoutingTable", func() {
 				It("overwrites the existing entries and emits registration and unregistration routing events", func() {
 					routingEvents, _ := routingTable.Swap(logger, tempRoutingTable, models.DomainSet{})
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-4", 63004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-4", 63004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 				})
 			})
@@ -1244,12 +1244,12 @@ var _ = Describe("TCPRoutingTable", func() {
 				It("overwrites the existing entries and emits registration and unregistration routing events", func() {
 					routingEvents, _ := routingTable.Swap(logger, tempRoutingTable, models.DomainSet{})
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-4", 63004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-3", 63004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-4", 63004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 
 					Expect(routingTable.TCPAssociationsCount()).Should(Equal(2))
@@ -1281,12 +1281,12 @@ var _ = Describe("TCPRoutingTable", func() {
 					routingEvents, _ := routingTable.Swap(logger, tempRoutingTable, domains)
 
 					Expect(routingEvents.Registrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("new-router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 					Expect(routingEvents.Unregistrations).Should(ConsistOf(
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}),
-						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-1", nil, 0, tcpmodels.ModificationTag{}, false, ""),
+						tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-2", 62004, 61443, "instance-guid-2", nil, 0, tcpmodels.ModificationTag{}, false, ""),
 					))
 				})
 			})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Updates route-emitter for routing-api updates, and bumps the routing-api module.

Backward Compatibility
---------------
Breaking Change? no