### PR TITLE
fix(inigo): replace deprecated http.Transport.Dial with DialContext i…

### DIFF
--- a/src/code.cloudfoundry.org/inigo/cell/ssh_test.go
+++ b/src/code.cloudfoundry.org/inigo/cell/ssh_test.go
@@ -1,9 +1,11 @@
 package cell_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -215,7 +217,9 @@ var _ = Describe("SSH", func() {
 
 			httpClient := &http.Client{
 				Transport: &http.Transport{
-					Dial: client.Dial,
+					DialContext: func(_ context.Context, n, addr string) (net.Conn, error) {
+						return client.Dial(n, addr)
+					},
 				},
 				Timeout: 5 * time.Second,
 			}
@@ -283,7 +287,9 @@ var _ = Describe("SSH", func() {
 
 				httpClient := &http.Client{
 					Transport: &http.Transport{
-						Dial: client.Dial,
+						DialContext: func(_ context.Context, n, addr string) (net.Conn, error) {
+							return client.Dial(n, addr)
+						},
 					},
 					Timeout: 5 * time.Second,
 				}


### PR DESCRIPTION
SA1019: net/http.Transport.Dial deprecated since Go 1.7; DialContext takes priority.