### PR TITLE
Standardize on locket's 5s RetryInterval instead of SQLRetryInterval

### DIFF
--- a/jobs/bbs/templates/bbs.json.erb
+++ b/jobs/bbs/templates/bbs.json.erb
@@ -25,7 +25,7 @@
     communication_timeout: "10s",
     desired_lrp_creation_timeout: "1m",
     lock_ttl: "15s",
-    lock_retry_interval: "2s",
+    lock_retry_interval: "5s",
     report_interval: "1m",
     convergence_workers: 20,
     update_workers: 1000,

--- a/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main.go
+++ b/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main.go
@@ -89,7 +89,7 @@ func main() {
 		lockIdentifier,
 		locket.DefaultSessionTTLInSeconds,
 		clock,
-		locket.SQLRetryInterval,
+		locket.RetryInterval,
 	)})
 
 	var lock ifrit.Runner

--- a/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main.go
+++ b/src/code.cloudfoundry.org/route-emitter/cmd/route-emitter/main.go
@@ -173,7 +173,7 @@ func main() {
 			lockIdentifier,
 			locket.DefaultSessionTTLInSeconds,
 			clock,
-			locket.SQLRetryInterval,
+			locket.RetryInterval,
 		)})
 
 		members = append(members,


### PR DESCRIPTION
* Rep uses 5s, BBS uses 2s, and several other components use 1s
* Very fast retries can cause a DoS in locket as existing requests pile up and must be processed 1-at-a-time before new requests are executed (due to SELECT FOR UPDATE holding the row lock)

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
My environment is slow enough where I occasionally see a locket request take longer than 1s. Components with a 1s retry will give up on the request because it take to long and then immediately make another request for ~15 retries. None of them succeed because they pile up on each other at the locket server. 

Backward Compatibility
---------------
Breaking Change? **No**