### PR TITLE
Make rep's locket TTL configurable

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -249,7 +249,11 @@ properties:
   diego.rep.locket.api_location:
     description: "Hostname and port of the Locket server. When set, the cell rep will establish its cell registration in the Locket API."
     default: locket.service.cf.internal:8891
-  diego.rep.locket.client_keepalive_time: 
+  diego.rep.locket.lock_ttl:
+    description: "TTL in seconds for the cell rep's lock in the Locket server."
+    default: 15
+
+  diego.rep.locket.client_keepalive_time:
     description: "Period in seconds after which the locket gRPC client sends keepalive ping requests to the locket server it is connected to."
     default: 10
   diego.rep.locket.client_keepalive_timeout: 

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -32,7 +32,7 @@
   config = {
     communication_timeout: p("diego.rep.bbs.request_timeout"),
     lock_retry_interval: "5s",
-    lock_ttl: "15s",
+    lock_ttl: "#{p("diego.rep.locket.lock_ttl")}s",
     session_name: "rep",
 
     reserved_expiration_time: "1m",

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -71,6 +71,17 @@ describe 'rep' do
   describe 'rep.json.erb' do
     let(:template) { job.template('config/rep.json') }
     
+    context 'lock_ttl' do
+      it 'defaults to 15s' do
+        expect(JSON.parse(rendered_template)['lock_ttl']).to eq('15s')
+      end
+
+      it 'is configurable' do
+        deployment_manifest_fragment['diego']['rep']['locket']['lock_ttl'] = 30
+        expect(JSON.parse(rendered_template)['lock_ttl']).to eq('30s')
+      end
+    end
+
     context 'check if locket keepalive time is bigger than the timeout' do
       it 'fails if the keepalive time is bigger than timeout' do
         deployment_manifest_fragment['diego']['rep']['locket']['client_keepalive_time'] = 23


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[lock_ttl had been hardcoded to 15s](https://github.com/cloudfoundry/diego-release/blob/7c2d8f957fd5431b75769aff38e9bf8c02ccda62/jobs/rep/templates/rep.json.erb#L35) and effectively the lock expires [before keepalive time and timeout is reached](https://github.com/cloudfoundry/diego-release/blob/7c2d8f957fd5431b75769aff38e9bf8c02ccda62/jobs/rep/spec#L252-L257) (32s) by default. This will allow us to increase the lock_ttl to a bigger number like 45s, so that would allow the rep to keep its presence and convergence wouldn't kick off.


Backward Compatibility
---------------
Breaking Change? **No**

