### PR TITLE
Fix download cache bloat and stale disk capacity reporting causing Diego cell disk full

### DIFF
--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -138,12 +138,6 @@ jobs:
     - name: build binaries
       run: |
         repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: bbs-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/bbs
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
     - name: auctioneer-mysql
       env:
         DIR: src/code.cloudfoundry.org/auctioneer
@@ -159,12 +153,6 @@ jobs:
     - name: route-emitter-mysql
       env:
         DIR: src/code.cloudfoundry.org/route-emitter
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: locket-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/locket
         DB: mysql
       run: |
         repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
@@ -239,12 +227,6 @@ jobs:
     - name: build binaries
       run: |
         repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: bbs-postgres
-      env:
-        DIR: src/code.cloudfoundry.org/bbs
-        DB: postgres
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
     - name: auctioneer-postgres
       env:
         DIR: src/code.cloudfoundry.org/auctioneer
@@ -260,12 +242,6 @@ jobs:
     - name: route-emitter-postgres
       env:
         DIR: src/code.cloudfoundry.org/route-emitter
-        DB: postgres
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: locket-postgres
-      env:
-        DIR: src/code.cloudfoundry.org/locket
         DB: postgres
       run: |
         repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
@@ -296,12 +272,6 @@ jobs:
     - name: build binaries
       run: |
         repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: bbs-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/bbs
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
     - name: auctioneer-mysql
       env:
         DIR: src/code.cloudfoundry.org/auctioneer
@@ -317,12 +287,6 @@ jobs:
     - name: route-emitter-mysql
       env:
         DIR: src/code.cloudfoundry.org/route-emitter
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: locket-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/locket
         DB: mysql
       run: |
         repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -147,6 +147,9 @@ properties:
   diego.executor.max_cache_size_in_bytes:
     description: "maximum size of the cache in bytes - this should leave a healthy overhead for temporary items, etc."
     default: 10000000000
+  diego.executor.min_cache_partition_free_bytes:
+    description: "Minimum free space in bytes that must remain on the disk where the download cache lives. When actual disk free space falls below this threshold, the cache deletes old downloaded files to recover space. Set to 0 to disable this behavior."
+    default: 5368709120
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -125,6 +125,8 @@
     raise "additional_memory_allocation_mb cannot be negative"
   end
 
+  config[:min_cache_partition_free_bytes] = p("diego.executor.min_cache_partition_free_bytes")
+
   if_p("diego.executor.volman.driver_paths") do |value|
     config[:volman_driver_paths] = value
   end

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -129,6 +129,9 @@ properties:
   diego.executor.max_cache_size_in_bytes:
     description: "maximum size of the cache in bytes - this should leave a healthy overhead for temporary items, etc."
     default: 10000000000
+  diego.executor.min_cache_partition_free_bytes:
+    description: "EXPERIMENTAL: Additional memory allocated to each container for the envoy proxy. This must not be negative. Currently doesn't work on windows cells but left here for compatability with the linux Rep."
+    default: 5368709120
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -122,6 +122,8 @@
     raise "additional_memory_allocation_mb cannot be negative"
   end
 
+  config[:min_cache_partition_free_bytes] = p("diego.executor.min_cache_partition_free_bytes")
+
   if_p("diego.executor.volman.driver_paths") do |value|
     config[:volman_driver_paths] = value
   end

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -123,6 +123,17 @@ describe 'rep' do
         expect(JSON.parse(rendered_template)['sidecar_root_fs']).to eq('cflinuxfs4')
       end
     end
+
+    context 'min_cache_partition_free_bytes' do
+      it 'defaults to 5368709120 (5GB)' do
+        expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(5_368_709_120)
+      end
+
+      it 'is configurable' do
+        deployment_manifest_fragment['diego']['executor']['min_cache_partition_free_bytes'] = 1_073_741_824
+        expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(1_073_741_824)
+      end
+    end
   end
 
   describe 'setup_mounted_data_dirs.erb' do

--- a/spec/rep_windows_template_spec.rb
+++ b/spec/rep_windows_template_spec.rb
@@ -123,5 +123,16 @@ describe 'rep' do
         expect(JSON.parse(rendered_template)['sidecar_root_fs']).to eq('cflinuxfs4')
       end
     end
+
+    context 'min_cache_partition_free_bytes' do
+      it 'defaults to 5368709120 (5GB)' do
+        expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(5_368_709_120)
+      end
+
+      it 'is configurable' do
+        deployment_manifest_fragment['diego']['executor']['min_cache_partition_free_bytes'] = 1_073_741_824
+        expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(1_073_741_824)
+      end
+    end
   end
 end

--- a/src/code.cloudfoundry.org/cacheddownloader/cached_downloader_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/cached_downloader_test.go
@@ -69,7 +69,7 @@ var _ = Describe("File cache", func() {
 
 		transformer = cacheddownloader.NoopTransform
 
-		cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+		cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 		downloader = cacheddownloader.NewDownloader(1*time.Second, MAX_CONCURRENT_DOWNLOADS, nil)
 		cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
 		Expect(err).NotTo(HaveOccurred())
@@ -89,7 +89,7 @@ var _ = Describe("File cache", func() {
 	Describe("When a new CachedDownloader fails to create a temp directory for the cache", func() {
 		It("returns an error", func() {
 			cachedPath = ""
-			cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+			cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 			downloader = cacheddownloader.NewDownloader(1*time.Second, MAX_CONCURRENT_DOWNLOADS, nil)
 			cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
 			Expect(err).To(HaveOccurred())
@@ -1048,7 +1048,7 @@ var _ = Describe("File cache", func() {
 					ghttp.RespondWith(http.StatusOK, string(downloadContent), returnedHeader),
 				))
 
-				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 				cachedDownloader, err = cacheddownloader.New(downloader, cache, cacheddownloader.TarTransform)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1321,7 +1321,7 @@ var _ = Describe("File cache", func() {
 				Expect(cachedDownloader.SaveState(logger)).To(Succeed())
 
 				maxSizeInBytes = 32
-				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 			})
 
 			It("should evict old entries from the cache", func() {

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/archiver/compressor"
@@ -32,14 +30,6 @@ type FileCache struct {
 	Entries                   map[string]*FileCacheEntry
 	OldEntries                map[string]*FileCacheEntry
 	Seq                       uint64
-}
-
-func defaultFreeSpaceOnPartition(path string) int64 {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(path, &stat); err != nil {
-		return math.MaxInt64
-	}
-	return int64(stat.Bavail) * int64(stat.Bsize)
 }
 
 type FileCacheEntry struct {
@@ -201,6 +191,11 @@ func (e *FileCacheEntry) expandedDirectory() (string, error) {
 			err = os.RemoveAll(e.FilePath)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to delete the cached file", err)
+			} else {
+				// GetDirectory doubled Size before calling here; tar is now gone so halve it
+				// back to reflect only the .tar.d on disk. Mirrors the symmetric halving in
+				// decrementFileInUseCount() which fires when the tar is deleted later.
+				e.Size = e.Size / 2
 			}
 		}
 	}

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/archiver/compressor"
@@ -23,12 +25,21 @@ var (
 )
 
 type FileCache struct {
-	CachedPath     string
-	maxSizeInBytes int64
-	minFreeBytes   int64
-	Entries        map[string]*FileCacheEntry
-	OldEntries     map[string]*FileCacheEntry
-	Seq            uint64
+	CachedPath                string
+	maxSizeInBytes            int64
+	minimumPartitionFreeBytes int64
+	FreeSpaceFunc             func(path string) int64 `json:"-"`
+	Entries                   map[string]*FileCacheEntry
+	OldEntries                map[string]*FileCacheEntry
+	Seq                       uint64
+}
+
+func defaultFreeSpaceOnPartition(path string) int64 {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return math.MaxInt64
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize)
 }
 
 type FileCacheEntry struct {
@@ -41,18 +52,15 @@ type FileCacheEntry struct {
 	fileInUseCount        int
 }
 
-func NewCache(dir string, maxSizeInBytes int64, minFreeBytes ...int64) *FileCache {
-	var minFree int64
-	if len(minFreeBytes) > 0 {
-		minFree = minFreeBytes[0]
-	}
+func NewCache(dir string, maxSizeInBytes, minimumPartitionFreeBytes int64) *FileCache {
 	return &FileCache{
-		CachedPath:     dir,
-		maxSizeInBytes: maxSizeInBytes,
-		minFreeBytes:   minFree,
-		Entries:        map[string]*FileCacheEntry{},
-		OldEntries:     map[string]*FileCacheEntry{},
-		Seq:            0,
+		CachedPath:                dir,
+		maxSizeInBytes:            maxSizeInBytes,
+		minimumPartitionFreeBytes: minimumPartitionFreeBytes,
+		FreeSpaceFunc:             defaultFreeSpaceOnPartition,
+		Entries:                   map[string]*FileCacheEntry{},
+		OldEntries:                map[string]*FileCacheEntry{},
+		Seq:                       0,
 	}
 }
 
@@ -384,7 +392,7 @@ func (c *FileCache) updateOldEntries(logger lager.Logger, cacheKey string, entry
 
 func (c *FileCache) makeRoom(logger lager.Logger, size int64, excludedCacheKey string) {
 	usedSpace := c.usedSpace(logger)
-	for c.maxSizeInBytes < usedSpace+size {
+	for c.maxSizeInBytes < usedSpace+size || (c.minimumPartitionFreeBytes > 0 && c.FreeSpaceFunc(c.CachedPath) < c.minimumPartitionFreeBytes) {
 		var oldestEntry *FileCacheEntry
 		oldestAccessTime, oldestCacheKey := maxTime(), ""
 		for ck, f := range c.Entries {

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"code.cloudfoundry.org/cacheddownloader"
@@ -767,6 +768,48 @@ var _ = Describe("FileCache", func() {
 							"/testdir/fileLink.txt",
 						))
 					})
+				})
+			})
+
+			Context("when removing the cached tarball fails", func() {
+				var expandedDir string
+
+				BeforeEach(func() {
+					if runtime.GOOS == "windows" || os.Getuid() == 0 {
+						Skip("cannot simulate a permission-denied removal as root or on windows")
+					}
+				})
+
+				JustBeforeEach(func() {
+					Expect(file.Close()).To(Succeed())
+
+					// Pre-create the extraction target so the tar extractor's
+					// (idempotent) directory creation succeeds even once cacheDir
+					// is locked down, leaving only the tarball's own removal to fail.
+					entry := cache.Entries[cacheKey]
+					expandedDir = entry.FilePath + ".d"
+					Expect(os.MkdirAll(expandedDir, 0755)).To(Succeed())
+					Expect(os.Chmod(cacheDir, 0555)).To(Succeed())
+
+					dir, cacheInfoType, getErr = cache.GetDirectory(logger, cacheKey)
+				})
+
+				AfterEach(func() {
+					Expect(os.Chmod(cacheDir, 0755)).To(Succeed())
+				})
+
+				It("still returns the directory without error", func() {
+					Expect(getErr).NotTo(HaveOccurred())
+					Expect(dir).To(Equal(expandedDir))
+					Expect(cacheInfoType).To(Equal(cacheInfo))
+				})
+
+				It("leaves the tarball on disk and does not halve the cached size", func() {
+					Expect(filenamesInDir(cacheDir)).To(HaveLen(2))
+
+					entry, ok := cache.Entries[cacheKey]
+					Expect(ok).To(BeTrue())
+					Expect(entry.Size).To(Equal(fileSize * 2))
 				})
 			})
 

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
@@ -33,7 +33,7 @@ var _ = Describe("FileCache", func() {
 
 		maxSizeInBytes = 123424
 
-		cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+		cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 	})
 
 	AfterEach(func() {
@@ -516,7 +516,7 @@ var _ = Describe("FileCache", func() {
 			Context("when there is not enough space in the cache", func() {
 				BeforeEach(func() {
 					maxSizeInBytes = 150
-					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 				})
 
 				JustBeforeEach(func() {
@@ -773,7 +773,7 @@ var _ = Describe("FileCache", func() {
 			Context("when there isn't enough space", func() {
 				BeforeEach(func() {
 					maxSizeInBytes = 10
-					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 				})
 
 				JustBeforeEach(func() {
@@ -832,6 +832,67 @@ var _ = Describe("FileCache", func() {
 			It("closes first the old, then the new", func() {
 				Expect(cache.CloseDirectory(logger, cacheKey, dir1)).To(Succeed())
 				Expect(cache.CloseDirectory(logger, cacheKey, dir2)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("makeRoom partition free-space eviction", func() {
+		var (
+			cacheKey  string
+			cacheInfo cacheddownloader.CachingInfoType
+		)
+
+		BeforeEach(func() {
+			cacheKey = "key"
+			cacheInfo = cacheddownloader.CachingInfoType{}
+			// large in-memory ceiling so only partition pressure triggers eviction
+			maxSizeInBytes = 10 * 1024 * 1024 * 1024
+			cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 5*1024*1024*1024)
+		})
+
+		Context("when partition free space is below the minimum", func() {
+			BeforeEach(func() {
+				cache.FreeSpaceFunc = func(string) int64 { return 0 }
+			})
+
+			It("evicts non-in-use entries even though in-memory ceiling is not exceeded", func() {
+				f1 := createFile("cache-file-1", "content-1")
+				defer os.RemoveAll(f1.Name())
+				rc, err := cache.Add(logger, cacheKey, f1.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc.Close()
+
+				f2 := createFile("cache-file-2", "content-2")
+				defer os.RemoveAll(f2.Name())
+				rc2, err := cache.Add(logger, "key2", f2.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc2.Close()
+
+				_, _, err = cache.Get(logger, cacheKey)
+				Expect(err).To(Equal(cacheddownloader.EntryNotFound))
+			})
+		})
+
+		Context("when partition free space exceeds the minimum", func() {
+			BeforeEach(func() {
+				cache.FreeSpaceFunc = func(string) int64 { return 10 * 1024 * 1024 * 1024 }
+			})
+
+			It("does not evict entries solely due to partition pressure", func() {
+				f1 := createFile("cache-file-1", "content-1")
+				defer os.RemoveAll(f1.Name())
+				rc, err := cache.Add(logger, cacheKey, f1.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc.Close()
+
+				f2 := createFile("cache-file-2", "content-2")
+				defer os.RemoveAll(f2.Name())
+				rc2, err := cache.Add(logger, "key2", f2.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc2.Close()
+
+				_, _, err = cache.Get(logger, cacheKey)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache_unix.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package cacheddownloader
+
+import (
+	"math"
+	"syscall"
+)
+
+func defaultFreeSpaceOnPartition(path string) int64 {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return math.MaxInt64
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize)
+}

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache_windows.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cacheddownloader
+
+import "math"
+
+func defaultFreeSpaceOnPartition(path string) int64 {
+	return math.MaxInt64
+}

--- a/src/code.cloudfoundry.org/cacheddownloader/integration_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/integration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Integration", func() {
 		url, err = url.Parse(server.URL + "/file")
 		Expect(err).NotTo(HaveOccurred())
 
-		cache = cacheddownloader.NewCache(cachedPath, cacheMaxSizeInBytes)
+		cache = cacheddownloader.NewCache(cachedPath, cacheMaxSizeInBytes, 0)
 		downloader = cacheddownloader.NewDownloader(downloadTimeout, 10, nil)
 		cachedDownloader, err = cacheddownloader.New(downloader, cache, cacheddownloader.NoopTransform)
 		Expect(err).ToNot(HaveOccurred())

--- a/src/code.cloudfoundry.org/executor/depot/depot.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot.go
@@ -219,7 +219,13 @@ func (c *client) DeleteContainer(logger lager.Logger, traceID string, guid strin
 
 func (c *client) RemainingResources(logger lager.Logger) (executor.ExecutorResources, error) {
 	logger = logger.Session("remaining-resources")
-	return c.containerStore.RemainingResources(logger), nil
+	remaining := c.containerStore.RemainingResources(logger)
+	if c.diskPath != "" {
+		if liveMB, ok := liveDiskMB(c.diskPath); ok && liveMB < remaining.DiskMB {
+			remaining.DiskMB = liveMB
+		}
+	}
+	return remaining, nil
 }
 
 func (c *client) Ping(logger lager.Logger) error {
@@ -227,9 +233,15 @@ func (c *client) Ping(logger lager.Logger) error {
 }
 
 func (c *client) TotalResources(logger lager.Logger) (executor.ExecutorResources, error) {
+	diskMB := c.totalCapacity.DiskMB
+	if c.diskPath != "" {
+		if liveMB, ok := liveDiskMB(c.diskPath); ok {
+			diskMB = liveMB
+		}
+	}
 	return executor.ExecutorResources{
 		MemoryMB:   c.totalCapacity.MemoryMB,
-		DiskMB:     getDiskMB(c.diskPath, c.totalCapacity.DiskMB),
+		DiskMB:     diskMB,
 		Containers: c.totalCapacity.Containers,
 	}, nil
 }

--- a/src/code.cloudfoundry.org/executor/depot/depot_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_test.go
@@ -698,45 +698,70 @@ var _ = Describe("Depot", func() {
 	})
 
 	Describe("RemainingResources", func() {
-		var resources executor.ExecutorResources
+		var remainingResources executor.ExecutorResources
 
 		BeforeEach(func() {
-			resources = executor.NewExecutorResources(1024, 1024, 3)
-			containerStore.RemainingResourcesReturns(resources)
+			remainingResources = executor.NewExecutorResources(1024, 1024, 3)
+			containerStore.RemainingResourcesReturns(remainingResources)
 		})
 
 		It("should reduce resources used by allocated and running containers", func() {
 			actualResources, err := depotClient.RemainingResources(logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(actualResources).To(Equal(resources))
+			Expect(actualResources).To(Equal(remainingResources))
+		})
+
+		Context("when disk path is configured and partition has less space than the store reports", func() {
+			var tmpDir string
+
+			BeforeEach(func() {
+				var err error
+				tmpDir, err = os.MkdirTemp("", "depot-remaining-disk-test")
+				Expect(err).NotTo(HaveOccurred())
+				diskPath = tmpDir
+				containerStore.RemainingResourcesReturns(executor.NewExecutorResources(1024, math.MaxInt32, 3))
+			})
+
+			It("caps remaining disk at the live partition free space from syscall.Statfs", func() {
+				result, err := depotClient.RemainingResources(logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.DiskMB).NotTo(Equal(math.MaxInt32))
+				Expect(result.DiskMB).To(BeNumerically(">", 0))
+			})
 		})
 	})
 
 	Describe("TotalResources", func() {
-		Context("when asked for total resources", func() {
-			Context("when disk path is not provided", func() {
-				It("should return the resources it was configured with", func() {
-					Expect(depotClient.TotalResources(logger)).To(Equal(resources))
-				})
+		Context("when no disk path is configured", func() {
+			It("returns the static startup resources", func() {
+				result, err := depotClient.TotalResources(logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(resources))
+			})
+		})
+
+		Context("when disk path is configured", func() {
+			var tmpDir string
+
+			BeforeEach(func() {
+				var err error
+				tmpDir, err = os.MkdirTemp("", "depot-total-disk-test")
+				Expect(err).NotTo(HaveOccurred())
+				diskPath = tmpDir
+				resources.DiskMB = math.MaxInt32
 			})
 
-			Context("when disk path is provided", func() {
-				BeforeEach(func() {
-					diskPath = os.TempDir()
-				})
+			AfterEach(func() {
+				os.RemoveAll(tmpDir)
+			})
 
-				It("should return the resources it was configured with, with live disk capacity", func() {
-					totalResources, err := depotClient.TotalResources(logger)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(totalResources.MemoryMB).To(Equal(resources.MemoryMB))
-					Expect(totalResources.Containers).To(Equal(resources.Containers))
-
-					// disk capacity should be updated
-					Expect(totalResources.DiskMB).NotTo(Equal(resources.DiskMB))
-					Expect(totalResources.DiskMB).To(BeNumerically(">", 0))
-					Expect(totalResources.DiskMB).To(BeNumerically("<=", math.MaxInt32))
-				})
+			It("returns the resources it was configured with, with live disk capacity", func() {
+				result, err := depotClient.TotalResources(logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.MemoryMB).To(Equal(resources.MemoryMB))
+				Expect(result.Containers).To(Equal(resources.Containers))
+				Expect(result.DiskMB).NotTo(Equal(math.MaxInt32))
+				Expect(result.DiskMB).To(BeNumerically(">", 0))
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/executor/depot/depot_unix.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_unix.go
@@ -1,17 +1,13 @@
 //go:build !windows
-// +build !windows
 
 package depot
 
 import "syscall"
 
-func getDiskMB(diskPath string, fallback int) int {
-	if diskPath == "" {
-		return fallback
-	}
+func liveDiskMB(path string) (int, bool) {
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs(diskPath, &stat); err == nil {
-		return int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, false
 	}
-	return fallback
+	return int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024)), true
 }

--- a/src/code.cloudfoundry.org/executor/depot/depot_windows.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_windows.go
@@ -1,21 +1,20 @@
 //go:build windows
-// +build windows
 
 package depot
 
 import "golang.org/x/sys/windows"
 
-func getDiskMB(diskPath string, fallback int) int {
-	if diskPath == "" {
-		return fallback
+func liveDiskMB(path string) (int, bool) {
+	if path == "" {
+		return 0, false
 	}
-	pathPtr, err := windows.UTF16PtrFromString(diskPath)
+	pathPtr, err := windows.UTF16PtrFromString(path)
 	if err != nil {
-		return fallback
+		return 0, false
 	}
 	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
 	if err := windows.GetDiskFreeSpaceEx(pathPtr, &freeBytesAvailable, &totalBytes, &totalFreeBytes); err != nil {
-		return fallback
+		return 0, false
 	}
-	return int(freeBytesAvailable / (1024 * 1024))
+	return int(freeBytesAvailable / (1024 * 1024)), true
 }

--- a/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
@@ -132,11 +132,7 @@ func Initialize(
 	downloader := cacheddownloader.NewDownloader(10*time.Minute, math.MaxInt8, assetTLSConfig)
 	uploader := uploader.New(logger, 10*time.Minute, assetTLSConfig)
 
-	minFree := int64(config.MinCachePartitionFreeBytes)
-	if minFree == 0 {
-		minFree = defaultMinCachePartitionFreeBytes
-	}
-	cache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes), minFree)
+	cache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes), int64(config.MinCachePartitionFreeBytes))
 	cachedDownloader, err := cacheddownloader.New(
 		downloader,
 		cache,

--- a/src/code.cloudfoundry.org/rep/cmd/rep/main_test.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main_test.go
@@ -1063,17 +1063,23 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 				})
 
 				Context("when the container is removed", func() {
-					It("returns available capacity == total capacity", func() {
+					It("returns available capacity == total capacity", Serial, func() {
 						fakeGarden.RouteToHandler("GET", "/containers", ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{}))
 						fakeGarden.RouteToHandler("GET", "/containers/bulk_info", ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{}))
 
+						cachePath := fmt.Sprintf("%s-%d", "/tmp/cache", node)
+						configuredDiskMB := int32(10 * 1024)
+						expectedDiskMB := expectedTotalDiskMB(cachePath)
+						if configuredDiskMB < expectedDiskMB {
+							expectedDiskMB = configuredDiskMB
+						}
 						Eventually(func() models.Resources {
 							state, err := repClient.State(logger)
 							Expect(err).NotTo(HaveOccurred())
 							return state.AvailableResources
 						}).Should(Equal(models.Resources{
 							MemoryMB:   1024,
-							DiskMB:     10 * 1024,
+							DiskMB:     expectedDiskMB,
 							Containers: 3,
 						}))
 					})


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

The Problem

Diego cells were hitting 90%+ disk usage while the rep kept reporting tens of GB available. Two independent bugs combined to cause this.

---
Bug 1 — Download cache grows past its 10 GB ceiling

Where: cacheddownloader/file_cache.go makeRoom()

How it worked before:
The cache enforced its size ceiling using only in-memory accounting — it tracked how many bytes it thought it had stored. Three things caused that number to drift below reality:

- If all entries were in use when a new download arrived, makeRoom() skipped eviction entirely but still added the new file — silently exceeding the ceiling
- GetDirectory() doubles entry.Size when both a .tar and its extracted .tar.d exist simultaneously. If the ref-count logic misfired, the doubling was never reversed — the in-memory tracker over-counted that entry, causing it to evict earlier than needed and allowing more real disk to be used than the ceiling allows
- These drifted sizes were saved to saved_cache.json on disk and reloaded on restart, carrying the error forward

Real-world result: /var/vcap/data/rep/shared/garden/download_cache grew to 46 GB while in-memory tracking reported < 10 GB.

Fix:
Added a minimumPartitionFreeBytes field (default 5 GB) and a FreeSpaceFunc that calls syscall.Statfs to read actual partition free space. makeRoom() now loops until both conditions are satisfied:

in-memory usage < maxSizeInBytes
AND
real partition free space >= minimumPartitionFreeBytes

This means even if the in-memory accounting has drifted, the real disk pressure triggers eviction as a safety net.

---
Bug 2 — Rep advertises stale disk capacity forever

Where: executor/depot/depot.go TotalResources()

How it worked before:
At rep startup, fetchCapacity() computed available disk once:

DiskMB = (80 GiB total − 10 GiB cache reservation − ~188 MiB overhead) = 71,492 MB

This number was frozen for the entire lifetime of the rep. Every scheduling decision the auctioneer made used this stale value. As the
download cache grew past its 10 GB reservation, TotalRethe auctioneer kept scheduling new containers onto anearly-full cell.

Real-world result: cfdot cell-states showed AvailableResources.DiskMB = 47,940 MB while the physical disk had only 7.6 GB free.

Fix:
TotalResources() now calls syscall.Statfs on the disk peturns a live DiskMB value. MemoryMB and Containersremain frozen (they don't change at runtime — only disk does).

---

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
