### PR TITLE
Add inigo test to validate there aren't deadlock issues with readines…

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/long_running_healthchecks_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/long_running_healthchecks_test.go
@@ -1,6 +1,7 @@
 package cell_test
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"code.cloudfoundry.org/inigo/helpers"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
+	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/rep/cmd/rep/config"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
@@ -32,6 +34,9 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 		processGuid         string
 		archiveFiles        []archive_helper.ArchiveFile
 		fileServerStaticDir string
+		cellPortsStart      uint16
+		cellAddr            string
+		cellSecureAddr      string
 
 		ifritRuntime ifrit.Process
 
@@ -48,6 +53,12 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 
 		processGuid = helpers.GenerateGuid()
 
+		var err error
+		cellPortsStart, err = componentMaker.PortAllocator().ClaimPorts(2)
+		Expect(err).NotTo(HaveOccurred())
+		cellAddr = fmt.Sprintf("0.0.0.0:%d", cellPortsStart)
+		cellSecureAddr = fmt.Sprintf("0.0.0.0:%d", cellPortsStart+1)
+
 		var fileServer ifrit.Runner
 		fileServer, fileServerStaticDir = componentMaker.FileServer(modifyFunFileServerLoggregatorConfig)
 
@@ -55,6 +66,8 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 			cfg.DeclarativeHealthCheckDefaultTimeout = durationjson.Duration(1 * time.Second)
 			cfg.DeclarativeHealthcheckPath = componentMaker.Artifacts().Healthcheck
 			cfg.HealthCheckWorkPoolSize = 1
+			cfg.ListenAddr = cellAddr
+			cfg.ListenAddrSecurable = cellSecureAddr
 		}
 
 		fixturesPath := path.Join("..", "fixtures", "certs")
@@ -63,7 +76,6 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 		metronClientKeyFile := path.Join(fixturesPath, "metron", "client.key")
 		metronServerCertFile := path.Join(fixturesPath, "metron", "metron.crt")
 		metronServerKeyFile := path.Join(fixturesPath, "metron", "metron.key")
-		var err error
 		testIngressServer, err = testhelpers.NewTestIngressServer(metronServerCertFile, metronServerKeyFile, metronCAFile)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -192,6 +204,75 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 			It("eventually runs", func() {
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 				Eventually(helpers.HelloWorldInstancePoller(componentMaker.Addresses().Router, helpers.DefaultHost)).Should(ConsistOf([]string{"0"}))
+			})
+		})
+
+		Context("when startup check times out but readiness check succeeds immediately", func() {
+			var repClient rep.Client
+			BeforeEach(func() {
+				// Create an LRP with:
+				// - Startup check on port 9999 (never becomes available, will timeout)
+				// - Readiness check on port 8080 (app listens here, will succeed immediately)
+				// - Very short startup timeout to trigger the timeout quickly
+				lrp = helpers.DefaultDeclaritiveHealthcheckLRPCreateRequest(componentMaker.Addresses(), processGuid, "log-guid", 1)
+				lrp.StartTimeoutMs = int64(2 * time.Second / time.Millisecond) // 2 second timeout
+
+				// Startup check: TCP check on port 9999 (never available)
+				// Readiness check: TCP check on port 8080 (available immediately)
+				lrp.CheckDefinition = &models.CheckDefinition{
+					Checks: []*models.Check{
+						{
+							TcpCheck: &models.TCPCheck{
+								Port:             9999, // Port that will never be available
+								ConnectTimeoutMs: 100,
+								IntervalMs:       100,
+							},
+						},
+					},
+					ReadinessChecks: []*models.Check{
+						{
+							TcpCheck: &models.TCPCheck{
+								Port:             8080, // Port where app listens, available immediately
+								ConnectTimeoutMs: 100,
+								IntervalMs:       100,
+							},
+						},
+					},
+				}
+				factory := componentMaker.RepClientFactory()
+				var err error
+				addr := fmt.Sprintf("https://cell.service.cf.internal:%d", cellPortsStart)
+				secureAddr := fmt.Sprintf("https://cell.service.cf.internal:%d", cellPortsStart+1)
+				repClient, err = factory.CreateClient(addr, secureAddr, "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			JustBeforeEach(func() {
+				// Wait for the LRP to start
+				Eventually(func() (int, error) {
+					state, err := repClient.State(lgr)
+					if err != nil {
+						return -1, err
+					}
+					return len(state.LRPs), nil
+				}).Should(Equal(1))
+			})
+
+			It("all processes exit when startup check times out", func() {
+				// The startup check should timeout after 2 seconds
+				// The readiness check should succeed immediately (port 8080 is available)
+				// This creates the deadlock scenario: readiness check tries to send to channel
+				// but storeNode.run() has already exited due to startup check failure
+				// We verify that all processes exit (no deadlock)
+
+				// Verify that the rep no longer has an lrp running
+				Eventually(func() (int, error) {
+					state, err := repClient.State(lgr)
+					if err != nil {
+						return -1, err
+					}
+					return len(state.LRPs), nil
+				}).Should(Equal(0))
 			})
 		})
 	})


### PR DESCRIPTION
…s checks upon container failure during startup when the readiness check succeeded

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
An inigo test to validate https://github.com/cloudfoundry/executor/pull/127 is able to clean up the entire container.

Backward Compatibility
---------------
Breaking Change? no