### PR TITLE
Increase BBS nf_conntrack_max

### DIFF
--- a/jobs/bbs/templates/set-bbs-kernel-params.erb
+++ b/jobs/bbs/templates/set-bbs-kernel-params.erb
@@ -16,11 +16,15 @@ echo 10 > /proc/sys/net/ipv4/tcp_fin_timeout
 
 echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
 
-# nf_conntrack_max
-# Sets this to 65535 (the default when using 2gb+ of memory), so that if a BBS node has <2gb of memory,
-# it does not suffer from severe networking slowness when BBS handles many apps/cells, but on limited memory.
+# NF_CONNTRACK_MAX
+# Only set to 65535 if the current value is less than or equal to 65535.
+# This ensures machines with low memory get a reasonable minimum value,
+# while allowing the kernel default to be used on machines with more memory.
 modprobe nf_conntrack
-echo 65535 > /proc/sys/net/netfilter/nf_conntrack_max
+current_value=$(cat /proc/sys/net/netfilter/nf_conntrack_max)
+if [ "$current_value" -le 65535 ]; then
+  echo 65535 > /proc/sys/net/netfilter/nf_conntrack_max
+fi
 <% else %>
 echo "Not setting /proc/sys/ parameters"
 <% end %>


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

## Summary

  Increase BBS `nf_conntrack_max` from 65535 to 262144 to match the REP configuration.

  ## Motivation

  The current `nf_conntrack_max` value of 65535 in the BBS kernel parameters is too low and can cause networking issues when BBS handles many apps and cells. 

  ## Changes

  - Updated `jobs/bbs/templates/set-bbs-kernel-params.erb`:
    - Changed `nf_conntrack_max` from 65535 to 262144
    - Updated comment to reflect the new value and rationale

  ## Impact

  This change will prevent BBS from running out of connection tracking entries under high load, improving stability and networking performance for deployments with many applications and cells.


Backward Compatibility
---------------
Breaking Change? **No**