### PR TITLE
fix(inigo): remove duplicate bbs/models import in world/components.go

### DIFF
--- a/src/code.cloudfoundry.org/inigo/world/components.go
+++ b/src/code.cloudfoundry.org/inigo/world/components.go
@@ -18,7 +18,6 @@ import (
 	auctioneerconfig "code.cloudfoundry.org/auctioneer/cmd/auctioneer/config"
 	"code.cloudfoundry.org/bbs"
 	bbsconfig "code.cloudfoundry.org/bbs/cmd/bbs/config"
-	"code.cloudfoundry.org/bbs/models"
 	bbsrunner "code.cloudfoundry.org/bbs/cmd/bbs/testrunner"
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/bbs/encryption"


### PR DESCRIPTION
  The go-fmt-ugh and develop branches both independently added the same
  import line, causing a models redeclared in this block go vet failure
  after the merge.

ai-assisted=yes
TNZ-92428
