### PR TITLE
fix gh actions with new modules and dir size calculation

### DIFF
--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -117,51 +117,6 @@ jobs:
     - name: lint-repo
       run: |
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/lint-repo/task.bash
-  test-on-mysql-5-7:
-    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
-    runs-on: ubuntu-latest
-    needs: [repo-clone, determine-image-tag]
-    env:
-      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-5.7:${{ needs.determine-image-tag.outputs.go_version }}
-      DB_USER: root
-      DB_PASSWORD: password
-    steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: repo
-    - run: |
-        tar -xzvf repo-artifact.tar.gz
-        tar -xzvf ci-artifact.tar.gz
-    - name: pull image
-      run: docker pull "$BUILD_IMAGE"
-    - name: build binaries
-      run: |
-        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: auctioneer-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/auctioneer
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: rep-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/rep
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: route-emitter-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/route-emitter
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
-    - name: cfdot-mysql
-      env:
-        DIR: src/code.cloudfoundry.org/cfdot
-        DB: mysql
-      run: |
-        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
   test-repos-withoutdb:
     if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
     runs-on: ubuntu-latest
@@ -204,6 +159,46 @@ jobs:
     - name: healthcheck
       env:
         DIR: src/code.cloudfoundry.org/healthcheck
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: buildpackapplifecycle
+      env:
+        DIR: src/code.cloudfoundry.org/buildpackapplifecycle
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cacheddownloader
+      env:
+        DIR: src/code.cloudfoundry.org/cacheddownloader
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: dockerapplifecycle
+      env:
+        DIR: src/code.cloudfoundry.org/dockerapplifecycle
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: ecrhelper
+      env:
+        DIR: src/code.cloudfoundry.org/ecrhelper
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: localdriver
+      env:
+        DIR: src/code.cloudfoundry.org/localdriver
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: operationq
+      env:
+        DIR: src/code.cloudfoundry.org/operationq
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: volman
+      env:
+        DIR: src/code.cloudfoundry.org/volman
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: workpool
+      env:
+        DIR: src/code.cloudfoundry.org/workpool
       run: |
         repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
   test-on-postgres:
@@ -257,6 +252,96 @@ jobs:
     needs: [repo-clone, determine-image-tag]
     env:
       BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-8.0:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auctioneer-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/auctioneer
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: rep-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/rep
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: route-emitter-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/route-emitter
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cfdot-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/cfdot
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+  test-on-mysql-8-4:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-8.4:${{ needs.determine-image-tag.outputs.go_version }}
+      DB_USER: root
+      DB_PASSWORD: password
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: repo
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
+    - name: pull image
+      run: docker pull "$BUILD_IMAGE"
+    - name: build binaries
+      run: |
+        repo/.github/helpers/build.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: auctioneer-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/auctioneer
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: rep-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/rep
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: route-emitter-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/route-emitter
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+    - name: cfdot-mysql
+      env:
+        DIR: src/code.cloudfoundry.org/cfdot
+        DB: mysql
+      run: |
+        repo/.github/helpers/test.bash ${{ github.workspace }} "$BUILD_IMAGE"
+  test-on-mysql-9-7:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-run')
+    runs-on: ubuntu-latest
+    needs: [repo-clone, determine-image-tag]
+    env:
+      BUILD_IMAGE: cloudfoundry/tas-runtime-mysql-9.7:${{ needs.determine-image-tag.outputs.go_version }}
       DB_USER: root
       DB_PASSWORD: password
     steps:

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
@@ -191,11 +191,6 @@ func (e *FileCacheEntry) expandedDirectory() (string, error) {
 			err = os.RemoveAll(e.FilePath)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to delete the cached file", err)
-			} else {
-				// GetDirectory doubled Size before calling here; tar is now gone so halve it
-				// back to reflect only the .tar.d on disk. Mirrors the symmetric halving in
-				// decrementFileInUseCount() which fires when the tar is deleted later.
-				e.Size = e.Size / 2
 			}
 		}
 	}
@@ -339,7 +334,8 @@ func (c *FileCache) GetDirectory(logger lager.Logger, cacheKey string) (string, 
 	}
 
 	// Was it expanded before
-	if entry.dirDoesNotExist() {
+	expanding := entry.dirDoesNotExist()
+	if expanding {
 		// Do we have enough room to double the size?
 		c.makeRoom(logger, entry.Size, cacheKey)
 		entry.Size = entry.Size * 2
@@ -349,6 +345,12 @@ func (c *FileCache) GetDirectory(logger lager.Logger, cacheKey string) (string, 
 	dir, err := entry.expandedDirectory()
 	if err != nil {
 		return "", CachingInfoType{}, err
+	}
+
+	// If the tarball got deleted during expansion, halve the doubled size back
+	// down to reflect only the .tar.d now on disk.
+	if expanding && entry.fileDoesNotExist() {
+		entry.Size = entry.Size / 2
 	}
 
 	return dir, entry.CachingInfo, nil


### PR DESCRIPTION
ai-assisted=yes
TNZ-1234

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
1. Include few missing submods to gh actions
   -- verified the new submod tests in [gh action](https://github.com/cloudfoundry/diego-release/actions/runs/28618492047/job/84868200692?pr=1169).

3. dir size halving
AddDirectory no longer touches this halving at all — it just gets entry.Size == size, as intended.
GetDirectory still halves back correctly when it re-expands an entry and the tar removal succeeds. So moving the size halving section into GetDirectory from expandedDirectory method.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
