### PR TITLE
fix inigo test for disk size calculation

### DIFF
--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Executor/Garden", func() {
 				It("reduces the capacity by the amount reserved", func() {
 					Expect(executorClient.RemainingResources(logger)).To(Equal(executor.ExecutorResources{
 						MemoryMB:   int(gardenCapacity.MemoryInBytes/1024/1024) - 256,
-						DiskMB:     expectedDiskCapacityMB - 256,
+						DiskMB:     expectedRemainingDiskCapacityMB(cachePath, expectedDiskCapacityMB-256),
 						Containers: int(gardenCapacity.MaxContainers) - 2,
 					}))
 				})
@@ -783,7 +783,7 @@ var _ = Describe("Executor/Garden", func() {
 
 					Eventually(func() (executor.ExecutorResources, error) { return executorClient.RemainingResources(logger) }).Should(Equal(executor.ExecutorResources{
 						MemoryMB:   int(gardenCapacity.MemoryInBytes / 1024 / 1024),
-						DiskMB:     expectedDiskCapacityMB,
+						DiskMB:     expectedRemainingDiskCapacityMB(cachePath, expectedDiskCapacityMB),
 						Containers: int(gardenCapacity.MaxContainers) - 1,
 					}))
 				})
@@ -881,7 +881,7 @@ var _ = Describe("Executor/Garden", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(remaining.MemoryMB).To(Equal(int(gardenCapacity.MemoryInBytes/1024/1024) - 64))
-					Expect(remaining.DiskMB).To(Equal(expectedDiskCapacityMB - 64))
+					Expect(remaining.DiskMB).To(Equal(expectedRemainingDiskCapacityMB(cachePath, expectedDiskCapacityMB-64)))
 				})
 
 				Context("when the container disappears", func() {
@@ -896,7 +896,7 @@ var _ = Describe("Executor/Garden", func() {
 						Eventually(func() (executor.ExecutorResources, error) { return executorClient.RemainingResources(logger) }).Should(
 							Equal(executor.ExecutorResources{
 								MemoryMB:   int(gardenCapacity.MemoryInBytes / 1024 / 1024),
-								DiskMB:     expectedDiskCapacityMB,
+								DiskMB:     expectedRemainingDiskCapacityMB(cachePath, expectedDiskCapacityMB),
 								Containers: int(gardenCapacity.MaxContainers) - 1,
 							}))
 					})

--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_notwindows_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_notwindows_test.go
@@ -12,9 +12,23 @@ import (
 
 func registerDiskCapacityTest(resources *executor.ExecutorResources, cachePath *string, _ *int) {
 	It("returns live disk space at cache path", Serial, func() {
-		var stat syscall.Statfs_t
-		Expect(syscall.Statfs(*cachePath, &stat)).To(Succeed())
-		expected := int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+		expected := liveFreeDiskMB(*cachePath)
 		Expect((*resources).DiskMB).To(Equal(expected))
 	})
+}
+
+// expectedRemainingDiskCapacityMB mirrors executor/depot's RemainingResources, which
+// caps the configured/reserved capacity at the live free space on the cache partition.
+func expectedRemainingDiskCapacityMB(cachePath string, configuredDiskCapacityMB int) int {
+	live := liveFreeDiskMB(cachePath)
+	if live < configuredDiskCapacityMB {
+		return live
+	}
+	return configuredDiskCapacityMB
+}
+
+func liveFreeDiskMB(cachePath string) int {
+	var stat syscall.Statfs_t
+	Expect(syscall.Statfs(cachePath, &stat)).To(Succeed())
+	return int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
 }

--- a/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_windows_test.go
+++ b/src/code.cloudfoundry.org/inigo/executor/executor_garden_totaldisk_windows_test.go
@@ -13,3 +13,10 @@ func registerDiskCapacityTest(resources *executor.ExecutorResources, _ *string, 
 		Expect((*resources).DiskMB).To(Equal(*expectedDiskCapacityMB))
 	})
 }
+
+// expectedRemainingDiskCapacityMB mirrors executor/depot's RemainingResources. Windows
+// CI hosts are assumed to have ample free space matching the configured capacity, so no
+// live check is performed here (matching registerDiskCapacityTest above).
+func expectedRemainingDiskCapacityMB(_ string, configuredDiskCapacityMB int) int {
+	return configuredDiskCapacityMB
+}


### PR DESCRIPTION
ai-assisted=yes
TNZ-1234

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Test result: https://ci.funtime.lol/teams/wg-arp-diego/pipelines/diego-release-inigo-test/jobs/inigo-mysql-linux/builds/2

Root cause: 
same class of bug as the rep/cmd/rep/main_test.go fix from earlier — executor/depot.go's RemainingResources() clamps DiskMB to live free space on the cache partition when it's smaller than the configured/reserved capacity. These 4 inigo specs hardcoded expectedDiskCapacityMB (a static value derived from Garden's reported DiskInBytes), never accounting for that live clamp. On this CI host, live free space (836168 MB) is genuinely less than the nominal capacity (938730 MB), so the clamp correctly kicks in and the hardcoded expectations fail.

Fix: 
added expectedRemainingDiskCapacityMB(cachePath, configuredMB) in the platform-split helper files (executor_garden_totaldisk_notwindows_test.go computes min(live, configuredMB) via syscall.Statfs; the Windows variant just returns configuredMB, matching the existing precedent that registerDiskCapacityTest already uses for TotalResources). Updated all 4 failing assertions to compute the expected value through this helper instead of raw expectedDiskCapacityMB [- reservation]:


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
