### PR TITLE
locket sql db read/write timeout setting

### DIFF
--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -63,10 +63,10 @@ properties:
     default: "30"
   diego.locket.sql.db_read_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be received from the server"
-    default: "600"
+    default: "60"
   diego.locket.sql.db_write_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be sent to the server"
-    default: "600"
+    default: "60"
   diego.locket.sql.require_ssl:
     description: "Whether to require SSL for Locket communication to the SQL backend"
     default: false


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Lower the db read/write timeout settings.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
