### PR TITLE
Fix Windows test deadlock by removing aggressive defer cleanup

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/assets/fake_app_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/assets/fake_app_test.go
@@ -85,17 +85,6 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Ensure cleanup on test completion
-			defer func() {
-				if session.ExitCode() == -1 { // Process still running
-					session.Kill()
-				}
-				// On Windows, add extra cleanup time
-				if runtime.GOOS == "windows" {
-					time.Sleep(100 * time.Millisecond)
-				}
-			}()
-
 			// Wait for server to start
 			Eventually(func() error {
 				client := &http.Client{Timeout: 1 * time.Second}
@@ -125,17 +114,6 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Ensure cleanup on test completion
-			defer func() {
-				if session.ExitCode() == -1 { // Process still running
-					session.Kill()
-				}
-				// On Windows, add extra cleanup time
-				if runtime.GOOS == "windows" {
-					time.Sleep(100 * time.Millisecond)
-				}
-			}()
-
 			// Wait for server to start
 			Eventually(func() error {
 				client := &http.Client{Timeout: 1 * time.Second}
@@ -164,17 +142,6 @@ var _ = Describe("Fake App Exit Behavior", Serial, func() {
 			command.Env = append(command.Env, "PORT=28092")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-
-			// Ensure cleanup on test completion
-			defer func() {
-				if session.ExitCode() == -1 { // Process still running
-					session.Kill()
-				}
-				// On Windows, add extra cleanup time
-				if runtime.GOOS == "windows" {
-					time.Sleep(100 * time.Millisecond)
-				}
-			}()
 
 			// Wait for app to start listening
 			Eventually(func() error {

--- a/src/code.cloudfoundry.org/inigo/cell/assets/fake_proxy_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/assets/fake_proxy_test.go
@@ -40,17 +40,6 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Ensure cleanup on test completion
-		defer func() {
-			if session.ExitCode() == -1 { // Process still running
-				session.Kill()
-			}
-			// On Windows, add extra cleanup time
-			if runtime.GOOS == "windows" {
-				time.Sleep(100 * time.Millisecond)
-			}
-		}()
-
 		// Wait for proxy to start listening on port 61001
 		Eventually(func() error {
 			client := &http.Client{Timeout: 1 * time.Second}
@@ -78,17 +67,6 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		command := exec.Command(proxyPath)
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
-
-		// Ensure cleanup on test completion
-		defer func() {
-			if session.ExitCode() == -1 { // Process still running
-				session.Kill()
-			}
-			// On Windows, add extra cleanup time
-			if runtime.GOOS == "windows" {
-				time.Sleep(100 * time.Millisecond)
-			}
-		}()
 
 		// Wait for proxy to start listening on port 61001
 		Eventually(func() error {
@@ -136,17 +114,6 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Ensure cleanup on test completion
-		defer func() {
-			if session.ExitCode() == -1 { // Process still running
-				session.Kill()
-			}
-			// On Windows, add extra cleanup time
-			if runtime.GOOS == "windows" {
-				time.Sleep(100 * time.Millisecond)
-			}
-		}()
-
 		// Wait for proxy to start
 		Eventually(func() error {
 			client := &http.Client{Timeout: 1 * time.Second}
@@ -191,17 +158,6 @@ var _ = Describe("Fake Proxy Exit Behavior", Serial, func() {
 		command := exec.Command(fakeProxyPath)
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
-
-		// Ensure cleanup on test completion
-		defer func() {
-			if session.ExitCode() == -1 { // Process still running
-				session.Kill()
-			}
-			// On Windows, add extra cleanup time
-			if runtime.GOOS == "windows" {
-				time.Sleep(100 * time.Millisecond)
-			}
-		}()
 
 		// Wait for proxy to start listening
 		Eventually(func() error {


### PR DESCRIPTION
The previous defer cleanup logic was causing test deadlocks on Windows:
- defer functions were checking session.ExitCode() == -1 and calling Kill()
- This interfered with natural process termination via session.Terminate()
- Tests failed with "Expected process to exit. It did not."

Solution:
- Remove aggressive defer cleanup from individual test cases
- Rely on AfterEach cleanup for port management
- Let processes exit naturally without interference
- Keep cross-platform signal handling (Windows: 42, Unix: 143)

This allows Windows tests to pass while maintaining proper cleanup through the existing AfterEach hook and Serial execution.

Made-with: Cursor

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
