### PR TITLE
change default for diego.rep.extra_root_fs_dir

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -59,7 +59,7 @@ properties:
     default: ""
   diego.rep.extra_root_fs_dir:
     description: "dir to scan for extra rootfs to be loaded by rep"
-    default: "/var/vcap/store/rootfses"
+    default: "/var/vcap/data/rootfses"
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"
     default:

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -53,7 +53,7 @@ properties:
     default: ""
   diego.rep.extra_root_fs_dir:
     description: "dir to scan for extra rootfs to be loaded by rep"
-    default: "/var/vcap/store/rootfses"
+    default: "/var/vcap/data/rootfses"
   diego.rep.rootfs_providers:
     description: "Array of schemes for which the underlying garden can support arbitrary root filesystems"
     default: []

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -92,8 +92,8 @@ describe 'rep' do
     end
 
     context 'extra_root_fs_dir' do
-      it 'is set to /var/vcap/store/rootfses by default' do
-        expect(JSON.parse(rendered_template)['extra_root_fs_dir']).to eq('/var/vcap/store/rootfses')
+      it 'is set to /var/vcap/data/rootfses by default' do
+        expect(JSON.parse(rendered_template)['extra_root_fs_dir']).to eq('/var/vcap/data/rootfses')
       end
 
       it 'is configurable' do

--- a/spec/rep_windows_template_spec.rb
+++ b/spec/rep_windows_template_spec.rb
@@ -92,8 +92,8 @@ describe 'rep' do
     end
 
     context 'extra_root_fs_dir' do
-      it 'is set to /var/vcap/store/rootfses by default' do
-        expect(JSON.parse(rendered_template)['extra_root_fs_dir']).to eq('/var/vcap/store/rootfses')
+      it 'is set to /var/vcap/data/rootfses by default' do
+        expect(JSON.parse(rendered_template)['extra_root_fs_dir']).to eq('/var/vcap/data/rootfses')
       end
 
       it 'is configurable' do

--- a/src/code.cloudfoundry.org/cfdot/git-hooks/pre-commit
+++ b/src/code.cloudfoundry.org/cfdot/git-hooks/pre-commit
@@ -1,1 +1,2 @@
-../scripts/generate-cfdot-documentation
+#!/bin/bash
+"$(dirname "$0")/../scripts/generate-cfdot-documentation"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
/var/vcap/store is for persistent data. /var/vcap/data is for ephemeral data. Storing the rootfs data under /var/vcap/store, was an issue because since there is no persistent disk on the cell the rootfs was getting stored on the smaller root disk.


Backward Compatibility
---------------
Breaking Change? No

No one but internal components should be relying on where this info is stored.