### PR TITLE
Replace pre-commit symlink with bash script

### DIFF
--- a/src/code.cloudfoundry.org/cfdot/git-hooks/pre-commit
+++ b/src/code.cloudfoundry.org/cfdot/git-hooks/pre-commit
@@ -1,1 +1,2 @@
-../scripts/generate-cfdot-documentation
+#!/bin/bash
+"$(dirname "$0")/../scripts/generate-cfdot-documentation"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Concourse v8.1.1 introduced a security check (PR #9486) that blocks volume streaming to Windows workers if a volume contains a symlink pointing outside of its target directory. The 'git-hooks/pre-commit' symlink pointed to '../scripts/generate-cfdot-documentation', causing the 'build-binaries-for-diego-release-windows' task to fail with a 'links outside of target directory' error.

Replacing the symlink with a bash script that executes the target script resolves this streaming failure while maintaining the hook's functionality.

Backward Compatibility
---------------
Breaking Change? No
