### PR TITLE
Add db_operation_timeout BOSH property for locket

### DIFF
--- a/jobs/locket/spec
+++ b/jobs/locket/spec
@@ -64,9 +64,12 @@ properties:
   diego.locket.sql.db_read_timeout: 
     description: "Timeout in seconds for a db client to wait for data to be received from the server"
     default: "60"
-  diego.locket.sql.db_write_timeout: 
+  diego.locket.sql.db_write_timeout:
     description: "Timeout in seconds for a db client to wait for data to be sent to the server"
     default: "60"
+  diego.locket.sql.db_operation_timeout:
+    description: "Timeout in seconds for handler-initiated DB operations (Lock, Release, Fetch). Independent of gRPC client deadline."
+    default: "10"
   diego.locket.sql.require_ssl:
     description: "Whether to require SSL for Locket communication to the SQL backend"
     default: false

--- a/jobs/locket/templates/locket.json.erb
+++ b/jobs/locket/templates/locket.json.erb
@@ -80,6 +80,10 @@ end
     config[:db_write_timeout] = "#{value}s" # add time unit
   end
 
+  if_p("diego.locket.sql.db_operation_timeout") do |value|
+    config[:db_operation_timeout] = "#{value}s" # add time unit
+  end
+
   if_p("diego.locket.health_check_timeout") do |value|
     config[:health_check_timeout] = "#{value}s" # add time unit
   end

--- a/spec/locket_template_spec.rb
+++ b/spec/locket_template_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+
+describe 'locket' do
+  let(:release_path) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
+  let(:job) { release.job('locket') }
+
+  describe 'locket.json.erb' do
+    let(:deployment_manifest_fragment) do
+      {
+        'diego' => {
+          'locket' => {
+            'listen_addr' => '0.0.0.0:8891',
+            'debug_addr' => '127.0.0.1:17018',
+            'log_level' => 'info',
+            'health_check_timeout' => 5,
+            'health_check_interval' => 10,
+            'health_check_failure_threshold' => 3,
+            'enable_db_health_check' => false,
+            'sql' => {
+              'db_host' => 'sql-db.service.cf.internal',
+              'db_port' => 5432,
+              'db_schema' => 'locket',
+              'db_username' => 'locket',
+              'db_password' => 'locket_pw',
+              'db_driver' => 'postgres',
+              'require_ssl' => false
+            }
+          }
+        },
+        'database' => {
+          'max_open_connections' => 200,
+          'tls' => {
+            'enable_identity_verification' => true
+          }
+        },
+        'tls' => {
+          'ca_cert' => 'CA CERT',
+          'cert' => 'SERVER CERT',
+          'key' => 'SERVER KEY'
+        },
+        'loggregator' => {
+          'v2_api_port' => 3458,
+          'ca_cert' => 'LOGGREGATOR CA',
+          'cert' => 'LOGGREGATOR CERT',
+          'key' => 'LOGGREGATOR KEY'
+        },
+        'set_kernel_parameters' => true
+      }
+    end
+
+    let(:template) { job.template('config/locket.json') }
+    let(:rendered_template) { template.render(deployment_manifest_fragment) }
+
+    describe 'Database timeout configurations' do
+      it 'includes db_operation_timeout when specified' do
+        deployment_manifest_fragment['diego']['locket']['sql']['db_operation_timeout'] = '15'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_operation_timeout']).to eq('15s')
+      end
+
+      it 'uses default db_operation_timeout of 10s when not overridden' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_operation_timeout']).to eq('10s')
+      end
+
+      it 'includes db_connection_timeout when specified' do
+        deployment_manifest_fragment['diego']['locket']['sql']['db_connection_timeout'] = '30'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_connection_timeout']).to eq('30s')
+      end
+
+      it 'includes db_read_timeout when specified' do
+        deployment_manifest_fragment['diego']['locket']['sql']['db_read_timeout'] = '60'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_read_timeout']).to eq('60s')
+      end
+
+      it 'includes db_write_timeout when specified' do
+        deployment_manifest_fragment['diego']['locket']['sql']['db_write_timeout'] = '60'
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['db_write_timeout']).to eq('60s')
+      end
+    end
+
+    describe 'basic configuration' do
+      it 'renders a valid JSON config' do
+        rendered_template_json = JSON.parse(rendered_template)
+        expect(rendered_template_json['listen_address']).to eq('0.0.0.0:8891')
+        expect(rendered_template_json['database_driver']).to eq('postgres')
+        expect(rendered_template_json['max_open_database_connections']).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Companion change for [cloudfoundry/locket#40](https://github.com/cloudfoundry/locket/pull/40)

Resubmission of #1141 (reverted in #1148 due to merge conflict with health check properties).

### What was wrong with #1141

The PR was based on `v2.135.0` and didn't account for the health check `if_p` blocks added to `locket.json.erb` on `develop`. When merged, the auto-merge produced broken ERB (syntax error at line 109). This version is rebased on current `develop` with the conflict properly resolved.

### Changes

- **`jobs/locket/spec`** — new property `diego.locket.sql.db_operation_timeout` (default: `"10"` seconds)
- **`jobs/locket/templates/locket.json.erb`** — renders the property as `"db_operation_timeout": "10s"`
- **`spec/locket_template_spec.rb`** — new template spec for locket (6 examples)

### Testing

```
$ rspec spec/locket_template_spec.rb
6 examples, 0 failures

$ rspec spec/
95 examples, 1 failure (pre-existing auctioneer IPAddr issue, unrelated)
```

### Related

- [CFAR-1388](https://jira.tools.sap/browse/CFAR-1388)
- [cloudfoundry/locket#40](https://github.com/cloudfoundry/locket/pull/40)
- [cloudfoundry/diego-release#1129](https://github.com/cloudfoundry/diego-release/issues/1129)