### PR TITLE
Evict file cache when cf-pcap flag changes

### DIFF
--- a/jobs/rep/templates/setup_mounted_data_dirs.erb
+++ b/jobs/rep/templates/setup_mounted_data_dirs.erb
@@ -59,6 +59,27 @@ cache_dir=${garden_shared_dir}/download_cache
 mkdir -p "$cache_dir"
 chown -R vcap:vcap $cache_dir
 
+# Invalidate download cache when extraction-relevant config changes.
+# The cf-pcap flag changes how archived files are extracted (xattrs
+# preservation), so a flag change requires re-extraction. Removing
+# saved_cache.json causes RecoverState() to treat this as a first boot,
+# which clears all cached files.
+cache_config_marker=/var/vcap/data/rep/cache_config
+current_cache_config="enable_cf_pcap=<%= p("diego.rep.enable_cf_pcap", false) %>"
+
+if [ -f "$cache_config_marker" ]; then
+  previous_cache_config=$(cat "$cache_config_marker")
+else
+  previous_cache_config=""
+fi
+
+if [ "$current_cache_config" != "$previous_cache_config" ]; then
+  rm -f "${cache_dir}/saved_cache.json"
+fi
+
+echo "$current_cache_config" > "$cache_config_marker"
+chown vcap:vcap "$cache_config_marker"
+
 trusted_certs_dir=${garden_shared_dir}/trusted_certs
 rm -rf "$trusted_certs_dir"
 <% if_p("containers.trusted_ca_certificates") do %>


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Since the flag controls whether rep can extract extended file attributes or not, the cache needs to be invalidated when the flag changes. Otherwise the extended file attributes might be missing after enabling the feature or they might still linger around even though the operator already disabled the feature.


Backward Compatibility
---------------
Breaking Change? **No**

Resolves #1117 
