### PR TITLE
Fix auctioneer tests after bumping the retry interval

### DIFF
--- a/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main_test.go
+++ b/src/code.cloudfoundry.org/auctioneer/cmd/auctioneer/main_test.go
@@ -124,6 +124,11 @@ var _ = Describe("Auctioneer", func() {
 				"-config", configFile.Name(),
 			),
 			StartCheck: "auctioneer.started",
+			// auctioneer only logs "started" once it has joined its ifrit group,
+			// which blocks on acquiring the sql lock. The default 5s
+			// StartCheckTimeout races against locket.RetryInterval (also 5s),
+			// so give it enough room to survive at least one retry.
+			StartCheckTimeout: locket.RetryInterval + 5*time.Second,
 			Cleanup: func() {
 				os.RemoveAll(configFile.Name())
 			},
@@ -314,7 +319,7 @@ var _ = Describe("Auctioneer", func() {
 						return auctioneerClient.RequestTaskAuctions(logger, "some-request-id", []*models.TaskStartRequest{
 							&models.TaskStartRequest{Task: *task},
 						})
-					}, 2*time.Second).ShouldNot(HaveOccurred())
+					}, locket.RetryInterval+5*time.Second).ShouldNot(HaveOccurred())
 				})
 			})
 		})
@@ -325,7 +330,11 @@ var _ = Describe("Auctioneer", func() {
 			})
 
 			It("exits with an error", func() {
-				Eventually(auctioneerProcess.Wait()).Should(Receive(Not(BeNil())))
+				// auctioneer never gets a hard error from the malformed locket
+				// address; it retries forever and only dies when ginkgomon's
+				// StartCheckTimeout (set above) kills it for never logging
+				// "auctioneer.started", so this must outlast that timeout.
+				Eventually(auctioneerProcess.Wait(), locket.RetryInterval+10*time.Second).Should(Receive(Not(BeNil())))
 			})
 		})
 


### PR DESCRIPTION
[ai-assisted=yes]

- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Root cause: commit b3879570c changed the auctioneer's lock retry interval from 1s (SQLRetryInterval) to 5s (RetryInterval). This collided with ginkgomon.Runner's hardcoded default StartCheckTimeout of exactly 5 seconds — auctioneer only logs "auctioneer.started" (the test's StartCheck string) after ifrit.Invoke() returns, which blocks until the lock is acquired. When the lock is initially unavailable, the test harness kills the process at t=5s in a race against auctioneer's own first retry attempt (also at t=5s), so the process never got a chance to succeed. This wasn't a hang — the process was being silently SIGKILL'd by the test harness itself, which is why no error or panic ever appeared in the logs.

Fix in auctioneer/cmd/auctioneer/main_test.go:
  1. Set StartCheckTimeout: locket.RetryInterval + 5*time.Second on the ginkgomon runner so it survives at least one retry cycle.
  2. Bumped the "acquires the lock and becomes active" test's own Eventually timeout (was a stale 2*time.Second from before the retry-interval change) to match.
  3. Extended the "invalid locket address" test's timeout, since it turned out to implicitly depend on the old 5s StartCheckTimeout to produce its expected "process exits with error" — a malformed locket address doesn't actually cause a fast, explicit failure in auctioneer's code; it retries forever and previously only died via that timeout.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
