### PR TITLE
Remove duplicate entries in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,15 +14,3 @@
 [submodule "src/code.cloudfoundry.org/credhub-cli"]
 	path = src/code.cloudfoundry.org/credhub-cli
 	url = https://github.com/cloudfoundry-incubator/credhub-cli/
-[submodule "src/garden"]
-	path = src/garden
-	url = https://github.com/cloudfoundry/garden
-[submodule "src/guardian"]
-	path = src/guardian
-	url = https://github.com/cloudfoundry/guardian
-[submodule "src/grootfs"]
-	path = src/grootfs
-	url = https://github.com/cloudfoundry/grootfs
-[submodule "src/idmapper"]
-	path = src/idmapper
-	url = https://github.com/cloudfoundry/idmapper


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove duplicate entries in .gitmodules

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
