### PR TITLE
Use host_256_fingerprint for diego-ssh

### DIFF
--- a/src/code.cloudfoundry.org/diego-ssh/authenticators/permissions_builder.go
+++ b/src/code.cloudfoundry.org/diego-ssh/authenticators/permissions_builder.go
@@ -89,11 +89,17 @@ func (pb *permissionsBuilder) createPermissions(
 				tlsAddress = fmt.Sprintf("%s:%d", actual.InstanceAddress, mapping.ContainerTlsProxyPort)
 			}
 
+			// Prefer SHA256 fingerprint if available, fall back to legacy fingerprint
+			hostFingerprint := sshRoute.Host256Fingerprint
+			if hostFingerprint == "" {
+				hostFingerprint = sshRoute.HostFingerprint
+			}
+
 			targetConfig = &proxy.TargetConfig{
 				Address:             fmt.Sprintf("%s:%d", address, port),
 				TLSAddress:          tlsAddress,
 				ServerCertDomainSAN: actual.ActualLRPInstanceKey.InstanceGuid,
-				HostFingerprint:     sshRoute.HostFingerprint,
+				HostFingerprint:     hostFingerprint,
 				User:                sshRoute.User,
 				Password:            sshRoute.Password,
 				PrivateKey:          sshRoute.PrivateKey,

--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
@@ -60,6 +60,7 @@ var _ = Describe("SSH proxy", Serial, func() {
 		healthCheckAddress          string
 		diegoCredentials            string
 		hostKeyFingerprint          string
+		hostKeySHA256Fingerprint    string
 		expectedGetActualLRPRequest *models.ActualLRPsRequest
 		actualLRPsResponse          *models.ActualLRPsResponse
 		getDesiredLRPRequest        *models.DesiredLRPByProcessGuidRequest
@@ -110,6 +111,7 @@ var _ = Describe("SSH proxy", Serial, func() {
 		privateKey, err := ssh.ParsePrivateKey([]byte(hostKeyPem))
 		Expect(err).NotTo(HaveOccurred())
 		hostKeyFingerprint = helpers.MD5Fingerprint(privateKey.PublicKey())
+		hostKeySHA256Fingerprint = helpers.SHA256Fingerprint(privateKey.PublicKey())
 
 		address = fmt.Sprintf("127.0.0.1:%d", sshProxyPort)
 		healthCheckAddress = fmt.Sprintf("127.0.0.1:%d", healthCheckProxyPort)
@@ -551,6 +553,37 @@ var _ = Describe("SSH proxy", Serial, func() {
 			output, err := session.Output("echo -n hello")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(Equal("hello"))
+		})
+
+		Context("when SHA256 fingerprint is provided", func() {
+			BeforeEach(func() {
+				paddedFingerprint := fmt.Sprintf("%s=", hostKeySHA256Fingerprint)
+
+				sshRoute, err := json.Marshal(routes.SSHRoute{
+					ContainerPort:      uint32(sshdContainerPort),
+					PrivateKey:         privateKeyPem,
+					Host256Fingerprint: paddedFingerprint,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				sshRouteMessage := json.RawMessage(sshRoute)
+				desiredLRPResponse.DesiredLrp.Routes = &models.Routes{
+					routes.DIEGO_SSH: &sshRouteMessage,
+				}
+			})
+
+			It("successfully validates using SHA256 fingerprint", func() {
+				client, err := ssh.Dial("tcp", address, clientConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				session, err := client.NewSession()
+				Expect(err).NotTo(HaveOccurred())
+				output, err := session.Output("echo -n hello")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(output)).To(Equal("hello"))
+
+				client.Close()
+			})
 		})
 
 		Context("when a tls intermediary is configured", func() {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
+	"crypto/sha1"
 	"fmt"
 	"strings"
 
@@ -10,15 +10,15 @@ import (
 )
 
 const MD5_FINGERPRINT_LENGTH = 47
-const SHA256_FINGERPRINT_LENGTH = 95
+const SHA1_FINGERPRINT_LENGTH = 59
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
 	return colonize(fmt.Sprintf("% x", md5sum))
 }
 
-func SHA256Fingerprint(key ssh.PublicKey) string {
-	sha1sum := sha256.Sum256(key.Marshal())
+func SHA1Fingerprint(key ssh.PublicKey) string {
+	sha1sum := sha1.Sum(key.Marshal())
 	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
@@ -11,6 +11,7 @@ import (
 
 const MD5_FINGERPRINT_LENGTH = 47
 const SHA1_FINGERPRINT_LENGTH = 59
+const SHA256_FINGERPRINT_LENGTH = 43
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
@@ -20,6 +21,12 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 func SHA1Fingerprint(key ssh.PublicKey) string {
 	sha1sum := sha1.Sum(key.Marshal())
 	return colonize(fmt.Sprintf("% x", sha1sum))
+}
+
+// SHA256Fingerprint returns the SHA256 fingerprint of a public key as unpadded base64
+func SHA256Fingerprint(key ssh.PublicKey) string {
+	value := ssh.FingerprintSHA256(key)
+	return strings.TrimPrefix(value, "SHA256:")
 }
 
 func colonize(s string) string {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
@@ -18,8 +18,8 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 }
 
 func SHA256Fingerprint(key ssh.PublicKey) string {
-	sha256sum := sha256.Sum256(key.Marshal())
-	return colonize(fmt.Sprintf("% x", sha256sum))
+	sha1sum := sha256.Sum256(key.Marshal())
+	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 
 func colonize(s string) string {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"crypto/md5"
-	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
 	"strings"
@@ -11,7 +10,6 @@ import (
 )
 
 const MD5_FINGERPRINT_LENGTH = 47
-const SHA1_FINGERPRINT_LENGTH = 59
 const SHA256_FINGERPRINT_LENGTH = 95
 
 func MD5Fingerprint(key ssh.PublicKey) string {
@@ -22,11 +20,6 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 func SHA256Fingerprint(key ssh.PublicKey) string {
 	sha256sum := sha256.Sum256(key.Marshal())
 	return colonize(fmt.Sprintf("% x", sha256sum))
-}
-
-func SHA1Fingerprint(key ssh.PublicKey) string {
-	sha1sum := sha1.Sum(key.Marshal())
-	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 
 func colonize(s string) string {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"crypto/md5"
 	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 
 const MD5_FINGERPRINT_LENGTH = 47
 const SHA1_FINGERPRINT_LENGTH = 59
-const SHA256_FINGERPRINT_LENGTH = 44 //unpadded base64
+const SHA256_FINGERPRINT_LENGTH = 95
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
@@ -19,8 +20,8 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 }
 
 func SHA256Fingerprint(key ssh.PublicKey) string {
-	value := ssh.FingerprintSHA256(key)
-	return strings.TrimPrefix(value, "SHA256:")
+	sha256sum := sha256.Sum256(key.Marshal())
+	return colonize(fmt.Sprintf("% x", sha256sum))
 }
 
 func SHA1Fingerprint(key ssh.PublicKey) string {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
@@ -40,7 +40,6 @@ HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 -----END RSA PRIVATE KEY-----`
 
 	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
-	ExpectedSHA1Fingerprint   = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
 	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
 )
 
@@ -66,20 +65,6 @@ var _ = Describe("Fingerprint", func() {
 
 		It("should match the expected fingerprint", func() {
 			Expect(fingerprint).To(Equal(ExpectedMD5Fingerprint))
-		})
-	})
-
-	Describe("SHA1 Fingerprint", func() {
-		BeforeEach(func() {
-			fingerprint = helpers.SHA1Fingerprint(publicKey)
-		})
-
-		It("should have the correct length", func() {
-			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA1_FINGERPRINT_LENGTH))
-		})
-
-		It("should match the expected fingerprint", func() {
-			Expect(fingerprint).To(Equal(ExpectedSHA1Fingerprint))
 		})
 	})
 

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
@@ -39,8 +39,8 @@ feuxbZkmphtEOKtaVDSWxGbNXbuN8H9eQqsGhK1Xcn/FxKVu7k+9GYyqeOwhjaqy
 HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 -----END RSA PRIVATE KEY-----`
 
-	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
-	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
+	ExpectedMD5Fingerprint  = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
+	ExpectedSHA1Fingerprint = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
 )
 
 var _ = Describe("Fingerprint", func() {
@@ -68,17 +68,17 @@ var _ = Describe("Fingerprint", func() {
 		})
 	})
 
-	Describe("SHA256 Fingerprint", func() {
+	Describe("SHA1 Fingerprint", func() {
 		BeforeEach(func() {
-			fingerprint = helpers.SHA256Fingerprint(publicKey)
+			fingerprint = helpers.SHA1Fingerprint(publicKey)
 		})
 
 		It("should have the correct length", func() {
-			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA256_FINGERPRINT_LENGTH))
+			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA1_FINGERPRINT_LENGTH))
 		})
 
 		It("should match the expected fingerprint", func() {
-			Expect(fingerprint).To(Equal(ExpectedSHA256Fingerprint))
+			Expect(fingerprint).To(Equal(ExpectedSHA1Fingerprint))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
@@ -1,7 +1,6 @@
 package helpers_test
 
 import (
-	"fmt"
 	"unicode/utf8"
 
 	"code.cloudfoundry.org/diego-ssh/helpers"
@@ -42,7 +41,7 @@ HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 
 	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
 	ExpectedSHA1Fingerprint   = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
-	ExpectedSHA256Fingerprint = `x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc=`
+	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
 )
 
 var _ = Describe("Fingerprint", func() {
@@ -86,7 +85,7 @@ var _ = Describe("Fingerprint", func() {
 
 	Describe("SHA256 Fingerprint", func() {
 		BeforeEach(func() {
-			fingerprint = fmt.Sprintf("%s=", helpers.SHA256Fingerprint(publicKey))
+			fingerprint = helpers.SHA256Fingerprint(publicKey)
 		})
 
 		It("should have the correct length", func() {

--- a/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/helpers/fingerprint_test.go
@@ -1,6 +1,7 @@
 package helpers_test
 
 import (
+	"fmt"
 	"unicode/utf8"
 
 	"code.cloudfoundry.org/diego-ssh/helpers"
@@ -39,8 +40,9 @@ feuxbZkmphtEOKtaVDSWxGbNXbuN8H9eQqsGhK1Xcn/FxKVu7k+9GYyqeOwhjaqy
 HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 -----END RSA PRIVATE KEY-----`
 
-	ExpectedMD5Fingerprint  = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
-	ExpectedSHA1Fingerprint = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
+	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
+	ExpectedSHA1Fingerprint   = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
+	ExpectedSHA256Fingerprint = `x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc`
 )
 
 var _ = Describe("Fingerprint", func() {
@@ -79,6 +81,49 @@ var _ = Describe("Fingerprint", func() {
 
 		It("should match the expected fingerprint", func() {
 			Expect(fingerprint).To(Equal(ExpectedSHA1Fingerprint))
+		})
+	})
+
+	Describe("SHA256 Fingerprint", func() {
+		BeforeEach(func() {
+			fingerprint = helpers.SHA256Fingerprint(publicKey)
+		})
+
+		It("should return unpadded base64 (43 characters)", func() {
+			// Go's ssh.FingerprintSHA256 returns unpadded base64
+			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(43))
+		})
+
+		Context("when comparing with CAPI format", func() {
+			It("matches CAPI fingerprint when padding is added", func() {
+				// CAPI uses Base64.strict_encode64 which includes padding
+				// Ruby sends: "x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc="
+				paddedFingerprint := fmt.Sprintf("%s=", fingerprint)
+
+				// This is what CAPI sends (44 chars with padding)
+				capiFormat := `x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc=`
+				Expect(paddedFingerprint).To(Equal(capiFormat))
+				Expect(utf8.RuneCountInString(paddedFingerprint)).To(Equal(44))
+			})
+
+		})
+	})
+
+	Describe("Fingerprint comparison", func() {
+		It("generates different fingerprints with different algorithms", func() {
+			md5 := helpers.MD5Fingerprint(publicKey)
+			sha1 := helpers.SHA1Fingerprint(publicKey)
+			sha256 := helpers.SHA256Fingerprint(publicKey)
+
+			Expect(md5).NotTo(Equal(sha1))
+			Expect(md5).NotTo(Equal(sha256))
+			Expect(sha1).NotTo(Equal(sha256))
+		})
+
+		It("generates consistent fingerprints for the same key", func() {
+			fp1 := helpers.SHA256Fingerprint(publicKey)
+			fp2 := helpers.SHA256Fingerprint(publicKey)
+			Expect(fp1).To(Equal(fp2))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/diego-ssh/keys/fake_keys/fake_key_pair.go
+++ b/src/code.cloudfoundry.org/diego-ssh/keys/fake_keys/fake_key_pair.go
@@ -59,6 +59,16 @@ type FakeKeyPair struct {
 	publicKeyReturnsOnCall map[int]struct {
 		result1 ssh.PublicKey
 	}
+	SHA256FingerprintStub        func() string
+	sHA256FingerprintMutex       sync.RWMutex
+	sHA256FingerprintArgsForCall []struct {
+	}
+	sHA256FingerprintReturns struct {
+		result1 string
+	}
+	sHA256FingerprintReturnsOnCall map[int]struct {
+		result1 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -68,16 +78,16 @@ func (fake *FakeKeyPair) AuthorizedKey() string {
 	ret, specificReturn := fake.authorizedKeyReturnsOnCall[len(fake.authorizedKeyArgsForCall)]
 	fake.authorizedKeyArgsForCall = append(fake.authorizedKeyArgsForCall, struct {
 	}{})
+	stub := fake.AuthorizedKeyStub
+	fakeReturns := fake.authorizedKeyReturns
 	fake.recordInvocation("AuthorizedKey", []interface{}{})
-	authorizedKeyStubCopy := fake.AuthorizedKeyStub
 	fake.authorizedKeyMutex.Unlock()
-	if authorizedKeyStubCopy != nil {
-		return authorizedKeyStubCopy()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.authorizedKeyReturns
 	return fakeReturns.result1
 }
 
@@ -121,16 +131,16 @@ func (fake *FakeKeyPair) Fingerprint() string {
 	ret, specificReturn := fake.fingerprintReturnsOnCall[len(fake.fingerprintArgsForCall)]
 	fake.fingerprintArgsForCall = append(fake.fingerprintArgsForCall, struct {
 	}{})
+	stub := fake.FingerprintStub
+	fakeReturns := fake.fingerprintReturns
 	fake.recordInvocation("Fingerprint", []interface{}{})
-	fingerprintStubCopy := fake.FingerprintStub
 	fake.fingerprintMutex.Unlock()
-	if fingerprintStubCopy != nil {
-		return fingerprintStubCopy()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.fingerprintReturns
 	return fakeReturns.result1
 }
 
@@ -174,16 +184,16 @@ func (fake *FakeKeyPair) PEMEncodedPrivateKey() string {
 	ret, specificReturn := fake.pEMEncodedPrivateKeyReturnsOnCall[len(fake.pEMEncodedPrivateKeyArgsForCall)]
 	fake.pEMEncodedPrivateKeyArgsForCall = append(fake.pEMEncodedPrivateKeyArgsForCall, struct {
 	}{})
+	stub := fake.PEMEncodedPrivateKeyStub
+	fakeReturns := fake.pEMEncodedPrivateKeyReturns
 	fake.recordInvocation("PEMEncodedPrivateKey", []interface{}{})
-	pEMEncodedPrivateKeyStubCopy := fake.PEMEncodedPrivateKeyStub
 	fake.pEMEncodedPrivateKeyMutex.Unlock()
-	if pEMEncodedPrivateKeyStubCopy != nil {
-		return pEMEncodedPrivateKeyStubCopy()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pEMEncodedPrivateKeyReturns
 	return fakeReturns.result1
 }
 
@@ -227,16 +237,16 @@ func (fake *FakeKeyPair) PrivateKey() ssh.Signer {
 	ret, specificReturn := fake.privateKeyReturnsOnCall[len(fake.privateKeyArgsForCall)]
 	fake.privateKeyArgsForCall = append(fake.privateKeyArgsForCall, struct {
 	}{})
+	stub := fake.PrivateKeyStub
+	fakeReturns := fake.privateKeyReturns
 	fake.recordInvocation("PrivateKey", []interface{}{})
-	privateKeyStubCopy := fake.PrivateKeyStub
 	fake.privateKeyMutex.Unlock()
-	if privateKeyStubCopy != nil {
-		return privateKeyStubCopy()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.privateKeyReturns
 	return fakeReturns.result1
 }
 
@@ -280,16 +290,16 @@ func (fake *FakeKeyPair) PublicKey() ssh.PublicKey {
 	ret, specificReturn := fake.publicKeyReturnsOnCall[len(fake.publicKeyArgsForCall)]
 	fake.publicKeyArgsForCall = append(fake.publicKeyArgsForCall, struct {
 	}{})
+	stub := fake.PublicKeyStub
+	fakeReturns := fake.publicKeyReturns
 	fake.recordInvocation("PublicKey", []interface{}{})
-	publicKeyStubCopy := fake.PublicKeyStub
 	fake.publicKeyMutex.Unlock()
-	if publicKeyStubCopy != nil {
-		return publicKeyStubCopy()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publicKeyReturns
 	return fakeReturns.result1
 }
 
@@ -328,19 +338,62 @@ func (fake *FakeKeyPair) PublicKeyReturnsOnCall(i int, result1 ssh.PublicKey) {
 	}{result1}
 }
 
+func (fake *FakeKeyPair) SHA256Fingerprint() string {
+	fake.sHA256FingerprintMutex.Lock()
+	ret, specificReturn := fake.sHA256FingerprintReturnsOnCall[len(fake.sHA256FingerprintArgsForCall)]
+	fake.sHA256FingerprintArgsForCall = append(fake.sHA256FingerprintArgsForCall, struct {
+	}{})
+	stub := fake.SHA256FingerprintStub
+	fakeReturns := fake.sHA256FingerprintReturns
+	fake.recordInvocation("SHA256Fingerprint", []interface{}{})
+	fake.sHA256FingerprintMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeKeyPair) SHA256FingerprintCallCount() int {
+	fake.sHA256FingerprintMutex.RLock()
+	defer fake.sHA256FingerprintMutex.RUnlock()
+	return len(fake.sHA256FingerprintArgsForCall)
+}
+
+func (fake *FakeKeyPair) SHA256FingerprintCalls(stub func() string) {
+	fake.sHA256FingerprintMutex.Lock()
+	defer fake.sHA256FingerprintMutex.Unlock()
+	fake.SHA256FingerprintStub = stub
+}
+
+func (fake *FakeKeyPair) SHA256FingerprintReturns(result1 string) {
+	fake.sHA256FingerprintMutex.Lock()
+	defer fake.sHA256FingerprintMutex.Unlock()
+	fake.SHA256FingerprintStub = nil
+	fake.sHA256FingerprintReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeKeyPair) SHA256FingerprintReturnsOnCall(i int, result1 string) {
+	fake.sHA256FingerprintMutex.Lock()
+	defer fake.sHA256FingerprintMutex.Unlock()
+	fake.SHA256FingerprintStub = nil
+	if fake.sHA256FingerprintReturnsOnCall == nil {
+		fake.sHA256FingerprintReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.sHA256FingerprintReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeKeyPair) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.authorizedKeyMutex.RLock()
-	defer fake.authorizedKeyMutex.RUnlock()
-	fake.fingerprintMutex.RLock()
-	defer fake.fingerprintMutex.RUnlock()
-	fake.pEMEncodedPrivateKeyMutex.RLock()
-	defer fake.pEMEncodedPrivateKeyMutex.RUnlock()
-	fake.privateKeyMutex.RLock()
-	defer fake.privateKeyMutex.RUnlock()
-	fake.publicKeyMutex.RLock()
-	defer fake.publicKeyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/diego-ssh/keys/fake_keys/fake_ssh_key_factory.go
+++ b/src/code.cloudfoundry.org/diego-ssh/keys/fake_keys/fake_ssh_key_factory.go
@@ -31,16 +31,16 @@ func (fake *FakeSSHKeyFactory) NewKeyPair(arg1 int) (keys.KeyPair, error) {
 	fake.newKeyPairArgsForCall = append(fake.newKeyPairArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.NewKeyPairStub
+	fakeReturns := fake.newKeyPairReturns
 	fake.recordInvocation("NewKeyPair", []interface{}{arg1})
-	newKeyPairStubCopy := fake.NewKeyPairStub
 	fake.newKeyPairMutex.Unlock()
-	if newKeyPairStubCopy != nil {
-		return newKeyPairStubCopy(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newKeyPairReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -92,8 +92,6 @@ func (fake *FakeSSHKeyFactory) NewKeyPairReturnsOnCall(i int, result1 keys.KeyPa
 func (fake *FakeSSHKeyFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.newKeyPairMutex.RLock()
-	defer fake.newKeyPairMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/diego-ssh/keys/rsa.go
+++ b/src/code.cloudfoundry.org/diego-ssh/keys/rsa.go
@@ -17,6 +17,7 @@ type KeyPair interface {
 
 	PublicKey() ssh.PublicKey
 	Fingerprint() string
+	SHA256Fingerprint() string // New method for SHA256
 	AuthorizedKey() string
 }
 
@@ -80,6 +81,10 @@ func (k *rsaKeyPair) PublicKey() ssh.PublicKey {
 
 func (k *rsaKeyPair) Fingerprint() string {
 	return helpers.MD5Fingerprint(k.PublicKey())
+}
+
+func (k *rsaKeyPair) SHA256Fingerprint() string {
+	return helpers.SHA256Fingerprint(k.PublicKey())
 }
 
 func (k *rsaKeyPair) AuthorizedKey() string {

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
@@ -401,8 +401,6 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 			switch utf8.RuneCountInString(expectedFingerprint) {
 			case helpers.MD5_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.MD5Fingerprint(key)
-			case helpers.SHA1_FINGERPRINT_LENGTH:
-				actualFingerprint = helpers.SHA1Fingerprint(key)
 			case helpers.SHA256_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.SHA256Fingerprint(key)
 			}

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"unicode/utf8"
 
@@ -406,8 +405,6 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 				actualFingerprint = helpers.SHA1Fingerprint(key)
 			case helpers.SHA256_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.SHA256Fingerprint(key)
-				//sshkey ruby gem pads the base64 output, but golang implementation returns unpaded
-				expectedFingerprint = strings.TrimRight(expectedFingerprint, "=")
 			}
 
 			if expectedFingerprint != actualFingerprint {

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
@@ -401,8 +401,8 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 			switch utf8.RuneCountInString(expectedFingerprint) {
 			case helpers.MD5_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.MD5Fingerprint(key)
-			case helpers.SHA256_FINGERPRINT_LENGTH:
-				actualFingerprint = helpers.SHA256Fingerprint(key)
+			case helpers.SHA1_FINGERPRINT_LENGTH:
+				actualFingerprint = helpers.SHA1Fingerprint(key)
 			}
 
 			if expectedFingerprint != actualFingerprint {

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"unicode/utf8"
 
@@ -403,6 +404,9 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 				actualFingerprint = helpers.MD5Fingerprint(key)
 			case helpers.SHA1_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.SHA1Fingerprint(key)
+			case helpers.SHA256_FINGERPRINT_LENGTH, helpers.SHA256_FINGERPRINT_LENGTH + 1: // 43 or 44 (with padding)
+				actualFingerprint = helpers.SHA256Fingerprint(key)
+				expectedFingerprint = strings.TrimRight(expectedFingerprint, "=")
 			}
 
 			if expectedFingerprint != actualFingerprint {

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -272,7 +271,7 @@ var _ = Describe("Proxy", func() {
 						BeforeEach(func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
-								HostFingerprint: fmt.Sprintf("%s=", helpers.SHA256Fingerprint(TestHostKey.PublicKey())),
+								HostFingerprint: helpers.SHA256Fingerprint(TestHostKey.PublicKey()),
 								User:            "some-user",
 								Password:        "fake-some-password",
 							})

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
@@ -248,29 +248,6 @@ var _ = Describe("Proxy", func() {
 						BeforeEach(func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
-								HostFingerprint: helpers.SHA1Fingerprint(TestHostKey.PublicKey()),
-								User:            "some-user",
-								Password:        "fake-some-password",
-							})
-							Expect(err).NotTo(HaveOccurred())
-
-							permissions := &ssh.Permissions{
-								CriticalOptions: map[string]string{
-									"proxy-target-config": string(targetConfigJson),
-								},
-							}
-							proxyAuthenticator.AuthenticateReturns(permissions, nil)
-						})
-
-						It("handshakes with the target using the provided configuration", func() {
-							Eventually(daemonAuthenticator.AuthenticateCallCount).Should(Equal(1))
-						})
-					})
-
-					Context("when the host fingerprint is a sha256 hash", func() {
-						BeforeEach(func() {
-							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
-								Address:         sshdListener.Addr().String(),
 								HostFingerprint: helpers.SHA256Fingerprint(TestHostKey.PublicKey()),
 								User:            "some-user",
 								Password:        "fake-some-password",

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Proxy", func() {
 						BeforeEach(func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
-								HostFingerprint: helpers.SHA256Fingerprint(TestHostKey.PublicKey()),
+								HostFingerprint: helpers.SHA1Fingerprint(TestHostKey.PublicKey()),
 								User:            "some-user",
 								Password:        "fake-some-password",
 							})

--- a/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/proxy/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -249,6 +250,29 @@ var _ = Describe("Proxy", func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
 								HostFingerprint: helpers.SHA1Fingerprint(TestHostKey.PublicKey()),
+								User:            "some-user",
+								Password:        "fake-some-password",
+							})
+							Expect(err).NotTo(HaveOccurred())
+
+							permissions := &ssh.Permissions{
+								CriticalOptions: map[string]string{
+									"proxy-target-config": string(targetConfigJson),
+								},
+							}
+							proxyAuthenticator.AuthenticateReturns(permissions, nil)
+						})
+
+						It("handshakes with the target using the provided configuration", func() {
+							Eventually(daemonAuthenticator.AuthenticateCallCount).Should(Equal(1))
+						})
+					})
+
+					Context("when the host fingerprint is a sha256 hash", func() {
+						BeforeEach(func() {
+							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
+								Address:         sshdListener.Addr().String(),
+								HostFingerprint: fmt.Sprintf("%s=", helpers.SHA256Fingerprint(TestHostKey.PublicKey())),
 								User:            "some-user",
 								Password:        "fake-some-password",
 							})

--- a/src/code.cloudfoundry.org/diego-ssh/routes/diego_ssh.go
+++ b/src/code.cloudfoundry.org/diego-ssh/routes/diego_ssh.go
@@ -3,9 +3,10 @@ package routes
 const DIEGO_SSH = "diego-ssh"
 
 type SSHRoute struct {
-	ContainerPort   uint32 `json:"container_port"`
-	HostFingerprint string `json:"host_fingerprint,omitempty"`
-	User            string `json:"user,omitempty"`
-	Password        string `json:"password,omitempty"`
-	PrivateKey      string `json:"private_key,omitempty"`
+	ContainerPort      uint32 `json:"container_port"`
+	HostFingerprint    string `json:"host_fingerprint,omitempty"`
+	Host256Fingerprint string `json:"host_256_fingerprint,omitempty"`
+	User               string `json:"user,omitempty"`
+	Password           string `json:"password,omitempty"`
+	PrivateKey         string `json:"private_key,omitempty"`
 }

--- a/src/code.cloudfoundry.org/diego-ssh/routes/diego_ssh_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/routes/diego_ssh_test.go
@@ -66,6 +66,28 @@ var _ = Describe("Diego SSH Route", func() {
 				Expect(payload).To(MatchJSON(expectedJson))
 			})
 		})
+		Context("when both fingerprints are present", func() {
+			BeforeEach(func() {
+				route = routes.SSHRoute{
+					ContainerPort:      2222,
+					HostFingerprint:    "24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8",
+					Host256Fingerprint: "x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc=",
+					PrivateKey:         "FAKE_PEM_ENCODED_KEY",
+				}
+			})
+
+			It("marshals both fingerprints correctly", func() {
+				payload, err := json.Marshal(route)
+				Expect(err).NotTo(HaveOccurred())
+
+				var result routes.SSHRoute
+				err = json.Unmarshal(payload, &result)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.HostFingerprint).To(Equal(route.HostFingerprint))
+				Expect(result.Host256Fingerprint).To(Equal(route.Host256Fingerprint))
+			})
+		})
 	})
 
 	Describe("Round Trip Marshalling", func() {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Cf deployment test results:

Validated in ssh-proxy logs:

lrp data: "host_256_fingerprint": "I2VSSfsKeq3/2rYjiriR+PlDXiPnwyByag1NirN6FOI="

```
{"fingerprint":"I2VSSfsKeq3/2rYjiriR+PlDXiPnwyByag1NirN6FOI=","length":44,"session":"7.1"}}
{"timestamp":"2026-01-29T21:35:07.123278010Z","level":"info","source":"ssh-proxy","message":"ssh-proxy.handle-connection.new-client-conn.fingerprint-validation-starting","data":{"fingerprint":"I2VSSfsKeq3/2rYjiriR+PlDXiPnwyByag1NirN6FOI=","length":44,"session":"24.1"}}{"actual":"I2VSSfsKeq3/2rYjiriR+PlDXiPnwyByag1NirN6FOI","expected":"I2VSSfsKeq3/2rYjiriR+PlDXiPnwyByag1NirN6FOI","session":"7.1"}}
```

```
$ cf ssh dora
vcap@6bca945b-41e4-4998-661a-bf8d:~$ 
```

Use host_256_fingerprint for diego-ssh
https://github.com/cloudfoundry/diego-release/issues/1014
```
root@4649106b995b:/# ./repo/scripts/docker/test.bash diego-ssh/cmd/ssh-proxy
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy
go version go1.25.5 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy
Verifying: verify_govet repo/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy
booting mysqlconnection established to mysql
[1768411737] SSH Proxy Suite - 54/54 specs - 7 procs •••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 4m15.353795074s 
[1768411737] Config Suite - 15/15 specs - 7 procs ••••••••••••••• SUCCESS! 25.871890887s 

Ginkgo ran 2 suites in 4m45.84921484s
Test Suite Passed

root@4649106b995b:/# ./repo/scripts/docker/test.bash diego-ssh/routes       
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/diego-ssh/routes
go version go1.25.5 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/diego-ssh/routes
Verifying: verify_govet repo/src/code.cloudfoundry.org/diego-ssh/routes
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/diego-ssh/routes
booting mysqlconnection established to mysql
Running Suite: Routes Suite - /repo/src/code.cloudfoundry.org/diego-ssh/routes
==============================================================================
Random Seed: 1768412502 - will randomize all specs

Will run 4 of 4 specs
Running in parallel across 7 processes
••••

Ran 4 of 4 Specs in 0.054 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped


Ginkgo ran 1 suite in 2.323735936s
```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
