### PR TITLE
Fix windows

### DIFF
--- a/src/code.cloudfoundry.org/executor/depot/depot.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot.go
@@ -3,7 +3,6 @@ package depot
 import (
 	"io"
 	"sync"
-	"syscall"
 
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/containerstore"
@@ -228,16 +227,9 @@ func (c *client) Ping(logger lager.Logger) error {
 }
 
 func (c *client) TotalResources(logger lager.Logger) (executor.ExecutorResources, error) {
-	diskMB := c.totalCapacity.DiskMB
-	if c.diskPath != "" {
-		var stat syscall.Statfs_t
-		if err := syscall.Statfs(c.diskPath, &stat); err == nil {
-			diskMB = int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
-		}
-	}
 	return executor.ExecutorResources{
 		MemoryMB:   c.totalCapacity.MemoryMB,
-		DiskMB:     diskMB,
+		DiskMB:     getDiskMB(c.diskPath, c.totalCapacity.DiskMB),
 		Containers: c.totalCapacity.Containers,
 	}, nil
 }

--- a/src/code.cloudfoundry.org/executor/depot/depot_unix.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package depot
+
+import "syscall"
+
+func getDiskMB(diskPath string, fallback int) int {
+	if diskPath == "" {
+		return fallback
+	}
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(diskPath, &stat); err == nil {
+		return int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+	}
+	return fallback
+}

--- a/src/code.cloudfoundry.org/executor/depot/depot_windows.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+// +build windows
+
+package depot
+
+func getDiskMB(_ string, fallback int) int {
+	return fallback
+}

--- a/src/code.cloudfoundry.org/inigo/cell/long_running_healthchecks_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/long_running_healthchecks_test.go
@@ -19,7 +19,6 @@ import (
 	"code.cloudfoundry.org/inigo/helpers"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
-	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/rep/cmd/rep/config"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"

--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -18,6 +18,7 @@ import (
 	auctioneerconfig "code.cloudfoundry.org/auctioneer/cmd/auctioneer/config"
 	"code.cloudfoundry.org/bbs"
 	bbsconfig "code.cloudfoundry.org/bbs/cmd/bbs/config"
+	"code.cloudfoundry.org/bbs/models"
 	bbsrunner "code.cloudfoundry.org/bbs/cmd/bbs/testrunner"
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/bbs/encryption"


### PR DESCRIPTION
  fix(depot): split syscall.Statfs into platform files to fix Windows build

  syscall.Statfs_t and syscall.Statfs are undefined on Windows. Commit
  236f79598 inlined the executor submodule and introduced this call into
  depot.go without a build tag, breaking go vet on Windows.

  Extract getDiskMB into depot_unix.go (build tag: !windows) and
  depot_windows.go (build tag: windows), following the existing pattern
  from transformer_unix.go / transformer_windows.go in this package.
  Windows falls back to the static configured DiskMB, which matches
  behavior before 236f79598.