### PR TITLE
Configurable host key algorithms in ssh proxy/daemon 

### DIFF
--- a/jobs/ssh_proxy/spec
+++ b/jobs/ssh_proxy/spec
@@ -66,6 +66,8 @@ properties:
     description: "Comma separated list of allowed MAC algorithms"
   diego.ssh_proxy.allowed_keyexchanges:
     description: "Comma separated list of allowed key exchange algorithms"
+  diego.ssh_proxy.allowed_host_key_algorithms:
+    description: "Comma separated list of allowed host key algorithms"
   diego.ssh_proxy.debug_addr:
     description: "address at which to serve debug info"
     default: "127.0.0.1:17016"

--- a/jobs/ssh_proxy/templates/ssh_proxy.json.erb
+++ b/jobs/ssh_proxy/templates/ssh_proxy.json.erb
@@ -76,6 +76,9 @@
   if_p("diego.ssh_proxy.allowed_keyexchanges") do |value|
     config[:allowed_key_exchanges] = value
   end
+  if_p("diego.ssh_proxy.allowed_host_key_algorithms") do |value|
+    config[:allowed_host_key_algorithms] = value
+  end
   if_p("diego.ssh_proxy.bbs.client_session_cache_size") do |value|
     config[:bbs_client_session_cache_size] = value
   end

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/config/config.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/config/config.go
@@ -40,6 +40,7 @@ type SSHProxyConfig struct {
 	AllowedCiphers            string                `json:"allowed_ciphers"`
 	AllowedMACs               string                `json:"allowed_macs"`
 	AllowedKeyExchanges       string                `json:"allowed_key_exchanges"`
+	AllowedHostKeyAlgorithms  string                `json:"allowed_host_key_algorithms"`
 	LoggregatorConfig         loggingclient.Config  `json:"loggregator"`
 	CommunicationTimeout      durationjson.Duration `json:"communication_timeout,omitempty"`
 	IdleConnectionTimeout     durationjson.Duration `json:"idle_connection_timeout,omitempty"`

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/config/config_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/config/config_test.go
@@ -43,6 +43,7 @@ var _ = Describe("SSHProxyConfig", func() {
 			"allowed_ciphers": "cipher1,cipher2,cipher3",
 			"allowed_macs": "mac1,mac2,mac3",
 			"allowed_key_exchanges": "exchange1,exchange2,exchange3",
+			"allowed_host_key_algorithms": "hostkeyalg1,hostkeyalg2,hostkeyalg3",
 			"log_level": "debug",
 			"debug_address": "5.5.5.5:9090",
 			"connect_to_instance_address": true,
@@ -102,6 +103,7 @@ var _ = Describe("SSHProxyConfig", func() {
 				AllowedCiphers:            "cipher1,cipher2,cipher3",
 				AllowedMACs:               "mac1,mac2,mac3",
 				AllowedKeyExchanges:       "exchange1,exchange2,exchange3",
+				AllowedHostKeyAlgorithms:  "hostkeyalg1,hostkeyalg2,hostkeyalg3",
 				ConnectToInstanceAddress:  true,
 				IdleConnectionTimeout:     durationjson.Duration(5 * time.Millisecond),
 				LagerConfig: lagerflags.LagerConfig{

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main.go
@@ -183,9 +183,10 @@ func configureProxy(logger lager.Logger, sshProxyConfig config.SSHProxyConfig) (
 		logger.Fatal("host-key-required", err)
 	}
 
-	key, err := parsePrivateKey(logger, sshProxyConfig.HostKey)
+	key, err := parsePrivateKey(logger, sshProxyConfig)
 	if err != nil {
 		logger.Fatal("failed-to-parse-host-key", err)
+		return nil, err
 	}
 
 	sshConfig.AddHostKey(key)
@@ -211,12 +212,24 @@ func configureProxy(logger lager.Logger, sshProxyConfig config.SSHProxyConfig) (
 	return sshConfig, err
 }
 
-func parsePrivateKey(logger lager.Logger, encodedKey string) (ssh.Signer, error) {
-	key, err := ssh.ParsePrivateKey([]byte(encodedKey))
+func parsePrivateKey(logger lager.Logger, sshProxyConfig config.SSHProxyConfig) (ssh.Signer, error) {
+	key, err := ssh.ParsePrivateKey([]byte(sshProxyConfig.HostKey))
 	if err != nil {
 		logger.Error("failed-to-parse-private-key", err)
 		return nil, err
 	}
+
+	if sshProxyConfig.AllowedHostKeyAlgorithms != "" {
+		key, err = ssh.NewSignerWithAlgorithms(
+			key.(ssh.AlgorithmSigner),
+			strings.Split(sshProxyConfig.AllowedHostKeyAlgorithms, ","),
+		)
+		if err != nil {
+			logger.Error("failed-to-restrict-host-key-algorithms", err)
+			return nil, err
+		}
+	}
+
 	return key, nil
 }
 

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
@@ -929,6 +929,47 @@ var _ = Describe("SSH proxy", Serial, func() {
 			})
 		})
 
+		Context("when the proxy is configured with a host key algorithm that doesnt match the host key", func() {
+			BeforeEach(func() {
+				sshProxyConfig.AllowedHostKeyAlgorithms = "non-rsa-algorithm"
+			})
+
+			It("exits with non-zero status code", func() {
+				Eventually(process.Wait()).Should(Receive(HaveOccurred()))
+			})
+		})
+
+		Context("when the proxy provides a supported host key algorithm", func() {
+			BeforeEach(func() {
+				sshProxyConfig.AllowedHostKeyAlgorithms = "rsa-sha2-256,rsa-sha2-512"
+				clientConfig = &ssh.ClientConfig{
+					User:            "diego:" + processGuid + "/99",
+					Auth:            []ssh.AuthMethod{ssh.Password(diegoCredentials)},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				}
+			})
+
+			It("allows a client to complete a handshake", func() {
+				client, err := ssh.Dial("tcp", address, clientConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = client.Close()
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the proxy provides the default host key algorithm", func() {
+			BeforeEach(func() {
+				clientConfig.HostKeyAlgorithms = []string{"ssh-ed25519"}
+			})
+
+			It("errors when the client doesn't provide the host key algorithm: 'ssh-ed25519'", func() {
+				_, err := ssh.Dial("tcp", address, clientConfig)
+				Expect(err).To(MatchError("ssh: handshake failed: ssh: no common algorithm for host key; we offered: [ssh-ed25519], peer offered: [rsa-sha2-256 rsa-sha2-512 ssh-rsa]"))
+				Expect(fakeBBS.ReceivedRequests()).To(HaveLen(0))
+			})
+		})
+
 		Context("when a non-existent process guid is used", func() {
 			BeforeEach(func() {
 				clientConfig.User = "diego:bad-process-guid/999"

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main.go
@@ -73,6 +73,12 @@ var allowedKeyExchanges = flag.String(
 	"Limit key exchanges algorithms to those provided (comma separated)",
 )
 
+var allowedHostKeyAlgorithms = flag.String(
+	"allowedHostKeyAlgorithms",
+	"",
+	"Limit key host key algorithms to those provided (comma separated)",
+)
+
 var hostKeyPEM string
 var authorizedKeyValue string
 
@@ -134,6 +140,7 @@ func runServer() error {
 			fmt.Sprintf("--inheritDaemonEnv=%t", *inheritDaemonEnv),
 			fmt.Sprintf("--allowedCiphers=%s", *allowedCiphers),
 			fmt.Sprintf("--allowedMACs=%s", *allowedMACs),
+			fmt.Sprintf("--allowedHostKeyAlgorithms=%s", *allowedHostKeyAlgorithms),
 			fmt.Sprintf("--logLevel=%s", logLevel),
 			fmt.Sprintf("--debugAddr=%s", debugserver.DebugAddress(flag.CommandLine)),
 		}, os.Environ())
@@ -225,7 +232,7 @@ func configure(logger lager.Logger) (*ssh.ServerConfig, error) {
 	key, err := acquireHostKey(logger)
 	if err != nil {
 		logger.Error("failed-to-acquire-host-key", err)
-		errorStrings = append(errorStrings, err.Error())
+		return nil, err
 	}
 
 	sshConfig.AddHostKey(key)
@@ -290,6 +297,18 @@ func acquireHostKey(logger lager.Logger) (ssh.Signer, error) {
 		logger.Error("failed-to-parse-host-key", err)
 		return nil, err
 	}
+
+	if *allowedHostKeyAlgorithms != "" {
+		key, err = ssh.NewSignerWithAlgorithms(
+			key.(ssh.AlgorithmSigner),
+			strings.Split(*allowedHostKeyAlgorithms, ","),
+		)
+		if err != nil {
+			logger.Error("failed-to-restrict-host-key-algorithms", err)
+			return nil, err
+		}
+	}
+
 	return key, nil
 }
 

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main_test.go
@@ -40,9 +40,10 @@ var _ = Describe("SSH daemon", func() {
 		privateKey    string
 		authorizedKey string
 
-		allowedCiphers      string
-		allowedMACs         string
-		allowedKeyExchanges string
+		allowedCiphers           string
+		allowedMACs              string
+		allowedKeyExchanges      string
+		allowedHostKeyAlgorithms string
 
 		allowUnauthenticatedClients bool
 		inheritDaemonEnv            bool
@@ -56,6 +57,7 @@ var _ = Describe("SSH daemon", func() {
 		allowedCiphers = ""
 		allowedMACs = ""
 		allowedKeyExchanges = ""
+		allowedHostKeyAlgorithms = ""
 
 		allowUnauthenticatedClients = false
 		inheritDaemonEnv = false
@@ -67,9 +69,10 @@ var _ = Describe("SSH daemon", func() {
 			HostKey:       string(hostKey),
 			AuthorizedKey: string(authorizedKey),
 
-			AllowedCiphers:      string(allowedCiphers),
-			AllowedMACs:         string(allowedMACs),
-			AllowedKeyExchanges: string(allowedKeyExchanges),
+			AllowedCiphers:           string(allowedCiphers),
+			AllowedMACs:              string(allowedMACs),
+			AllowedKeyExchanges:      string(allowedKeyExchanges),
+			AllowedHostKeyAlgorithms: string(allowedHostKeyAlgorithms),
 
 			AllowUnauthenticatedClients: allowUnauthenticatedClients,
 			InheritDaemonEnv:            inheritDaemonEnv,
@@ -131,6 +134,30 @@ var _ = Describe("SSH daemon", func() {
 				})
 			})
 		})
+
+		Context("when allowedHostKeyAlgorithms is set", func() {
+			Context("and the value is invalid", func() {
+				BeforeEach(func() {
+					allowedHostKeyAlgorithms = "invalid"
+				})
+
+				It("reports and dies", func() {
+					Expect(runner).To(gbytes.Say("failed-to-restrict-host-key-algorithms"))
+					Expect(runner).NotTo(gexec.Exit(0))
+				})
+			})
+
+			Context("and the algorithm matches the key type", func() {
+				BeforeEach(func() {
+					allowedHostKeyAlgorithms = "ssh-rsa"
+				})
+
+				It("starts normally", func() {
+					Expect(process).NotTo(BeNil())
+				})
+			})
+		})
+
 	})
 
 	Describe("env variable validation", func() {

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/testrunner/runner.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/testrunner/runner.go
@@ -15,6 +15,7 @@ type Args struct {
 	AllowedCiphers              string
 	AllowedMACs                 string
 	AllowedKeyExchanges         string
+	AllowedHostKeyAlgorithms    string
 	AllowUnauthenticatedClients bool
 	InheritDaemonEnv            bool
 }
@@ -27,6 +28,7 @@ func (args Args) ArgSlice() []string {
 		"-allowedCiphers=" + args.AllowedCiphers,
 		"-allowedMACs=" + args.AllowedMACs,
 		"-allowedKeyExchanges=" + args.AllowedKeyExchanges,
+		"-allowedHostKeyAlgorithms=" + args.AllowedHostKeyAlgorithms,
 		"-allowUnauthenticatedClients=" + strconv.FormatBool(args.AllowUnauthenticatedClients),
 		"-inheritDaemonEnv=" + strconv.FormatBool(args.InheritDaemonEnv),
 	}


### PR DESCRIPTION
Summary
---

This PR extends both the `ssh-proxy` and `sshd` components with new configuration options that allow operators to choose which Host Key algorithms are advertised, in a similar way to the allowed KEX, MAC and ciphers.

New spec property for `ssh-proxy`:
```ruby
diego.ssh_proxy.allowed_host_key_algorithms:
  description: "Comma separated list of allowed host key algorithms"
```

New config flag for `sshd`:
```go
var allowedHostKeyAlgorithms = flag.String(
	"allowedHostKeyAlgorithms",
	"",
	"Limit key host key algorithms to those provided (comma separated)",
)
```

No existing behavior changes unless the new configuration fields are set. With no config, the components behave exactly as before.

Why We Need It
---
Currently the `ssh-proxy` and `sshd` advertise `ssh-rsa` host key algorithm, which uses SHA-1 and has been disabled by default in OpenSSH since version 8.8 due to cryptographic weaknesses in SHA-1. This configuration is needed to disable it without breaking compatibility in deployments that use it.

Backward Compatibility 
--------------- 
Breaking Change? **No**