### PR TITLE
mock auctioneer http server to respond to bbs 

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_suite_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -46,7 +47,8 @@ var (
 	natsPort           uint16
 	healthCheckAddress string
 
-	oauthServer *ghttp.Server
+	oauthServer      *ghttp.Server
+	auctioneerServer *ghttp.Server
 
 	bbsPath      string
 	bbsURL       *url.URL
@@ -185,7 +187,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		},
 		ListenAddress:            bbsAddress,
 		AdvertiseURL:             bbsURL.String(),
-		AuctioneerAddress:        "http://some-address",
+		AuctioneerAddress:        "",
 		DatabaseDriver:           sqlRunner.DriverName(),
 		DatabaseConnectionString: sqlRunner.ConnectionString(),
 		HealthAddress:            bbsHealthAddress,
@@ -240,10 +242,22 @@ func startOAuthServer() *ghttp.Server {
 	return server
 }
 
+func startAuctioneerServer() *ghttp.Server {
+	server := ghttp.NewServer()
+	// Handle LRP auction requests
+	server.RouteToHandler("POST", "/v1/lrps", ghttp.RespondWith(http.StatusAccepted, nil))
+	// Handle task auction requests
+	server.RouteToHandler("POST", "/v1/tasks", ghttp.RespondWith(http.StatusAccepted, nil))
+	return server
+}
+
 var _ = BeforeEach(func() {
 	cfgs = nil
 	oauthServer = startOAuthServer()
+	auctioneerServer = startAuctioneerServer()
 	sqlProcess = ginkgomon.Invoke(sqlRunner)
+	// Wait for SQL database to be ready before starting locket
+	time.Sleep(200 * time.Millisecond)
 
 	fixturesPath := "fixtures"
 	var err error
@@ -271,9 +285,23 @@ var _ = BeforeEach(func() {
 	logger := lagertest.NewTestLogger("test")
 	logger.Debug(fmt.Sprintf("bbs locket address: %s", locketAddress))
 	locketProcess = ginkgomon.Invoke(locketRunner)
+	// Wait for locket to be ready before BBS tries to connect
+	// First check TCP connectivity
+	Eventually(func() error {
+		conn, err := net.DialTimeout("tcp", locketAddress, 100*time.Millisecond)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+	// Additional wait to ensure gRPC service is fully initialized
+	// The TCP check may pass before gRPC is ready
+	time.Sleep(500 * time.Millisecond)
 
 	bbsConfig.ClientLocketConfig = locketrunner.ClientLocketConfig()
 	bbsConfig.ClientLocketConfig.LocketAddress = locketAddress
+	bbsConfig.AuctioneerAddress = auctioneerServer.URL()
 	startBBS()
 
 	certDepot, err = os.MkdirTemp("", "")
@@ -316,6 +344,9 @@ var _ = AfterEach(func() {
 	ginkgomon.Kill(locketProcess)
 	Eventually(locketProcess.Wait()).Should(Receive())
 
+	if auctioneerServer != nil {
+		auctioneerServer.Close()
+	}
 	testIngressServer.Stop()
 	close(signalMetricsChan)
 

--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -340,6 +341,19 @@ var _ = Describe("Route Emitter", func() {
 
 		})
 		routingAPILocketProcess = ginkgomon.Invoke(routingAPILocketRunner)
+		// Wait for routing-api locket to be ready before routing-api tries to connect
+		// First check TCP connectivity
+		Eventually(func() error {
+			conn, err := net.DialTimeout("tcp", routingAPILocketAddress, 100*time.Millisecond)
+			if err != nil {
+				return err
+			}
+			conn.Close()
+			return nil
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+		// Additional wait to ensure gRPC service is fully initialized
+		// The TCP check may pass before gRPC is ready
+		time.Sleep(500 * time.Millisecond)
 		routingAPIPort := port + 2
 		routingAPIRunner, err = runners.NewRoutingAPIRunner(routingAPIPath, int(port+1), sqlConfig, func(cfg *runners.Config) {
 			cfg.API = routinapiconfig.APIConfig{
@@ -2287,7 +2301,7 @@ var _ = Describe("Route Emitter", func() {
 						}
 					}()
 
-					Eventually(registeredRoutes, 3*msgReceiveTimeout).Should(Receive(MatchRegistryMessage(routingtable.RegistryMessage{
+					expectedRoute1Message := routingtable.RegistryMessage{
 						Host:                 "1.2.3.4",
 						Port:                 65100,
 						TlsPort:              0,
@@ -2304,7 +2318,23 @@ var _ = Describe("Route Emitter", func() {
 							"some-tag":  "some-value",
 						},
 						AvailabilityZone: "some-zone",
-					})))
+					}
+
+					// Drain messages until we find route-1 with the new details
+					// We may receive route-2 messages first, so we need to keep reading
+					Eventually(func() bool {
+						select {
+						case msg := <-registeredRoutes:
+							matched, err := MatchRegistryMessage(expectedRoute1Message).Match(msg)
+							if err != nil {
+								return false
+							}
+							return matched
+						case <-time.After(100 * time.Millisecond):
+							// No message received, continue waiting
+							return false
+						}
+					}, 3*msgReceiveTimeout).Should(BeTrue())
 					done <- struct{}{}
 
 					Consistently(unregisteredRoutes, 3*msgReceiveTimeout).ShouldNot(Receive())


### PR DESCRIPTION
Summary:
----------
This PR addresses the failure of the `route-emitter-mysql-windows` unit tests in the diego-release pipeline runs. The failure was mainly due to the BBS retrying to connect to auctioneer and failing due to `dial tcp: lookup some-address: no such host`. This resulted in `StartActualLRP` not emitting the route-1 re-registration event causing the test failure. This PR adds a local `auctioneer` http server which responds to the BBS POST requests `/v1/lrps` and `/v1/tasks` with a HTTP 200. 

Also, added a check to wait for locket to be ready before BBS tries to connect, to avoid panic.

Failed log:
----------
[o]bbs] {"timestamp":"2025-12-03T05:50:32.602016800Z","level":"error","source":"bbs","message":"bbs.request.desire-lrp.start-instance-range.request-lrp-auctions.do-request.failed-doing-request","data":{"error":"Post \"[http://some-address/v1/lrps\](http://some-address/v1/lrps%5C)": dial tcp: lookup some-address: no such host","lower":0,"session":"48.1.3.2.1","upper":5}}

Backward Compatibility
------------------------
Breaking Change? No
