### PR TITLE
fix: make container certificates compliant with X.501 standard

### DIFF
--- a/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager.go
@@ -473,12 +473,19 @@ func createCertificateTemplate(guid string, certSAN certificateSAN, notBefore, n
 	for _, route := range certSAN.InternalRoutes {
 		dnsNames = append(dnsNames, route.Hostname)
 	}
+    organizationalUnits := []pkix.AttributeTypeAndValue{}
+    for _, ou := range certSAN.OrganizationalUnits {
+        organizationalUnits = append(organizationalUnits, pkix.AttributeTypeAndValue{
+            Type:  []int{2, 5, 4, 11}, // OID for Organizational Unit RDN
+            Value: ou,
+        })
+    }
 
 	return &x509.Certificate{
 		SerialNumber: big.NewInt(0),
 		Subject: pkix.Name{
-			CommonName:         guid,
-			OrganizationalUnit: certSAN.OrganizationalUnits,
+			CommonName: guid,
+			ExtraNames: organizationalUnits,
 		},
 		IPAddresses: ipaddr,
 		DNSNames:    dnsNames,


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Golang's `crypto/x509/pkix` does not generate X.501-compliant structure for multi-valued RDNs (see https://github.com/golang/go/issues/40876), such as Organizational Unit (used here for app, space and org GUIDs). The difference can be easily identified e.g. with `openssl asn1parse`. For the correct certificates, the relevant section looks like that (note that each OU `SEQUENCE` is in a separate `SET`):
```
openssl asn1parse -in certificate.pem

Output:
(...)
130:d=3 hl=2 l= 12 cons: SET
132:d=4 hl=2 l= 10 cons: SEQUENCE
134:d=5 hl=2 l= 3 prim: OBJECT :organizationalUnitName
139:d=5 hl=2 l= 3 prim: UTF8STRING :ou1
144:d=3 hl=2 l= 12 cons: SET
146:d=4 hl=2 l= 10 cons: SEQUENCE
148:d=5 hl=2 l= 3 prim: OBJECT :organizationalUnitName
153:d=5 hl=2 l= 3 prim: UTF8STRING :ou2
158:d=2 hl=4 l= 290 cons: SEQUENCE
(...)
```

For the certificate created with Go crypto/x509, the same structure is different (both `SEQUENCE`s are in a single `SET`):
```
openssl asn1parse -in certificate.pem

Output:
(...)
108:d=3 hl=2 l= 24 cons: SET
110:d=4 hl=2 l= 10 cons: SEQUENCE
112:d=5 hl=2 l= 3 prim: OBJECT :organizationalUnitName
117:d=5 hl=2 l= 3 prim: PRINTABLESTRING :ou1
122:d=4 hl=2 l= 10 cons: SEQUENCE
124:d=5 hl=2 l= 3 prim: OBJECT :organizationalUnitName
129:d=5 hl=2 l= 3 prim: PRINTABLESTRING :ou2
134:d=3 hl=2 l= 20 cons: SET
136:d=4 hl=2 l= 18 cons: SEQUENCE
(...)
```

That prevents some services (such as AWS IAM RolesAnywhere) from correctly parsing the certificate subject (in case of AWS RolesAnywhere, only the first OU, ie. app GUID, is retrieved). 

Because the original Go library bug will not be fixed, this PR implements a workaround: instead of `pkix.Name.OrganizationalUnits` it uses `ExtraNames` property [which encodes each entry as a separate RDN](https://github.com/golang/go/blob/release-branch.go1.27/src/crypto/x509/pkix/pkix.go#L249). 

Backward Compatibility
---------------
Breaking Change? **No**

Even though the certificate structure is changed, any existing libraries that worked with the non-compliant certificate should be also able to read the proper one.