### PR TITLE
diego-release: startup resilience fixes for BOSH upgrades (tnz-96144, tnz-96145)

### DIFF
--- a/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main_test.go
+++ b/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main_test.go
@@ -141,9 +141,12 @@ var _ = Describe("Auctioneer", func() {
 			testIngressServer.Stop()
 		})
 
-		It("exits with non-zero status code", func() {
-			auctioneerProcess = ifrit.Background(runner)
-			Eventually(auctioneerProcess.Wait()).Should(Receive(HaveOccurred()))
+		// diego-logging-client now dials loggregator non-blocking (lazy). The
+		// auctioneer starts successfully and retries the connection in the
+		// background, so it must NOT exit when metron is temporarily unavailable.
+		It("starts successfully and does not exit", func() {
+			auctioneerProcess = ginkgomon.Invoke(runner)
+			Consistently(auctioneerProcess.Wait()).ShouldNot(Receive())
 		})
 	})
 

--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main_test.go
@@ -444,9 +444,13 @@ var _ = Describe("Route Emitter", func() {
 			runner = createEmitterRunner("emitter1", "", cfgs...)
 		})
 
-		It("exit with non-zero status code", func() {
-			emitter = ifrit.Background(runner)
-			Eventually(emitter.Wait()).Should(Receive(HaveOccurred()))
+		// diego-logging-client now dials loggregator non-blocking (lazy). The
+		// route-emitter starts successfully and retries the connection in the
+		// background, so it must NOT exit when the loggregator agent is
+		// temporarily unavailable.
+		It("starts successfully and does not exit", func() {
+			emitter = ginkgomon.Invoke(runner)
+			Consistently(emitter.Wait()).ShouldNot(Receive())
 		})
 	})
 


### PR DESCRIPTION
## Summary
This PR bundles two independent startup resilience improvements that reduce unnecessary Monit restart cycles during BOSH rolling upgrades of Diego cells.

## Fix 1 — Garden health check retry on startup (tnz-96144)

During BOSH starting_jobs, Monit starts Garden and rep simultaneously. Garden requires ~60–90 seconds to warm up before it can successfully create containers. Previously, the executor's Garden health check would fail fatally on the very first transient error, causing rep to exit and enter a ~53s Monit restart cycle.

This fix (landed in [cloudfoundry/executor#130](https://github.com/cloudfoundry/executor/pull/130)) makes the initial health check resilient to transient errors by retrying in a bounded loop until GardenHealthcheckTimeout (default 10m) expires.

Key properties preserved:

The cell is correctly marked as unhealthy during the retry phase so BBS does not schedule LRPs there.
An UnrecoverableError (e.g. bad TLS certs) still causes an immediate fatal exit — only transient connection errors trigger the retry.

A fatal error is triggered if the full timeout is reached, ensuring permanently broken Garden instances are still detected and the CellUnhealthy metric is emitted.

Picked up via the upstream bot submodule bump in 1aa487f83 (executor → 9e97ac1b). No additional submodule change needed in this PR.

## Fix 2 — Non-blocking Loggregator dial on startup (tnz-96145)

diego-logging-client [tnz-96145](https://github.com/cloudfoundry/diego-logging-client/pull/XXX) removed grpc.WithBlock() from NewIngressClient. Previously, if metron_agent was not yet listening at startup (common during stemcell rolls), any component using NewIngressClient would fail to start and enter a Monit restart cycle (~53s). With the non-blocking dial, the gRPC connection is established lazily in the background — the component starts immediately and retries the connection automatically.

This affects four components whose test suites asserted the old "exits when metron is down" behaviour. This PR updates those tests to assert the new correct behaviour: the component starts and keeps running when metron is temporarily unavailable.

<img width="856" height="249" alt="image" src="https://github.com/user-attachments/assets/1b1b39cb-4574-40c8-a82b-829717f8a39f" />

The rep submodule bump also picks up [cloudfoundry/rep#84](https://github.com/cloudfoundry/rep/pull/84) (tnz-96147 — silk-daemon init retry), which landed upstream before this PR.

## Backward Compatibility
Breaking Change? No

Both fixes modify internal startup resilience only. No external APIs, metric definitions, or failure conditions are changed. Both are fully backwards compatible and take effect immediately on all deployments.
