### PR TITLE
mtls for fileserver

### DIFF
--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -13,6 +13,7 @@ templates:
   loggregator_client.key.erb: config/certs/loggregator/client.key
   tls.crt.erb: config/certs/tls.crt
   tls.key.erb: config/certs/tls.key
+  tls.client_ca_cert.erb: config/certs/tls.client_ca_cert
 
 packages:
   - pid_utils
@@ -56,6 +57,8 @@ properties:
     description: "PEM-encoded tls certificate that can be used for server auth"
   tls.key:
     description: "PEM-encoded tls key"
+  tls.client_ca_cert:
+    description: "PEM-encoded CA certificate for mTLS, optional"
 
   loggregator.v2_api_port:
     description: "Port which the component should use to communicate to the metron agent's v2 API (host is assumed to be `localhost`)."

--- a/jobs/file_server/templates/file_server.json.erb
+++ b/jobs/file_server/templates/file_server.json.erb
@@ -33,6 +33,10 @@
     config[:key_file]  = "#{conf_dir}/certs/tls.key"
   end
 
+  if_p("tls.client_ca_cert") do |_|
+    config[:client_ca_cert_file]  = "#{conf_dir}/certs/tls.client_ca_cert"
+  end
+
   if config[:https_server_enabled] && (config[:cert_file].nil? || config[:key_file].nil?)
     raise "tls.cert and tls.key are required if https_server_enabled is set to true"
   end

--- a/jobs/file_server/templates/tls.client_ca_cert.erb
+++ b/jobs/file_server/templates/tls.client_ca_cert.erb
@@ -1,0 +1,4 @@
+<% if_p("tls.client_ca_cert") do |value| %>
+<%= value %>
+<% end %>
+

--- a/spec/file_server_template_spec.rb
+++ b/spec/file_server_template_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+# rubocop: disable Metrics/BlockLength
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+
+describe 'file_server' do
+  let(:release_path) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
+  let(:job) { release.job('file_server') }
+
+  describe 'file_server.json.erb' do
+    let(:deployment_manifest_fragment) do
+      {
+        'diego' => {
+          'file_server' => {
+            'listen_addr' => '0.0.0.0:8080',
+            'static_directory' => '/var/vcap/jobs/file_server/packages/',
+            'debug_addr' => '127.0.0.1:17005',
+            'log_level' => 'info'
+          }
+        },
+        'https_server_enabled' => false,
+        'https_listen_addr' => '0.0.0.0:8443',
+        'loggregator' => {
+          'v2_api_port' => 3458,
+          'ca_cert' => 'LOGGREGATOR CA CERT',
+          'cert' => 'LOGGREGATOR CLIENT CERT',
+          'key' => 'LOGGREGATOR CLIENT KEY'
+        }
+      }
+    end
+
+    let(:template) { job.template('config/file_server.json') }
+    let(:rendered_template) { template.render(deployment_manifest_fragment) }
+
+    describe 'default configuration' do
+      it 'renders the config with default values' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['server_address']).to eq('0.0.0.0:8080')
+        expect(rendered_template_json['debug_address']).to eq('127.0.0.1:17005')
+        expect(rendered_template_json['static_directory']).to eq('/var/vcap/jobs/file_server/packages/')
+        expect(rendered_template_json['https_server_enabled']).to be false
+        expect(rendered_template_json['https_listen_addr']).to eq('0.0.0.0:8443')
+        expect(rendered_template_json['log_level']).to eq('info')
+      end
+
+      it 'uses rfc3339 time format' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['time_format']).to eq('rfc3339')
+      end
+
+      it 'does not include TLS cert paths when TLS is not configured' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['cert_file']).to be_nil
+        expect(rendered_template_json['key_file']).to be_nil
+        expect(rendered_template_json['client_ca_cert_file']).to be_nil
+      end
+    end
+
+    describe 'log level configuration' do
+      it 'sets the default log level to info' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['log_level']).to eq('info')
+      end
+
+      it 'allows setting custom log level' do
+        deployment_manifest_fragment['diego']['file_server']['log_level'] = 'debug'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['log_level']).to eq('debug')
+      end
+    end
+
+    describe 'IP address validation' do
+      it 'validates diego.file_server.listen_addr' do
+        deployment_manifest_fragment['diego']['file_server']['listen_addr'] = 'invalid-ip:8080'
+        expect do
+          rendered_template
+        end.to raise_error(/Invalid diego.file_server.listen_addr/)
+      end
+
+      it 'validates diego.file_server.debug_addr' do
+        deployment_manifest_fragment['diego']['file_server']['debug_addr'] = 'invalid-ip:17005'
+        expect do
+          rendered_template
+        end.to raise_error(/Invalid diego.file_server.debug_addr/)
+      end
+
+      it 'validates https_listen_addr' do
+        deployment_manifest_fragment['https_listen_addr'] = 'invalid-ip:8443'
+        expect do
+          rendered_template
+        end.to raise_error(/Invalid https_listen_addr/)
+      end
+
+      it 'accepts valid IPv4 addresses' do
+        deployment_manifest_fragment['diego']['file_server']['listen_addr'] = '10.0.0.1:8080'
+        deployment_manifest_fragment['diego']['file_server']['debug_addr'] = '127.0.0.1:17005'
+        deployment_manifest_fragment['https_listen_addr'] = '0.0.0.0:8443'
+        expect { rendered_template }.not_to raise_error
+      end
+    end
+
+    describe 'TLS configuration' do
+      context 'when TLS cert and key are provided' do
+        before do
+          deployment_manifest_fragment['tls'] = {
+            'cert' => 'TLS CERT',
+            'key' => 'TLS KEY'
+          }
+        end
+
+        it 'includes TLS cert and key file paths' do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['cert_file']).to eq('/var/vcap/jobs/file_server/config/certs/tls.crt')
+          expect(rendered_template_json['key_file']).to eq('/var/vcap/jobs/file_server/config/certs/tls.key')
+        end
+      end
+
+      context 'when TLS client CA cert is provided' do
+        before do
+          deployment_manifest_fragment['tls'] = {
+            'cert' => 'TLS CERT',
+            'key' => 'TLS KEY',
+            'client_ca_cert' => 'CLIENT CA CERT'
+          }
+        end
+
+        it 'includes client CA cert file path' do
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['client_ca_cert_file']).to eq('/var/vcap/jobs/file_server/config/certs/tls.client_ca_cert')
+        end
+      end
+
+      context 'when HTTPS server is enabled' do
+        before do
+          deployment_manifest_fragment['https_server_enabled'] = true
+        end
+
+        it 'requires both tls.cert and tls.key' do
+          expect do
+            rendered_template
+          end.to raise_error(/tls.cert and tls.key are required if https_server_enabled is set to true/)
+        end
+
+        it 'succeeds when both cert and key are provided' do
+          deployment_manifest_fragment['tls'] = {
+            'cert' => 'TLS CERT',
+            'key' => 'TLS KEY'
+          }
+          expect { rendered_template }.not_to raise_error
+        end
+
+        it 'renders HTTPS configuration' do
+          deployment_manifest_fragment['tls'] = {
+            'cert' => 'TLS CERT',
+            'key' => 'TLS KEY'
+          }
+          rendered_template_json = JSON.parse(rendered_template)
+          expect(rendered_template_json['https_server_enabled']).to be true
+          expect(rendered_template_json['https_listen_addr']).to eq('0.0.0.0:8443')
+        end
+      end
+    end
+
+    describe 'loggregator configuration' do
+      it 'includes loggregator configuration' do
+        rendered_template_json = JSON.parse(rendered_template)
+        loggregator_config = rendered_template_json['loggregator']
+
+        expect(loggregator_config['loggregator_api_port']).to eq(3458)
+        expect(loggregator_config['loggregator_ca_path']).to eq('/var/vcap/jobs/file_server/config/certs/loggregator/ca.crt')
+        expect(loggregator_config['loggregator_cert_path']).to eq('/var/vcap/jobs/file_server/config/certs/loggregator/client.crt')
+        expect(loggregator_config['loggregator_key_path']).to eq('/var/vcap/jobs/file_server/config/certs/loggregator/client.key')
+        expect(loggregator_config['loggregator_job_origin']).to eq('file_server')
+        expect(loggregator_config['loggregator_source_id']).to eq('file_server')
+      end
+
+      it 'uses custom loggregator port when specified' do
+        deployment_manifest_fragment['loggregator']['v2_api_port'] = 4444
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['loggregator']['loggregator_api_port']).to eq(4444)
+      end
+    end
+  end
+
+  describe 'tls.crt.erb' do
+    let(:template) { job.template('config/certs/tls.crt') }
+
+    it 'renders the TLS certificate when provided' do
+      deployment_manifest_fragment = { 'tls' => { 'cert' => 'TLS CERTIFICATE CONTENT' } }
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template).to include('TLS CERTIFICATE CONTENT')
+    end
+
+    it 'renders empty when tls.cert is not provided' do
+      deployment_manifest_fragment = {}
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template.strip).to be_empty
+    end
+  end
+
+  describe 'tls.key.erb' do
+    let(:template) { job.template('config/certs/tls.key') }
+
+    it 'renders the TLS key when provided' do
+      deployment_manifest_fragment = { 'tls' => { 'key' => 'TLS KEY CONTENT' } }
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template).to include('TLS KEY CONTENT')
+    end
+
+    it 'renders empty when tls.key is not provided' do
+      deployment_manifest_fragment = {}
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template.strip).to be_empty
+    end
+  end
+
+  describe 'tls.client_ca_cert.erb' do
+    let(:template) { job.template('config/certs/tls.client_ca_cert') }
+
+    it 'renders the client CA certificate when provided' do
+      deployment_manifest_fragment = { 'tls' => { 'client_ca_cert' => 'CLIENT CA CERTIFICATE CONTENT' } }
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template).to include('CLIENT CA CERTIFICATE CONTENT')
+    end
+
+    it 'renders empty when tls.client_ca_cert is not provided' do
+      deployment_manifest_fragment = {}
+      rendered_template = template.render(deployment_manifest_fragment)
+      expect(rendered_template.strip).to be_empty
+    end
+  end
+
+  describe 'loggregator certificate templates' do
+    describe 'loggregator_ca.crt.erb' do
+      let(:template) { job.template('config/certs/loggregator/ca.crt') }
+
+      it 'renders the loggregator CA certificate' do
+        deployment_manifest_fragment = { 'loggregator' => { 'ca_cert' => 'LOGGREGATOR CA CERT' } }
+        rendered_template = template.render(deployment_manifest_fragment)
+        expect(rendered_template).to include('LOGGREGATOR CA CERT')
+      end
+    end
+
+    describe 'loggregator_client.crt.erb' do
+      let(:template) { job.template('config/certs/loggregator/client.crt') }
+
+      it 'renders the loggregator client certificate' do
+        deployment_manifest_fragment = { 'loggregator' => { 'cert' => 'LOGGREGATOR CLIENT CERT' } }
+        rendered_template = template.render(deployment_manifest_fragment)
+        expect(rendered_template).to include('LOGGREGATOR CLIENT CERT')
+      end
+    end
+
+    describe 'loggregator_client.key.erb' do
+      let(:template) { job.template('config/certs/loggregator/client.key') }
+
+      it 'renders the loggregator client key' do
+        deployment_manifest_fragment = { 'loggregator' => { 'key' => 'LOGGREGATOR CLIENT KEY' } }
+        rendered_template = template.render(deployment_manifest_fragment)
+        expect(rendered_template).to include('LOGGREGATOR CLIENT KEY')
+      end
+    end
+  end
+end

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/config/config.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/config/config.go
@@ -17,6 +17,7 @@ type FileServerConfig struct {
 	HTTPSListenAddr    string `json:"https_listen_addr"`
 	CertFile           string `json:"cert_file"`
 	KeyFile            string `json:"key_file"`
+	ClientCACertFile   string `json:"client_ca_cert_file,omitempty"`
 
 	LoggregatorConfig loggingclient.Config `json:"loggregator"`
 	debugserver.DebugServerConfig

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/config/config_test.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/config/config_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Config", func() {
 			"https_listen_addr": "192.168.1.1:8443",
 			"cert_file": "/tmp/cert_file",
 			"key_file": "/tmp/key_file",
+			"client_ca_cert_file": "/tmp/client_ca_cert_file",
 
 			"debug_address": "127.0.0.1:17017",
 			"log_level": "debug"
@@ -57,6 +58,7 @@ var _ = Describe("Config", func() {
 			HTTPSListenAddr:    "192.168.1.1:8443",
 			CertFile:           "/tmp/cert_file",
 			KeyFile:            "/tmp/key_file",
+			ClientCACertFile:   "/tmp/client_ca_cert_file",
 
 			DebugServerConfig: debugserver.DebugServerConfig{
 				DebugAddress: "127.0.0.1:17017",

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/main.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/main.go
@@ -51,10 +51,15 @@ func main() {
 			logger.Fatal("invalid-https-configuration", nil)
 		}
 		var err error
-		tlsConfig, err = tlsconfig.Build(
+		builder := tlsconfig.Build(
 			tlsconfig.WithInternalServiceDefaults(),
 			tlsconfig.WithIdentityFromFile(cfg.CertFile, cfg.KeyFile),
-		).Server()
+		)
+		if strings.TrimSpace(cfg.ClientCACertFile) != "" {
+			tlsConfig, err = builder.Server(tlsconfig.WithClientAuthenticationFromFile(cfg.ClientCACertFile))
+		} else {
+			tlsConfig, err = builder.Server()
+		}
 		if err != nil {
 			logger.Fatal("failed-to-create-tls-config", err)
 		}

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/main_test.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/main_test.go
@@ -171,8 +171,9 @@ var _ = Describe("File server", func() {
 
 		Context("when all required HTTPS configuration is provided", func() {
 			var (
-				caCertPool        *x509.CertPool
-				certFile, keyFile *os.File
+				caCertPool                    *x509.CertPool
+				certFile, keyFile, caFile     *os.File
+				clientCertFile, clientKeyFile *os.File
 			)
 
 			BeforeEach(func() {
@@ -180,28 +181,50 @@ var _ = Describe("File server", func() {
 				Expect(err).NotTo(HaveOccurred())
 				cert, err := ca.BuildSignedCertificate("fileserver")
 				Expect(err).NotTo(HaveOccurred())
+				clientCert, err := ca.BuildSignedCertificate("client")
+				Expect(err).NotTo(HaveOccurred())
 				caCertPool, err = ca.CertPool()
 				Expect(err).NotTo(HaveOccurred())
 
+				caPem, err := ca.CertificatePEM()
+				Expect(err).NotTo(HaveOccurred())
 				pem, privKey, err := cert.CertificatePEMAndPrivateKey()
+				Expect(err).NotTo(HaveOccurred())
+				clientPem, clientPrivKey, err := clientCert.CertificatePEMAndPrivateKey()
 				Expect(err).NotTo(HaveOccurred())
 
 				certFile, err = os.CreateTemp("", "testcert")
 				Expect(err).NotTo(HaveOccurred())
 				keyFile, err = os.CreateTemp("", "testkey")
 				Expect(err).NotTo(HaveOccurred())
+				caFile, err = os.CreateTemp("", "testca")
+				Expect(err).NotTo(HaveOccurred())
+				clientCertFile, err = os.CreateTemp("", "testclientcert")
+				Expect(err).NotTo(HaveOccurred())
+				clientKeyFile, err = os.CreateTemp("", "testclientkey")
+				Expect(err).NotTo(HaveOccurred())
 
 				_, err = certFile.Write(pem)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = keyFile.Write(privKey)
 				Expect(err).NotTo(HaveOccurred())
+				_, err = caFile.Write(caPem)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = clientCertFile.Write(clientPem)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = clientKeyFile.Write(clientPrivKey)
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(certFile.Close()).To(Succeed())
 				Expect(keyFile.Close()).To(Succeed())
+				Expect(caFile.Close()).To(Succeed())
+				Expect(clientCertFile.Close()).To(Succeed())
+				Expect(clientKeyFile.Close()).To(Succeed())
 
 				cfg.HTTPSListenAddr = fmt.Sprintf("localhost:%d", tlsPort)
 				cfg.CertFile = certFile.Name()
 				cfg.KeyFile = keyFile.Name()
+				cfg.ClientCACertFile = caFile.Name()
 			})
 
 			JustBeforeEach(func() {
@@ -212,11 +235,14 @@ var _ = Describe("File server", func() {
 			AfterEach(func() {
 				Expect(os.Remove(certFile.Name())).To(Succeed())
 				Expect(os.Remove(keyFile.Name())).To(Succeed())
+				Expect(os.Remove(caFile.Name())).To(Succeed())
+				Expect(os.Remove(clientCertFile.Name())).To(Succeed())
+				Expect(os.Remove(clientKeyFile.Name())).To(Succeed())
 			})
 
 			It("should successfully return the test file on an HTTPS GET request", func() {
 				clientTLSConfig, err := tlsconfig.Build(
-					tlsconfig.WithInternalServiceDefaults(),
+					tlsconfig.WithIdentityFromFile(clientCertFile.Name(), clientKeyFile.Name()),
 				).Client(tlsconfig.WithAuthority(caCertPool))
 				Expect(err).NotTo(HaveOccurred())
 
@@ -240,7 +266,7 @@ var _ = Describe("File server", func() {
 
 			It("fails to return test when caCertPool is missing", func() {
 				clientTLSConfig, err := tlsconfig.Build(
-					tlsconfig.WithInternalServiceDefaults(),
+					tlsconfig.WithIdentityFromFile(clientCertFile.Name(), clientKeyFile.Name()),
 				).Client()
 				Expect(err).NotTo(HaveOccurred())
 
@@ -250,12 +276,28 @@ var _ = Describe("File server", func() {
 					},
 				}
 				_, err = httpClient.Get(fmt.Sprintf("https://localhost:%d/v1/static/test", tlsPort))
-				Expect(err.Error()).To(ContainSubstring("x509: certificate signed by unknown authority"))
+				Expect(err.Error()).To(ContainSubstring("tls: failed to verify certificate: x509:"))
+			})
+
+			It("fails to return test when client certificate is not provided (mTLS required)", func() {
+				clientTLSConfig, err := tlsconfig.Build(
+					tlsconfig.WithInternalServiceDefaults(),
+				).Client(tlsconfig.WithAuthority(caCertPool))
+				Expect(err).NotTo(HaveOccurred())
+
+				httpClient := &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: clientTLSConfig,
+					},
+				}
+				_, err = httpClient.Get(fmt.Sprintf("https://localhost:%d/v1/static/test", tlsPort))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tls: certificate required"))
 			})
 
 			It("should return a 301 redirect to the HTTPS URL when making an HTTP Get request", func() {
 				clientTLSConfig, err := tlsconfig.Build(
-					tlsconfig.WithInternalServiceDefaults(),
+					tlsconfig.WithIdentityFromFile(clientCertFile.Name(), clientKeyFile.Name()),
 				).Client(tlsconfig.WithAuthority(caCertPool))
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Summary
---------------
- optional tls.client_ca_cert to specify a CA cert for mtls
- if configured, fileserver requires a client cert signed by client_ca_cert
- add tests for file_server template rendering

Backward Compatibility
---------------
Breaking Change? **No**
