### PR TITLE
Inigo should have native passwords enabled

### DIFF
--- a/src/code.cloudfoundry.org/inigo/bin/test.ps1
+++ b/src/code.cloudfoundry.org/inigo/bin/test.ps1
@@ -67,7 +67,8 @@ datadir=C:\\var\\vcap\\data\\mysql
 ssl-cert=$certFile
 ssl-key=$keyFile
 ssl-ca=$caFile
-max_connections=1000"
+max_connections=1000
+mysql_native_password=ON"
 
   Restart-Service Mysql
 }


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Inigo overwrites mysql config and needs mysql native passwd to login



Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
