### PR TITLE
Add BOSH properties for Locket DB health check.

### DIFF
--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -72,6 +72,18 @@ properties:
     default: false
   diego.locket.sql.ca_cert:
     description: "Bundle of CA certificates for the Locket to verify the SQL server SSL certificate when connecting via SSL"
+  diego.locket.health_check_timeout:
+    description: "Number of seconds to wait for the DB health check insert/retrieve operation to time out"
+    default: 5
+  diego.locket.health_check_interval:
+    description: "Number of seconds to wait between DB health checks"
+    default: 10
+  diego.locket.health_check_failure_threshold:
+    description: "Number of consecutive failed DB health checks before restarting Locket"
+    default: 3
+  diego.locket.enable_db_health_check:
+    description: "Whether or not to enable DB health checks in Locket to ensure it restarts in a timely fashion upon severe DB degradation"
+    default: false
 
   loggregator.v2_api_port:
     description: "Local metron agent gRPC port"

--- a/jobs/locket/templates/locket.json.erb
+++ b/jobs/locket/templates/locket.json.erb
@@ -27,6 +27,8 @@ config = {
   log_level: p("diego.locket.log_level"),
   max_open_database_connections: p("database.max_open_connections"),
   max_database_connection_lifetime: "1h",
+  health_check_failure_threshold: p("diego.locket.health_check_failure_threshold"),
+  enable_db_health_check: p("diego.locket.enable_db_health_check"),
 }
 
 def db_params
@@ -76,6 +78,14 @@ end
 
   if_p("diego.locket.sql.db_write_timeout") do |value|
     config[:db_write_timeout] = "#{value}s" # add time unit
+  end
+
+  if_p("diego.locket.health_check_timeout") do |value|
+    config[:health_check_timeout] = "#{value}s" # add time unit
+  end
+
+  if_p("diego.locket.health_check_interval") do |value|
+    config[:health_check_interval] = "#{value}s" # add time unit
   end
 
 config[:time_format] = "rfc3339"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds BOSH job properties to configure the Locket database health check feature implemented in [cloudfoundry/locket#38](https://github.com/cloudfoundry/locket/pull/38)

**Resolves**: #1105

  **New Properties**:
  - `diego.locket.enable_db_health_check` - Feature flag (default: `false`)
  - `diego.locket.health_check_interval` - Check frequency (default: `10` seconds)
  - `diego.locket.health_check_timeout` - Check timeout (default: `5` seconds)
  - `diego.locket.health_check_failure_threshold` - Failures before restart (default: `3`)

  **Related Work**:
  - Locket implementation: [cloudfoundry/locket#XXX](https://github.com/cloudfoundry/locket/pull/38)
  - BBS BOSH properties: #1088
  - BBS implementation: cloudfoundry/bbs#134

  ### Test Results

  Tested on dev landscape with Cloud Foundry deployment:

  - ✅ **Test 1**: Default disabled, no behavior change
  - ✅ **Test 2**: Properties correctly templated, health checks run every 10s
  - ✅ **Test 3**: Detected database failure, auto-restart works
  - ✅ **Test 4**: Timeout configuration works correctly
  - ✅ **Test 5**: All property values applied correctly with time units

  ### Deployment Example

  ```yaml
  instance_groups:
  - name: diego-api
    jobs:
    - name: locket
      properties:
        diego:
          locket:
            enable_db_health_check: true
            health_check_interval: 10
            health_check_timeout: 5
            health_check_failure_threshold: 3
```

### Backward Compatibility

Breaking Change? **No**

All properties have safe defaults and the feature is **disabled by default**. Operators can upgrade without manifest changes. Health check can be enabled after upgrade via configuration-only deployment.