### PR TITLE
vizzini: expect task result on failure (match rep behavior)

### DIFF
--- a/src/code.cloudfoundry.org/vizzini/tasks_test.go
+++ b/src/code.cloudfoundry.org/vizzini/tasks_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Tasks", func() {
 				Expect(bbsClient.DesireTask(logger, traceID, guid, domain, task)).To(Succeed())
 			})
 
-			It("should be marked as failed and should not return the result file", func() {
+			It("should be marked as failed and should return the result file", func() {
 				Eventually(TaskGetter(logger, guid)).Should(HaveTaskState(models.Task_Completed))
 
 				task, err := bbsClient.TaskByGuid(logger, traceID, guid)
@@ -134,7 +134,7 @@ var _ = Describe("Tasks", func() {
 				Expect(task.TaskGuid).To(Equal(guid))
 				Expect(task.Failed).To(BeTrue())
 
-				Expect(task.Result).To(BeEmpty())
+				Expect(task.Result).ToNot(BeEmpty())
 
 				Expect(bbsClient.ResolvingTask(logger, traceID, guid)).To(Succeed())
 				Expect(bbsClient.DeleteTask(logger, traceID, guid)).To(Succeed())


### PR DESCRIPTION
Summary
---------------
The Rep commit https://github.com/cloudfoundry/rep/commit/f8415d49931852a637b5a2171770cf90b931285a  ensures the result file is sent back even when there is a failure. However, this new behavior broke the vizzini test suite which did not expect a result file upon failure. This PR changes the vizzini test code to match the new Rep behavior.

Failing test: 
https://github.com/cloudfoundry/diego-release/blob/develop/src/code.cloudfoundry.org/vizzini/tasks_test.go#L137

Backward Compatibility
---------------
No
