### PR TITLE
Pass EnableBackendMTLS in tcp route info

### DIFF
--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint.go
@@ -94,6 +94,7 @@ type ExternalEndpointInfo struct {
 	TLSEnabled           bool
 	SniHostname          string
 	TerminateFrontendTLS bool
+	EnableBackendMTLS    bool
 }
 
 func (info ExternalEndpointInfo) Hash() interface{} {
@@ -133,6 +134,7 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 		info.TerminateFrontendTLS,
 		"",
 	)
+	mapping.EnableBackendMTLS = info.EnableBackendMTLS
 	if e.IsDirectInstanceRoute(directInstanceRoute) {
 		mapping = tcpmodels.NewTcpRouteMapping(
 			info.RouterGroupGUID,
@@ -148,6 +150,7 @@ func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ b
 			info.TerminateFrontendTLS,
 			"",
 		)
+		mapping.EnableBackendMTLS = info.EnableBackendMTLS
 	}
 	return nil, &mapping, nil
 }

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/endpoint_utils_test.go
@@ -349,6 +349,7 @@ var _ = Describe("LRP Utils", func() {
 				TLSEnabled:           true,
 				SniHostname:          "sni-hostname",
 				TerminateFrontendTLS: true,
+				EnableBackendMTLS:    true,
 			}
 		})
 
@@ -362,6 +363,18 @@ var _ = Describe("LRP Utils", func() {
 			Expect(mapping.InstanceId).To(Equal("instance-guid"))
 			Expect(*mapping.SniHostname).To(Equal("sni-hostname"))
 			Expect(mapping.TerminateFrontendTLS).To(BeTrue())
+			Expect(mapping.EnableBackendMTLS).To(BeTrue())
+		})
+
+		Context("when EnableBackendMTLS is not set", func() {
+			BeforeEach(func() {
+				externalEndpointInfo.EnableBackendMTLS = false
+			})
+
+			It("defaults EnableBackendMTLS to false on the TcpRouteMapping", func() {
+				_, mapping, _ := externalEndpointInfo.MessageFor(endpoint, false, false)
+				Expect(mapping.EnableBackendMTLS).To(BeFalse())
+			})
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/routingtable.go
@@ -477,6 +477,7 @@ func (g tcpRoutesGenerator) RoutesFrom(lrp *models.DesiredLRP) map[RoutingKey][]
 			Port:                 route.ExternalPort,
 			TLSEnabled:           g.tlsEnabled,
 			TerminateFrontendTLS: route.TerminateFrontendTLS,
+			EnableBackendMTLS:    route.EnableBackendMTLS,
 		}
 		if route.SniHostname != nil {
 			info.SniHostname = *route.SniHostname

--- a/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
+++ b/src/code.cloudfoundry.org/route-emitter/routingtable/tcp_routing_table_test.go
@@ -124,6 +124,35 @@ var _ = Describe("TCPRoutingTable", func() {
 		})
 	})
 
+	Context("when TCP route specifies enable_backend_mtls", func() {
+		BeforeEach(func() {
+			modificationTag = &models.ModificationTag{Epoch: "abc", Index: 1}
+			routingTable = routingtable.NewRoutingTable(false, true, fakeMetronClient)
+			sni := "sni-hostname"
+			sniTcpRoutes := tcp_routes.TCPRoutes{
+				{
+					RouterGroupGuid:      "router-group-guid",
+					ExternalPort:         61000,
+					ContainerPort:        8080,
+					SniHostname:          &sni,
+					TerminateFrontendTLS: true,
+					EnableBackendMTLS:    true,
+				},
+			}
+			beforeLRP := getDesiredLRP("process-guid-sni", "log-guid-sni", sniTcpRoutes, modificationTag)
+			_, _ = routingTable.SetRoutes(logger, nil, beforeLRP)
+		})
+
+		It("emits TcpRouteMapping with EnableBackendMTLS set on AddEndpoint", func() {
+			actual := getActualLRP("process-guid-sni", "instance-guid-sni", "some-ip-1", "container-ip-1", 62004, 8080, 61443, 5443, modificationTag)
+			events, _ := routingTable.AddEndpoint(logger, actual)
+			sni := "sni-hostname"
+			expected := tcpmodels.NewTcpRouteMapping("router-group-guid", 61000, "some-ip-1", 62004, 61443, "instance-guid-sni", &sni, nil, 0, tcpmodels.ModificationTag{}, true, "")
+			expected.EnableBackendMTLS = true
+			Expect(events.Registrations).To(ConsistOf(expected))
+		})
+	})
+
 	Context("when no entry exist for route", func() {
 		BeforeEach(func() {
 			routingTable = routingtable.NewRoutingTable(false, false, fakeMetronClient)


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR is a follow-up from this - https://github.com/cloudfoundry/routing-release/pull/578

It will pass EnableBackendMTLS flag from the desired LRP to the TCP route in route-emitter. This flag can be set to true to enable mTLS in backwards compatible way.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
