### PR TITLE
fix(rep): use live GetDiskFreeSpaceEx in Windows test helper

### DIFF
--- a/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_windows_test.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main_totaldisk_windows_test.go
@@ -2,6 +2,16 @@
 
 package main_test
 
-func expectedTotalDiskMB(_ string) int32 {
-	return 10 * 1024
+import (
+	"golang.org/x/sys/windows"
+
+	. "github.com/onsi/gomega"
+)
+
+func expectedTotalDiskMB(cachePath string) int32 {
+	pathPtr, err := windows.UTF16PtrFromString(cachePath)
+	Expect(err).NotTo(HaveOccurred())
+	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
+	Expect(windows.GetDiskFreeSpaceEx(pathPtr, &freeBytesAvailable, &totalBytes, &totalFreeBytes)).To(Succeed())
+	return int32(freeBytesAvailable / (1024 * 1024))
 }


### PR DESCRIPTION
expectedTotalDiskMB was returning static 10*1024 MB but getDiskMB now returns freeBytesAvailable via GetDiskFreeSpaceEx on Windows. Match the production behavior so the assertion compares live to live.