### PR TITLE
Revert "Sync .github dir templates"

### DIFF
--- a/.github/gh-config-template/README.md
+++ b/.github/gh-config-template/README.md
@@ -1,0 +1,16 @@
+# Generate github actions from template
+
+ytt -f ./gh_template.yml -f [ytt-helpers.star](https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/shared/helpers/ytt-helpers.star) -f [index.yml](https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/diego-release/index.yml) > ./workflows/tests-workflow.yml
+
+## Supported jobs
+- Template tests
+- Lint repo
+- Basic Verifications
+- Unit and Integration tests (without DB)
+- Unit and Integration tests (MySQL 5.7)
+- Unit and Integration tests (Postgres)
+- Unit and Integration tests (MySQL 8.0)
+
+### How to run
+
+Workflow runs automatically on pull requests targeting the `develop` branch.

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -1,0 +1,238 @@
+#@ load("@ytt:data", "data")
+#@ load("ytt-helpers.star", "helpers")
+name: unit-integration-tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - develop
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'jobs/**'
+      - 'config/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
+      - '.github/helpers/**'
+
+env:
+  MAPPING: |
+    build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2
+  FLAGS: |
+    --keep-going
+    --trace
+    -r
+    --fail-on-pending
+    --randomize-all
+    --nodes=7
+    --race
+    --timeout 30m
+    --flake-attempts 2
+  RUN_AS: root
+  VERIFICATIONS: |
+    verify_go repo/$DIR
+    verify_gofmt repo/$DIR
+    verify_govet repo/$DIR
+    verify_staticcheck repo/$DIR
+  FUNCTIONS: ci/diego-release/helpers/build-binaries.bash
+  DB: ""
+
+jobs:
+  repo-clone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: diego-release-repo
+        uses: actions/checkout@v4.3.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          submodules: recursive
+          path: repo
+      - name: Check out wg-appruntime code
+        uses: actions/checkout@v4.3.1
+        with:
+          repository: cloudfoundry/wg-app-platform-runtime-ci
+          path: ci
+      - name: zip repo artifacts
+        run: |
+          tar -czf repo-artifact.tar.gz repo
+          tar -czf ci-artifact.tar.gz ci
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: |
+            repo-artifact.tar.gz
+            ci-artifact.tar.gz
+  determine-image-tag:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    outputs:
+      go_version: ${{ steps.get-version.outputs.go_version }}
+    steps:
+    - name: checkout ci repo
+      uses: actions/checkout@v4.3.1
+      with:
+        repository: cloudfoundry/wg-app-platform-runtime-ci
+        sparse-checkout: go-version.json
+        sparse-checkout-cone-mode: false
+    - name: get-version
+      id: get-version
+      run: |
+        version=$(jq -r '.releases["diego"] // .default' go-version.json)
+        echo "go_version=${version}" >> "$GITHUB_OUTPUT"
+  template-tests:
+    runs-on: ubuntu-latest
+    needs: [repo-clone]
+    container: cloudfoundry/tas-runtime-build:latest
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: template-tests
+      run: |
+        "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-tests-templates/task.bash
+  lint-repo:
+    runs-on: ubuntu-latest
+    needs: [repo-clone]
+    container: cloudfoundry/tas-runtime-build:latest
+    env:
+      LINTERS: |
+        sync-package-specs.bash
+        sync-submodule-config.bash
+        match-golang-os-package-versions.bash
+        check-envoy-versions.bash
+        check-for-windows-drift.bash
+        check-proto-files.bash
+        check-metrics-documentation.bash
+        check-expiring-certs.bash
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: lint-repo
+      run: |
+        "${GITHUB_WORKSPACE}"/ci/shared/tasks/lint-repo/task.bash
+  test-on-mysql-5-7:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-5.7:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ for package in helpers.packages_with_configure_db(data.values.internal_repos):
+    - name: #@ "{}-mysql".format(package.name)
+      env:
+        DIR: #@ "src/code.cloudfoundry.org/{}".format(package.name)
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ end
+  test-repos-withoutdb:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-build:${{ needs.determine-image-tag.outputs.go_version }}
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ for package in helpers.packages_without_configure_db(data.values.internal_repos):
+    - name: #@ package.name
+      env:
+        DIR: #@ "src/code.cloudfoundry.org/{}".format(package.name)
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ end
+  test-on-postgres:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-postgres:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: postgres
+      DB_PASSWORD: ""
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ for package in helpers.packages_with_configure_db(data.values.internal_repos):
+    - name: #@ "{}-postgres".format(package.name)
+      env:
+        DIR: #@ "src/code.cloudfoundry.org/{}".format(package.name)
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ end
+  test-on-mysql-8-0:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-8.0:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ for package in helpers.packages_with_configure_db(data.values.internal_repos):
+    - name: #@ "{}-mysql".format(package.name)
+      env:
+        DIR: #@ "src/code.cloudfoundry.org/{}".format(package.name)
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+#@ end
+#! test

--- a/.github/helpers/build.bash
+++ b/.github/helpers/build.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+GH_WORKSPACE=$1
+BUILD_IMAGE=$2
+docker run --cap-add=SYS_ADMIN --rm --privileged \
+	-v "$GH_WORKSPACE:/workspace" \
+	-w /workspace \
+	-e MAPPING="$MAPPING" -e RUN_AS="$RUN_AS" -e FUNCTIONS="$FUNCTIONS" \
+	"$BUILD_IMAGE" \
+	bash ci/shared/tasks/build-binaries/task.bash

--- a/.github/helpers/test.bash
+++ b/.github/helpers/test.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+GH_WORKSPACE=$1
+BUILD_IMAGE=$2
+docker run --cap-add=SYS_ADMIN --rm --privileged \
+	-v "$GH_WORKSPACE:/workspace" \
+	-w /workspace \
+	-e MAPPING="$MAPPING" -e DB="$DB" -e DIR="$DIR" -e RUN_AS="$RUN_AS" \
+	-e VERIFICATIONS="$VERIFICATIONS" -e FUNCTIONS="$FUNCTIONS" \
+	-e FLAGS="$FLAGS" \
+	-e DB_USER="${DB_USER:-}" -e DB_PASSWORD="${DB_PASSWORD:-}" \
+	"$BUILD_IMAGE" \
+	bash ci/shared/tasks/run-bin-test/task.bash

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,0 +1,334 @@
+name: unit-integration-tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - develop
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'jobs/**'
+      - 'config/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
+      - '.github/helpers/**'
+env:
+  MAPPING: |
+    build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2
+  FLAGS: |
+    --keep-going
+    --trace
+    -r
+    --fail-on-pending
+    --randomize-all
+    --nodes=7
+    --race
+    --timeout 30m
+    --flake-attempts 2
+  RUN_AS: root
+  VERIFICATIONS: |
+    verify_go repo/$DIR
+    verify_gofmt repo/$DIR
+    verify_govet repo/$DIR
+    verify_staticcheck repo/$DIR
+  FUNCTIONS: ci/diego-release/helpers/build-binaries.bash
+  DB: ""
+jobs:
+  repo-clone:
+    runs-on: ubuntu-latest
+    steps:
+    - name: diego-release-repo
+      uses: actions/checkout@v4.3.1
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        submodules: recursive
+        path: repo
+    - name: Check out wg-appruntime code
+      uses: actions/checkout@v4.3.1
+      with:
+        repository: cloudfoundry/wg-app-platform-runtime-ci
+        path: ci
+    - name: zip repo artifacts
+      run: |
+        tar -czf repo-artifact.tar.gz repo
+        tar -czf ci-artifact.tar.gz ci
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: repo
+        path: |
+          repo-artifact.tar.gz
+          ci-artifact.tar.gz
+  determine-image-tag:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    outputs:
+      go_version: ${{ steps.get-version.outputs.go_version }}
+    steps:
+    - name: checkout ci repo
+      uses: actions/checkout@v4.3.1
+      with:
+        repository: cloudfoundry/wg-app-platform-runtime-ci
+        sparse-checkout: go-version.json
+        sparse-checkout-cone-mode: false
+    - name: get-version
+      id: get-version
+      run: |
+        version=$(jq -r '.releases["diego"] // .default' go-version.json)
+        echo "go_version=${version}" >> "$GITHUB_OUTPUT"
+  template-tests:
+    runs-on: ubuntu-latest
+    needs: [repo-clone]
+    container: cloudfoundry/tas-runtime-build:latest
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: template-tests
+      run: |
+        "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-tests-templates/task.bash
+  lint-repo:
+    runs-on: ubuntu-latest
+    needs: [repo-clone]
+    container: cloudfoundry/tas-runtime-build:latest
+    env:
+      LINTERS: |
+        sync-package-specs.bash
+        sync-submodule-config.bash
+        match-golang-os-package-versions.bash
+        check-envoy-versions.bash
+        check-for-windows-drift.bash
+        check-proto-files.bash
+        check-metrics-documentation.bash
+        check-expiring-certs.bash
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: lint-repo
+      run: |
+        "${GITHUB_WORKSPACE}"/ci/shared/tasks/lint-repo/task.bash
+  test-on-mysql-5-7:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-5.7:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: bbs-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/bbs
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auctioneer-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/auctioneer
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: rep-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/rep
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: route-emitter-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/route-emitter
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: locket-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/locket
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cfdot-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/cfdot
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+  test-repos-withoutdb:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-build:${{ needs.determine-image-tag.outputs.go_version }}
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auction
+      env:
+        DIR: src/code.cloudfoundry.org/auction
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: executor
+      env:
+        DIR: src/code.cloudfoundry.org/executor
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: diego-ssh
+      env:
+        DIR: src/code.cloudfoundry.org/diego-ssh
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: fileserver
+      env:
+        DIR: src/code.cloudfoundry.org/fileserver
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: healthcheck
+      env:
+        DIR: src/code.cloudfoundry.org/healthcheck
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+  test-on-postgres:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-postgres:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: postgres
+      DB_PASSWORD: ""
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: bbs-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/bbs
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auctioneer-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/auctioneer
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: rep-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/rep
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: route-emitter-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/route-emitter
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: locket-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/locket
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cfdot-postgres
+      env:
+        DIR: src/code.cloudfoundry.org/cfdot
+        DB: postgres
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+  test-on-mysql-8-0:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-8.0:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: bbs-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/bbs
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auctioneer-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/auctioneer
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: rep-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/rep
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: route-emitter-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/route-emitter
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: locket-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/locket
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cfdot-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/cfdot
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"


### PR DESCRIPTION
## Summary

- Reverts commit 4f1e412 which accidentally deleted GitHub Actions workflow files via the sync-dot-github-dir Concourse job
- Restores 5 deleted files:
  - `.github/workflows/tests-workflow.yml`
  - `.github/helpers/build.bash`
  - `.github/helpers/test.bash`
  - `.github/gh-config-template/gh_template.yml`
  - `.github/gh-config-template/README.md`

## Root cause

The `sync-dot-github-dir` task in `wg-app-platform-runtime-ci` uses `rm -rf ".github"` before re-syncing templates, which wipes all `.github/` contents including `workflows/`, `helpers/`, and `gh-config-template/` that are not part of the synced template set.

A fix has been applied to `wg-app-platform-runtime-ci/shared/tasks/sync-dot-github-dir/task.bash` to only remove sync-owned files going forward.

## Test plan
- [ ] Verify all 5 files are restored
- [ ] Confirm GitHub Actions `unit-integration-tests` workflow is active after merge