### PR TITLE
fix(rep): update TotalResources disk test to match live Statfs behavior

### DIFF
--- a/src/code.cloudfoundry.org/rep/cmd/rep/main_test.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main_test.go
@@ -1049,13 +1049,17 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 				It("returns total capacity and state information", func() {
 					state, err := repClient.State(logger)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(state.TotalResources).To(Equal(models.Resources{
-						MemoryMB:   1024,
-						DiskMB:     10 * 1024,
-						Containers: 3,
-					}))
+					Expect(state.TotalResources.MemoryMB).To(Equal(int32(1024)))
+					Expect(state.TotalResources.Containers).To(Equal(3))
 					Expect(state.PlacementTags).To(Equal([]string{"test"}))
 					Expect(state.OptionalPlacementTags).To(Equal([]string{"optional_tag"}))
+				})
+
+				It("returns actual total disk capacity", Serial, func() {
+					state, err := repClient.State(logger)
+					Expect(err).NotTo(HaveOccurred())
+					cachePath := fmt.Sprintf("%s-%d", "/tmp/cache", node)
+					Expect(state.TotalResources.DiskMB).To(Equal(expectedTotalDiskMB(cachePath)))
 				})
 
 				Context("when the container is removed", func() {

--- a/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_notwindows_test.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_notwindows_test.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main_test
+
+import (
+	"syscall"
+
+	. "github.com/onsi/gomega"
+)
+
+func expectedTotalDiskMB(cachePath string) int32 {
+	var stat syscall.Statfs_t
+	Expect(syscall.Statfs(cachePath, &stat)).To(Succeed())
+	return int32(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+}

--- a/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_windows_test.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_windows_test.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main_test
+
+func expectedTotalDiskMB(_ string) int32 {
+	return 10 * 1024
+}


### PR DESCRIPTION
Keep MemoryMB/Containers assertion in existing It; add Serial It that computes expected DiskMB via syscall.Statfs on the cache path (matching what depot.getDiskMB returns). Windows uses hardcoded 10240 fallback.

ai-assisted=yes
TNZ-92428