### PR TITLE
diego-ssh: update loggregator-down test for non-blocking dial (tnz-96…

### DIFF
--- a/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/main_test.go
@@ -772,8 +772,12 @@ var _ = Describe("SSH proxy", Serial, func() {
 					testIngressServer.Stop()
 				})
 
-				It("exits with non-zero status code", func() {
-					Eventually(process.Wait()).Should(Receive(HaveOccurred()))
+				// diego-logging-client now dials loggregator non-blocking (lazy).
+				// ssh-proxy starts successfully and retries the connection in the
+				// background, so it must NOT exit when the loggregator server is
+				// temporarily unavailable.
+				It("starts successfully and does not exit", func() {
+					Consistently(process.Wait()).ShouldNot(Receive())
 				})
 			})
 


### PR DESCRIPTION
## Summary
Fixes a test that became invalid after the non-blocking loggregator dial change (tnz-96145) landed in diego-logging-client.

**Why this PR is necessary**

cloudfoundry/diego-logging-client#<N> (tnz-96145) removed grpc.WithBlock() and grpc.WithTimeout() from NewIngressClient, making the loggregator gRPC dial non-blocking (lazy). Previously, if the loggregator server was unavailable at startup, NewIngressClient returned an error after a 1-second dial timeout, ssh-proxy logged
"failed-to-initialize-metron-client", and exited with a non-zero status.

With the lazy dial, the call always succeeds immediately and ssh-proxy starts normally, retrying the connection to the loggregator server in the background.

The test:

  "SSH proxy / authenticating with the diego realm metrics / when the loggregator server isn't up / exits with non-zero status code"

used:

  `Eventually(process.Wait()).Should(Receive(HaveOccurred()))`

This now times out because ssh-proxy no longer exits when the loggregator server is unavailable. The assertion is changed to:

  `Consistently(process.Wait()).ShouldNot(Receive())`

which correctly describes the new behaviour: ssh-proxy starts successfully and keeps running when the loggregator server is temporarily unavailable.

**Prior work**

- Non-blocking loggregator dial: cloudfoundry/diego-logging-client#<N> (tnz-96145)
- Same fix applied to: auctioneer, route-emitter (merged upstream PR #1140), bbs (merged upstream PR #146), rep (cloudfoundry/rep#<N>), locket (cloudfoundry/locket#<N>)

## Backward Compatibility
Breaking Change? **No**

Test-only change. No production code, BOSH jobs, or manifests are modified. The new behaviour (ssh-proxy starts successfully when the loggregator server is transiently unavailable and reconnects lazily) is the intended outcome of the diego-logging-client change and improves startup resilience during BOSH rolling upgrades.