### PR TITLE
sni based routing for tcp apps

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
@@ -89,9 +89,11 @@ func NewEndpoint(
 }
 
 type ExternalEndpointInfo struct {
-	RouterGroupGUID string
-	Port            uint32
-	TLSEnabled      bool
+	RouterGroupGUID      string
+	Port                 uint32
+	TLSEnabled           bool
+	SniHostname          string
+	TerminateFrontendTLS bool
 }
 
 func (info ExternalEndpointInfo) Hash() interface{} {
@@ -107,6 +109,12 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 		tlsContainerPort = int(e.ContainerTlsProxyPort)
 		instanceGUID = e.InstanceGUID
 	}
+
+	var sniHostname *string
+	if info.SniHostname != "" {
+		sniHostname = &info.SniHostname
+	}
+
 	mapping := tcpmodels.NewTcpRouteMapping(
 		info.RouterGroupGUID,
 		uint16(info.Port),
@@ -114,11 +122,11 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 		uint16(e.Port),
 		tlsHostPort,
 		instanceGUID,
-		nil,
+		sniHostname,
 		nil,
 		0,
 		tcpmodels.ModificationTag{},
-		false,
+		info.TerminateFrontendTLS,
 		"",
 	)
 	if e.IsDirectInstanceRoute(directInstanceRoute) {
@@ -129,11 +137,11 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 			uint16(e.ContainerPort),
 			tlsContainerPort,
 			instanceGUID,
-			nil,
+			sniHostname,
 			nil,
 			0,
 			tcpmodels.ModificationTag{},
-			false,
+			info.TerminateFrontendTLS,
 			"",
 		)
 	}

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
@@ -262,6 +262,44 @@ var _ = Describe("LRP Utils", func() {
 			})
 		})
 	})
+
+	Describe("MessageFor", func() {
+		var (
+			endpoint             routingtable.Endpoint
+			externalEndpointInfo routingtable.ExternalEndpointInfo
+		)
+
+		BeforeEach(func() {
+			endpoint = routingtable.Endpoint{
+				InstanceGUID:          "instance-guid",
+				Host:                  "host",
+				Port:                  1234,
+				ContainerIP:           "container-ip",
+				ContainerPort:         5678,
+				TlsProxyPort:          61001,
+				ContainerTlsProxyPort: 61002,
+			}
+			externalEndpointInfo = routingtable.ExternalEndpointInfo{
+				RouterGroupGUID:      "router-group-guid",
+				Port:                 8080,
+				TLSEnabled:           true,
+				SniHostname:          "sni-hostname",
+				TerminateFrontendTLS: true,
+			}
+		})
+
+		It("returns a TcpRouteMapping with the expected fields", func() {
+			_, mapping, _ := externalEndpointInfo.MessageFor(endpoint, false, false)
+			Expect(mapping.RouterGroupGuid).To(Equal("router-group-guid"))
+			Expect(mapping.ExternalPort).To(Equal(uint16(8080)))
+			Expect(mapping.HostIP).To(Equal("host"))
+			Expect(mapping.HostPort).To(Equal(uint16(1234)))
+			Expect(mapping.HostTLSPort).To(Equal(61001))
+			Expect(mapping.InstanceId).To(Equal("instance-guid"))
+			Expect(*mapping.SniHostname).To(Equal("sni-hostname"))
+			Expect(mapping.TerminateFrontendTLS).To(BeTrue())
+		})
+	})
 })
 
 func newEndpointWithTlsProxyPort(

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable.go
@@ -471,11 +471,16 @@ func (g tcpRoutesGenerator) RoutesFrom(lrp *models.DesiredLRP) map[RoutingKey][]
 	for _, route := range routes {
 		key := RoutingKey{ProcessGUID: lrp.ProcessGuid, ContainerPort: route.ContainerPort}
 
-		routeEntries[key] = append(routeEntries[key], ExternalEndpointInfo{
-			RouterGroupGUID: route.RouterGroupGuid,
-			Port:            route.ExternalPort,
-			TLSEnabled:      g.tlsEnabled,
-		})
+		info := ExternalEndpointInfo{
+			RouterGroupGUID:      route.RouterGroupGuid,
+			Port:                 route.ExternalPort,
+			TLSEnabled:           g.tlsEnabled,
+			TerminateFrontendTLS: route.TerminateFrontendTLS,
+		}
+		if route.SniHostname != nil {
+			info.SniHostname = *route.SniHostname
+		}
+		routeEntries[key] = append(routeEntries[key], info)
 	}
 	return routeEntries
 }

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
@@ -96,6 +96,34 @@ var _ = Describe("TCPRoutingTable", func() {
 		}
 	})
 
+	Context("when TCP route specifies SNI and terminate_frontend_tls", func() {
+		BeforeEach(func() {
+			modificationTag = &models.ModificationTag{Epoch: "abc", Index: 1}
+			routingTable = routingtable.NewRoutingTable(false, true, fakeMetronClient)
+			sni := "sni-hostname"
+			sniTcpRoutes := tcp_routes.TCPRoutes{
+				{
+					RouterGroupGuid:      "router-group-guid",
+					ExternalPort:         61000,
+					ContainerPort:        8080,
+					SniHostname:          &sni,
+					TerminateFrontendTLS: true,
+				},
+			}
+			beforeLRP := getDesiredLRP("process-guid-sni", "log-guid-sni", sniTcpRoutes, modificationTag)
+			_, _ = routingTable.SetRoutes(logger, nil, beforeLRP)
+		})
+
+		It("emits TcpRouteMapping with SNI and terminate_frontend_tls on AddEndpoint", func() {
+			actual := getActualLRP("process-guid-sni", "instance-guid-sni", "some-ip-1", "container-ip-1", 62004, 8080, 61443, 5443, modificationTag)
+			events, _ := routingTable.AddEndpoint(logger, actual)
+			sni := "sni-hostname"
+			Expect(events.Registrations).To(ConsistOf(
+				tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-sni", &sni, nil, 0, tcpmodels.ModificationTag{}, true, ""),
+			))
+		})
+	})
+
 	Context("when no entry exist for route", func() {
 		BeforeEach(func() {
 			routingTable = routingtable.NewRoutingTable(false, false, fakeMetronClient)


### PR DESCRIPTION
ai-assisted=yes
TNZ-81099

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adding sni route and tls terminate property to endpoint info

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
