### PR TITLE
Fix debug server config for file-server

### DIFF
--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -38,8 +38,8 @@ properties:
     default: "/var/vcap/jobs/file_server/packages/"
     description: "Fully-qualified path to the doc root for the file server's static files"
   diego.file_server.debug_addr:
-    description: "address at which to serve debug info"
-    default: "127.0.0.1:17005"
+    description: "Address at which to serve debug info, e.g. 127.0.0.1:17005. Debug server is disabled when empty (default)"
+    default: ""
   diego.file_server.log_level:
     description: "Log level"
     default: "info"

--- a/spec/file_server_template_spec.rb
+++ b/spec/file_server_template_spec.rb
@@ -17,8 +17,8 @@ describe 'file_server' do
           'file_server' => {
             'listen_addr' => '0.0.0.0:8080',
             'static_directory' => '/var/vcap/jobs/file_server/packages/',
-            'debug_addr' => '127.0.0.1:17005',
-            'log_level' => 'info'
+            'log_level' => 'info',
+            'debug_addr' => ''
           }
         },
         'https_server_enabled' => false,
@@ -39,7 +39,7 @@ describe 'file_server' do
       it 'renders the config with default values' do
         rendered_template_json = JSON.parse(rendered_template)
         expect(rendered_template_json['server_address']).to eq('0.0.0.0:8080')
-        expect(rendered_template_json['debug_address']).to eq('127.0.0.1:17005')
+        expect(rendered_template_json['debug_address']).to eq('')
         expect(rendered_template_json['static_directory']).to eq('/var/vcap/jobs/file_server/packages/')
         expect(rendered_template_json['https_server_enabled']).to be false
         expect(rendered_template_json['https_listen_addr']).to eq('0.0.0.0:8443')
@@ -69,6 +69,19 @@ describe 'file_server' do
         deployment_manifest_fragment['diego']['file_server']['log_level'] = 'debug'
         rendered_template_json = JSON.parse(rendered_template)
         expect(rendered_template_json['log_level']).to eq('debug')
+      end
+    end
+
+    describe 'debug_addr configuration' do
+      it 'sets debug_address to empty string by default' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['debug_address']).to eq('')
+      end
+
+      it 'renders the debug_address when debug_addr is configured' do
+        deployment_manifest_fragment['diego']['file_server']['debug_addr'] = '127.0.0.1:17005'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['debug_address']).to eq('127.0.0.1:17005')
       end
     end
 

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/main.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/main.go
@@ -68,7 +68,7 @@ func main() {
 		{Name: "file server", Runner: initializeServer(logger, cfg.StaticDirectory, cfg.ServerAddress, cfg.HTTPSListenAddr, tlsConfig)},
 	}
 
-	if dbgAddr := debugserver.DebugAddress(flag.CommandLine); dbgAddr != "" {
+	if dbgAddr := cfg.DebugAddress; dbgAddr != "" {
 		members = append(grouper.Members{
 			{Name: "debug-server", Runner: debugserver.Runner(dbgAddr, reconfigurableSink)},
 		}, members...)

--- a/src/code.cloudfoundry.org/fileserver/cmd/file-server/main_test.go
+++ b/src/code.cloudfoundry.org/fileserver/cmd/file-server/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"code.cloudfoundry.org/debugserver"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
 
 	"code.cloudfoundry.org/fileserver/cmd/file-server/config"
@@ -320,6 +321,109 @@ var _ = Describe("File server", func() {
 				location, err := resp.Location()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(location.String()).To(Equal(fmt.Sprintf("https://file-server.service.test.com:%d/v1/static/test", tlsPort)))
+			})
+		})
+	})
+
+	Context("debug server", func() {
+		var debugPort int
+
+		BeforeEach(func() {
+			servedDirectory, err = os.MkdirTemp("", "file_server-test")
+			Expect(err).NotTo(HaveOccurred())
+
+			port = 8182 + GinkgoParallelProcess()
+			debugPort = 17005 + GinkgoParallelProcess()
+		})
+
+		Context("when debug_address is configured", func() {
+			BeforeEach(func() {
+				cfg = config.FileServerConfig{
+					LagerConfig: lagerflags.LagerConfig{
+						LogLevel:   lagerflags.INFO,
+						TimeFormat: lagerflags.FormatUnixEpoch,
+					},
+					LoggregatorConfig: loggingclient.Config{
+						CACertPath: metronCAFile,
+						CertPath:   metronServerCertFile,
+						KeyPath:    metronServerKeyFile,
+					},
+					StaticDirectory: servedDirectory,
+					ServerAddress:   fmt.Sprintf("localhost:%d", port),
+				}
+				cfg.DebugAddress = fmt.Sprintf("127.0.0.1:%d", debugPort)
+			})
+
+			JustBeforeEach(func() {
+				cfg.LoggregatorConfig.APIPort, _ = testIngressServer.Port()
+				configFile, err := os.CreateTemp("", "file_server-test-config")
+				Expect(err).NotTo(HaveOccurred())
+				configPath = configFile.Name()
+
+				encoder := json.NewEncoder(configFile)
+				err = encoder.Encode(&cfg)
+				Expect(err).NotTo(HaveOccurred())
+
+				session = start()
+			})
+
+			It("should start the debug server and respond to requests", func() {
+				Eventually(func() error {
+					resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", debugPort))
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("expected status 200, got %d", resp.StatusCode)
+					}
+					return nil
+				}).Should(Succeed())
+			})
+		})
+
+		Context("when debug_address is not configured", func() {
+			BeforeEach(func() {
+				cfg = config.FileServerConfig{
+					LagerConfig: lagerflags.LagerConfig{
+						LogLevel:   lagerflags.INFO,
+						TimeFormat: lagerflags.FormatUnixEpoch,
+					},
+					LoggregatorConfig: loggingclient.Config{
+						CACertPath: metronCAFile,
+						CertPath:   metronServerCertFile,
+						KeyPath:    metronServerKeyFile,
+					},
+					StaticDirectory: servedDirectory,
+					ServerAddress:   fmt.Sprintf("localhost:%d", port),
+					DebugServerConfig: debugserver.DebugServerConfig{
+						DebugAddress: "",
+					},
+				}
+			})
+
+			JustBeforeEach(func() {
+				cfg.LoggregatorConfig.APIPort, _ = testIngressServer.Port()
+				configFile, err := os.CreateTemp("", "file_server-test-config")
+				Expect(err).NotTo(HaveOccurred())
+				configPath = configFile.Name()
+
+				encoder := json.NewEncoder(configFile)
+				err = encoder.Encode(&cfg)
+				Expect(err).NotTo(HaveOccurred())
+
+				session = start()
+			})
+
+			It("should not start the debug server", func() {
+				Consistently(func() error {
+					resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", debugPort))
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+					return nil
+				}).Should(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
Summary
---------------

fileserver expected debugserver config on cmd line but bosh configures it via file_server.json. As a consequence, the debug server was always disabled.

Changed fileserver to start debug server when configured in file_server.json. Disabled debug server by default.


Backward Compatibility
---------------
Breaking Change? **No**
