### PR TITLE
Bump cnbapplifecycle version to 0.0.8

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -20,7 +20,7 @@ require (
 	code.cloudfoundry.org/certsplitter v0.79.0
 	code.cloudfoundry.org/cfhttp/v2 v2.85.0
 	code.cloudfoundry.org/clock v1.78.0
-	code.cloudfoundry.org/cnbapplifecycle v0.0.7
+	code.cloudfoundry.org/cnbapplifecycle v0.0.8
 	code.cloudfoundry.org/credhub-cli v0.0.0-20260629130111-5ee9a1ab59ab
 	code.cloudfoundry.org/debugserver v0.105.0
 	code.cloudfoundry.org/diego-logging-client v0.114.0

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -612,8 +612,8 @@ code.cloudfoundry.org/cfhttp/v2 v2.85.0 h1:rH4jiATt4gkUoqQo1K8LhXnTCfmDy9iS5q8mb
 code.cloudfoundry.org/cfhttp/v2 v2.85.0/go.mod h1:DSUmtiJmxp97/gq3jUQsJY3oBrHYKZIHdUHabFWz4lw=
 code.cloudfoundry.org/clock v1.78.0 h1:DGECrKZCjf3kVoI4TmWH990/JZ5e8J4Y/7Ogbtxzm3w=
 code.cloudfoundry.org/clock v1.78.0/go.mod h1:dQlTy94p6U+od/RJve8qD54N7sYvW2RHQQe2H/FVeRc=
-code.cloudfoundry.org/cnbapplifecycle v0.0.7 h1:AzqDUODGftsW8Nv1kfueEaJdCpaMB/KUA5G8EljvngQ=
-code.cloudfoundry.org/cnbapplifecycle v0.0.7/go.mod h1:zGH5W2aIad1LKU9yz6UQ42K6G6nwk5vqNNnuSMNblbg=
+code.cloudfoundry.org/cnbapplifecycle v0.0.8 h1:faEligvjF7NhmzcG3Vh9ixKSo+ANUuOWB2AyEj8Xygk=
+code.cloudfoundry.org/cnbapplifecycle v0.0.8/go.mod h1:hC925KLVuER3HQMD+xvxWZrGvKRIXH2Cr/LSz7w0CdI=
 code.cloudfoundry.org/commandrunner v0.69.0 h1:f7ugvBag57VKX56ADAqjV5xDx2qMqCs1EERUcbQsqjE=
 code.cloudfoundry.org/commandrunner v0.69.0/go.mod h1:q2MgM/HJeJkLT+t3t0owPtZB7mAMYMk/x51z3PCFdT4=
 code.cloudfoundry.org/credhub-cli v0.0.0-20260629130111-5ee9a1ab59ab h1:nO+VR7o7NsSWRu+ZYoTPiaSEnoPBgQKIlrY5wzrpKw0=

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cnbapplifecycle/pkg/buildpacks/download.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cnbapplifecycle/pkg/buildpacks/download.go
@@ -97,15 +97,20 @@ func removeDuplicates(buildpacks []buildpack.BuildModule) []buildpack.BuildModul
 
 func extractBuildpacks(buildpacks []buildpack.BuildModule, dir string) error {
 	for _, bp := range buildpacks {
-		reader, err := bp.Open()
+		err := extractBuildpack(bp, dir)
 		if err != nil {
-			return err
-		}
-		defer reader.Close()
-
-		if err := archive.ExtractWithBaseOverride(reader, dist.BuildpacksDir, dir); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func extractBuildpack(bp buildpack.BuildModule, dir string) error {
+	reader, err := bp.Open()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	return archive.ExtractWithBaseOverride(reader, dist.BuildpacksDir, dir)
 }

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -58,8 +58,8 @@ code.cloudfoundry.org/cfhttp/v2/handlers
 ## explicit; go 1.25.0
 code.cloudfoundry.org/clock
 code.cloudfoundry.org/clock/fakeclock
-# code.cloudfoundry.org/cnbapplifecycle v0.0.7
-## explicit; go 1.26.1
+# code.cloudfoundry.org/cnbapplifecycle v0.0.8
+## explicit; go 1.26.4
 code.cloudfoundry.org/cnbapplifecycle/cmd/builder
 code.cloudfoundry.org/cnbapplifecycle/cmd/builder/cli
 code.cloudfoundry.org/cnbapplifecycle/cmd/launcher


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR bumps cnbapplifecycle to the latest version which fixes this issue: https://github.com/cloudfoundry/diego-release/issues/1172


Backward Compatibility
---------------
Breaking Change? **No**

This is not a breaking change, but resolves the regression introduced by using an outdated version of cnbapplifecycle 0.0.7 in diego-release 2.139.0 and 2.140.0
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
