### PR TITLE
Show full error message if git clone fails in builpacklifecycle

### DIFF
--- a/src/code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/git_buildpack.go
+++ b/src/code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/git_buildpack.go
@@ -40,7 +40,7 @@ func GitClone(repo url.URL, destination string) error {
 			}, branch)
 
 		if err != nil {
-			return fmt.Errorf("Failed to clone git repository at %s", gitUrl)
+			return fmt.Errorf("Failed to clone git repository at %s: %w", gitUrl, err)
 		}
 	}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Small enhancement to show the full error message if "git clone" fails during the buildpack lifecycle.

Example for the current output:
```
 2026-07-21T07:29:01.89+0000 [STG/0] ERR Failed to clone git repository at https://github.com/cloudfoundry/staticfile-buildpack.git
   2026-07-21T07:29:01.90+0000 [STG/0] OUT Exit status 1
```

-> Root cause is not clear.

Backward Compatibility
---------------
Breaking Change? **No**
