### PR TITLE
feat: report container IPv6 address to NATS

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
@@ -36,6 +36,7 @@ type Endpoint struct {
 	Index                 int32
 	Host                  string
 	ContainerIP           string
+	ContainerIPv6         string
 	Port                  uint32
 	ContainerPort         uint32
 	TlsProxyPort          uint32
@@ -239,6 +240,7 @@ func NewEndpointsFromActual(actualLRP *models.ActualLRP) []Endpoint {
 				Index:                 actualLRP.Index,
 				Host:                  actualLRP.Address,
 				ContainerIP:           actualLRP.InstanceAddress,
+				ContainerIPv6:         actualLRP.InstanceIpv6Address,
 				Port:                  portMapping.HostPort,
 				ContainerPort:         portMapping.ContainerPort,
 				Presence:              actualLRP.Presence,

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
@@ -107,6 +107,32 @@ var _ = Describe("LRP Utils", func() {
 			})
 		})
 
+		Context("when actual has an IPv6 address", func() {
+			It("populates ContainerIPv6 on the endpoint", func() {
+				tag := models.ModificationTag{Epoch: "abc", Index: 0}
+				actualInfo := &models.ActualLRP{
+					ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+					ActualLRPNetInfo: models.NewActualLRPNetInfoWithIPv6(
+						"1.1.1.1",
+						"2.2.2.2",
+						"fd00::1",
+						models.ActualLRPNetInfo_PreferredAddressHost,
+						models.NewPortMapping(11, 44),
+					),
+					Presence:         models.ActualLRP_Ordinary,
+					State:            models.ActualLRPStateRunning,
+					ModificationTag:  tag,
+					AvailabilityZone: "some-zone",
+				}
+
+				endpoints := routingtable.NewEndpointsFromActual(actualInfo)
+
+				Expect(endpoints).To(HaveLen(1))
+				Expect(endpoints[0].ContainerIPv6).To(Equal("fd00::1"))
+			})
+		})
+
 		Context("when actual is evacuating", func() {
 			It("builds a map of container port to endpoint", func() {
 				tag := models.ModificationTag{Epoch: "abc", Index: 0}

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/registry_message.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/registry_message.go
@@ -129,5 +129,8 @@ func populateMetricTags(input map[string]*models.MetricTagValue, endpoint Endpoi
 		tags[k] = value
 	}
 	tags["component"] = "route-emitter"
+	if endpoint.ContainerIPv6 != "" {
+		tags["cf_instance_ipv6"] = endpoint.ContainerIPv6
+	}
 	return tags
 }

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/registry_message_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/registry_message_test.go
@@ -222,6 +222,18 @@ var _ = Describe("RegistryMessage", func() {
 				Expect(message).To(Equal(expectedMessage))
 			})
 		})
+
+		Context("when the endpoint has an IPv6 address", func() {
+			BeforeEach(func() {
+				endpoint.ContainerIPv6 = "fd00::1"
+				expectedMessage.Tags["cf_instance_ipv6"] = "fd00::1"
+			})
+
+			It("includes the cf_instance_ipv6 tag", func() {
+				message := routingtable.RegistryMessageFor(endpoint, route, true)
+				Expect(message).To(Equal(expectedMessage))
+			})
+		})
 	})
 
 	Describe("InternalAddressRegistryMessageFor", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
To allow other components to make use of the newly added container IPv6 address this commit adds a new tag to the outgoing registry message containing the IPv6 address of the container.



Backward Compatibility
---------------
Breaking Change? **No**

PR 3/3 to expose container IPv6 addresses.