### PR TITLE
Fix Windows unit test compatibility and port management

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/assets/fake_app_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/assets/fake_app_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,10 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 
 	AfterEach(func() {
 		gexec.CleanupBuildArtifacts()
+		// On Windows, add a small delay to ensure ports are released
+		if runtime.GOOS == "windows" {
+			time.Sleep(500 * time.Millisecond)
+		}
 	})
 
 	DescribeTable("fake app should exit with correct exit codes",
@@ -62,7 +67,7 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			actualExitCode := session.ExitCode()
 			if exitCode == 134 {
 				// SIGABRT simulation via panic results in exit code 2 cross-platform
-				Expect(actualExitCode).To(Equal(2), 
+				Expect(actualExitCode).To(Equal(2),
 					fmt.Sprintf("Expected panic exit code 2 for SIGABRT simulation, got %d", actualExitCode))
 			} else {
 				Expect(actualExitCode).To(Equal(exitCode))
@@ -79,6 +84,17 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			command.Env = append(command.Env, "PORT=28090")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Ensure cleanup on test completion
+			defer func() {
+				if session.ExitCode() == -1 { // Process still running
+					session.Kill()
+				}
+				// On Windows, add extra cleanup time
+				if runtime.GOOS == "windows" {
+					time.Sleep(100 * time.Millisecond)
+				}
+			}()
 
 			// Wait for server to start
 			Eventually(func() error {
@@ -109,6 +125,17 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Ensure cleanup on test completion
+			defer func() {
+				if session.ExitCode() == -1 { // Process still running
+					session.Kill()
+				}
+				// On Windows, add extra cleanup time
+				if runtime.GOOS == "windows" {
+					time.Sleep(100 * time.Millisecond)
+				}
+			}()
+
 			// Wait for server to start
 			Eventually(func() error {
 				client := &http.Client{Timeout: 1 * time.Second}
@@ -138,6 +165,17 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Ensure cleanup on test completion
+			defer func() {
+				if session.ExitCode() == -1 { // Process still running
+					session.Kill()
+				}
+				// On Windows, add extra cleanup time
+				if runtime.GOOS == "windows" {
+					time.Sleep(100 * time.Millisecond)
+				}
+			}()
+
 			// Wait for app to start listening
 			Eventually(func() error {
 				client := &http.Client{Timeout: 1 * time.Second}
@@ -152,8 +190,14 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			// Send SIGTERM to simulate natural shutdown
 			session.Terminate()
 
-			// Should exit with code 42
-			Eventually(session, 10*time.Second).Should(gexec.Exit(143))
+			// Cross-platform exit code handling
+			if runtime.GOOS == "windows" {
+				// Windows doesn't have SIGTERM, process exits naturally
+				Eventually(session, 10*time.Second).Should(gexec.Exit(42))
+			} else {
+				// Unix systems: SIGTERM results in exit code 143 (128 + 15)
+				Eventually(session, 10*time.Second).Should(gexec.Exit(143))
+			}
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/inigo/cell/assets/fake_proxy_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/assets/fake_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,10 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 
 	AfterEach(func() {
 		gexec.CleanupBuildArtifacts()
+		// On Windows, add a small delay to ensure ports are released
+		if runtime.GOOS == "windows" {
+			time.Sleep(500 * time.Millisecond)
+		}
 	})
 
 	// Helper function for normal exit codes
@@ -34,6 +39,17 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		command := exec.Command(proxyPath)
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure cleanup on test completion
+		defer func() {
+			if session.ExitCode() == -1 { // Process still running
+				session.Kill()
+			}
+			// On Windows, add extra cleanup time
+			if runtime.GOOS == "windows" {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}()
 
 		// Wait for proxy to start listening on port 61001
 		Eventually(func() error {
@@ -63,6 +79,17 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Ensure cleanup on test completion
+		defer func() {
+			if session.ExitCode() == -1 { // Process still running
+				session.Kill()
+			}
+			// On Windows, add extra cleanup time
+			if runtime.GOOS == "windows" {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}()
+
 		// Wait for proxy to start listening on port 61001
 		Eventually(func() error {
 			client := &http.Client{Timeout: 1 * time.Second}
@@ -85,7 +112,7 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 
 		// Verify SIGABRT simulation exit code (panic results in exit code 2)
 		actualExitCode := session.ExitCode()
-		Expect(actualExitCode).To(Equal(2), 
+		Expect(actualExitCode).To(Equal(2),
 			fmt.Sprintf("Expected panic exit code 2 for SIGABRT simulation, got %d", actualExitCode))
 	}
 
@@ -108,6 +135,17 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		command := exec.Command(fakeProxyPath)
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure cleanup on test completion
+		defer func() {
+			if session.ExitCode() == -1 { // Process still running
+				session.Kill()
+			}
+			// On Windows, add extra cleanup time
+			if runtime.GOOS == "windows" {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}()
 
 		// Wait for proxy to start
 		Eventually(func() error {
@@ -154,6 +192,17 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Ensure cleanup on test completion
+		defer func() {
+			if session.ExitCode() == -1 { // Process still running
+				session.Kill()
+			}
+			// On Windows, add extra cleanup time
+			if runtime.GOOS == "windows" {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}()
+
 		// Wait for proxy to start listening
 		Eventually(func() error {
 			client := &http.Client{Timeout: 1 * time.Second}
@@ -168,7 +217,13 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		// Send SIGTERM to simulate natural shutdown
 		session.Terminate()
 
-		// Should exit with code 42
-		Eventually(session, 10*time.Second).Should(gexec.Exit(143))
+		// Cross-platform exit code handling
+		if runtime.GOOS == "windows" {
+			// Windows doesn't have SIGTERM, process exits naturally
+			Eventually(session, 10*time.Second).Should(gexec.Exit(42))
+		} else {
+			// Unix systems: SIGTERM results in exit code 143 (128 + 15)
+			Eventually(session, 10*time.Second).Should(gexec.Exit(143))
+		}
 	})
 })


### PR DESCRIPTION
Addresses Windows-specific test failures in fake app/proxy unit tests:

1. **Signal Handling Fix**:
   - Added cross-platform signal handling for SIGTERM tests
   - Windows: expect exit code 42 (natural termination)
   - Unix: expect exit code 143 (128 + SIGTERM signal 15)

2. **Port Management Improvements**:
   - Added aggressive session cleanup with defer functions
   - Added Windows-specific delays to allow port release
   - Ensures all test processes are properly terminated
   - Prevents "Only one usage of each socket address" errors

3. **Session Lifecycle Management**:
   - Added proper session cleanup to all unit tests
   - Kill any remaining processes after test completion
   - Cross-platform cleanup timing adjustments

These changes ensure unit tests pass on both Windows and Unix platforms while maintaining the same test behavior and coverage.

Made-with: Cursor

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
