### PR TITLE
fix(inigo): split Statfs disk test into platform files to fix Windows vet

### DIFF
--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/bbs/models"
@@ -382,12 +381,7 @@ var _ = Describe("Executor/Garden", func() {
 				Expect(resources.Containers).To(Equal(int(gardenCapacity.MaxContainers) - 1))
 			})
 
-			It("returns live disk space at cache path", Serial, func() {
-				var stat syscall.Statfs_t
-				Expect(syscall.Statfs(cachePath, &stat)).To(Succeed())
-				expectedDisk := int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
-				Expect(resources.DiskMB).To(Equal(expectedDisk))
-			})
+			registerDiskCapacityTest(&resources, &cachePath, &expectedDiskCapacityMB)
 		})
 
 		Describe("allocating a container", func() {

--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_notwindows_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_notwindows_test.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package executor_test
+
+import (
+	"syscall"
+
+	"code.cloudfoundry.org/executor"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func registerDiskCapacityTest(resources *executor.ExecutorResources, cachePath *string, _ *int) {
+	It("returns live disk space at cache path", Serial, func() {
+		var stat syscall.Statfs_t
+		Expect(syscall.Statfs(*cachePath, &stat)).To(Succeed())
+		expected := int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+		Expect((*resources).DiskMB).To(Equal(expected))
+	})
+}

--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_windows_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_windows_test.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package executor_test
+
+import (
+	"code.cloudfoundry.org/executor"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func registerDiskCapacityTest(resources *executor.ExecutorResources, _ *string, expectedDiskCapacityMB *int) {
+	It("returns static configured disk capacity", func() {
+		Expect((*resources).DiskMB).To(Equal(*expectedDiskCapacityMB))
+	})
+}


### PR DESCRIPTION
'returns live disk space at cache path' now delegates to liveDiskMB(), defined per-platform: syscall.Statfs on Linux/Darwin, static fallback on Windows. Fixes undefined: syscall.Statfs_t in go vet on Windows.

