### PR TITLE
Forward workload identity to volume drivers via mount config

### DIFF
--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
@@ -850,6 +850,48 @@ var _ = Describe("Container Store", func() {
 					Expect(gardenClient.CreateArgsForCall(0).BindMounts).To(ContainElement(expectedBindMount2))
 				})
 
+				Context("when the container carries an LRP lifecycle tag", func() {
+					BeforeEach(func() {
+						runReq.Tags = executor.Tags{
+							"lifecycle":    "lrp",
+							"process-guid": "app-guid-123",
+						}
+					})
+
+					It("forwards the workload identity to the volume manager on mount", func() {
+						_, err := containerStore.Create(logger, "some-trace-id", containerGuid)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(volumeManager.MountCallCount()).To(Equal(2))
+
+						_, _, _, _, config := volumeManager.MountArgsForCall(0)
+						Expect(config["_workload_guid"]).To(Equal("app-guid-123"))
+						Expect(config["_workload_type"]).To(Equal("lrp"))
+						Expect(config["some-config"]).To(Equal("interface"))
+
+						_, _, _, _, config = volumeManager.MountArgsForCall(1)
+						Expect(config["_workload_guid"]).To(Equal("app-guid-123"))
+						Expect(config["_workload_type"]).To(Equal("lrp"))
+					})
+				})
+
+				Context("when the container carries a Task lifecycle tag", func() {
+					BeforeEach(func() {
+						runReq.Tags = executor.Tags{
+							"lifecycle": "task",
+						}
+					})
+
+					It("forwards the task guid as the workload identity on mount", func() {
+						_, err := containerStore.Create(logger, "some-trace-id", containerGuid)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(volumeManager.MountCallCount()).To(Equal(2))
+
+						_, _, _, _, config := volumeManager.MountArgsForCall(0)
+						Expect(config["_workload_guid"]).To(Equal(containerGuid))
+						Expect(config["_workload_type"]).To(Equal("task"))
+					})
+				})
+
 				Context("when it errors on mount", func() {
 					Context("when the driver returns a safeError", func() {
 						BeforeEach(func() {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
@@ -853,8 +853,8 @@ var _ = Describe("Container Store", func() {
 				Context("when the container carries an LRP lifecycle tag", func() {
 					BeforeEach(func() {
 						runReq.Tags = executor.Tags{
-							"lifecycle":    "lrp",
-							"process-guid": "app-guid-123",
+							executor.LifecycleTag:   executor.LRPLifecycle,
+							executor.ProcessGuidTag: "app-guid-123",
 						}
 					})
 
@@ -864,20 +864,21 @@ var _ = Describe("Container Store", func() {
 						Expect(volumeManager.MountCallCount()).To(Equal(2))
 
 						_, _, _, _, config := volumeManager.MountArgsForCall(0)
-						Expect(config["_workload_guid"]).To(Equal("app-guid-123"))
-						Expect(config["_workload_type"]).To(Equal("lrp"))
+						Expect(config[executor.WorkloadGuidKey]).To(Equal("app-guid-123"))
+						Expect(config[executor.WorkloadTypeKey]).To(Equal(executor.LRPLifecycle))
 						Expect(config["some-config"]).To(Equal("interface"))
 
 						_, _, _, _, config = volumeManager.MountArgsForCall(1)
-						Expect(config["_workload_guid"]).To(Equal("app-guid-123"))
-						Expect(config["_workload_type"]).To(Equal("lrp"))
+						Expect(config[executor.WorkloadGuidKey]).To(Equal("app-guid-123"))
+						Expect(config[executor.WorkloadTypeKey]).To(Equal(executor.LRPLifecycle))
+						Expect(config["some-config"]).To(Equal("interface"))
 					})
 				})
 
 				Context("when the container carries a Task lifecycle tag", func() {
 					BeforeEach(func() {
 						runReq.Tags = executor.Tags{
-							"lifecycle": "task",
+							executor.LifecycleTag: executor.TaskLifecycle,
 						}
 					})
 
@@ -887,8 +888,14 @@ var _ = Describe("Container Store", func() {
 						Expect(volumeManager.MountCallCount()).To(Equal(2))
 
 						_, _, _, _, config := volumeManager.MountArgsForCall(0)
-						Expect(config["_workload_guid"]).To(Equal(containerGuid))
-						Expect(config["_workload_type"]).To(Equal("task"))
+						Expect(config[executor.WorkloadGuidKey]).To(Equal(containerGuid))
+						Expect(config[executor.WorkloadTypeKey]).To(Equal(executor.TaskLifecycle))
+						Expect(config["some-config"]).To(Equal("interface"))
+
+						_, _, _, _, config = volumeManager.MountArgsForCall(1)
+						Expect(config[executor.WorkloadGuidKey]).To(Equal(containerGuid))
+						Expect(config[executor.WorkloadTypeKey]).To(Equal(executor.TaskLifecycle))
+						Expect(config["some-config"]).To(Equal("interface"))
 					})
 				})
 

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
@@ -336,10 +336,22 @@ func (n *storeNode) mountVolumes(logger lager.Logger, info executor.Container) (
 //	_workload_guid: process_guid (LRP) or task_guid (Task)
 //	_workload_type: "lrp" or "task"
 //
-// Containers without a lifecycle tag are returned unchanged.
+// Containers without a recognized lifecycle tag, or without a resolvable
+// workload GUID, are returned unchanged (the original map, which may be nil).
 func injectWorkloadIdentity(config map[string]interface{}, info executor.Container) map[string]interface{} {
-	lifecycle, ok := info.Tags["lifecycle"]
-	if !ok {
+	var workloadGuid, workloadType string
+	switch info.Tags[executor.LifecycleTag] {
+	case executor.LRPLifecycle:
+		workloadGuid, workloadType = info.Tags[executor.ProcessGuidTag], executor.LRPLifecycle
+	case executor.TaskLifecycle:
+		workloadGuid, workloadType = info.Guid, executor.TaskLifecycle
+	default:
+		// No lifecycle tag, or an unrecognized value: nothing to inject.
+		return config
+	}
+
+	if workloadGuid == "" {
+		// Nothing authoritative to forward; leave the config untouched.
 		return config
 	}
 
@@ -347,15 +359,8 @@ func injectWorkloadIdentity(config map[string]interface{}, info executor.Contain
 	for k, v := range config {
 		enriched[k] = v
 	}
-
-	switch lifecycle {
-	case "lrp":
-		enriched["_workload_guid"] = info.Tags["process-guid"]
-		enriched["_workload_type"] = "lrp"
-	case "task":
-		enriched["_workload_guid"] = info.Guid
-		enriched["_workload_type"] = "task"
-	}
+	enriched[executor.WorkloadGuidKey] = workloadGuid
+	enriched[executor.WorkloadTypeKey] = workloadType
 
 	return enriched
 }

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
@@ -309,7 +309,8 @@ func (n *storeNode) Create(logger lager.Logger, traceID string) error {
 func (n *storeNode) mountVolumes(logger lager.Logger, info executor.Container) ([]garden.BindMount, error) {
 	gardenMounts := []garden.BindMount{}
 	for _, volume := range info.VolumeMounts {
-		hostMount, err := n.volumeManager.Mount(logger, volume.Driver, volume.VolumeId, info.Guid, volume.Config)
+		config := injectWorkloadIdentity(volume.Config, info)
+		hostMount, err := n.volumeManager.Mount(logger, volume.Driver, volume.VolumeId, info.Guid, config)
 		if err != nil {
 			return nil, err
 		}
@@ -322,6 +323,41 @@ func (n *storeNode) mountVolumes(logger lager.Logger, info executor.Container) (
 			})
 	}
 	return gardenMounts, nil
+}
+
+// injectWorkloadIdentity returns a copy of the volume mount config enriched
+// with the identity of the workload the volume is being mounted for, which
+// Rep already knows from the container tags. Volume drivers that validate a
+// mount against the workload's service bindings can read these keys directly
+// instead of reconstructing the identity out-of-band.
+//
+// Keys added (underscore-prefixed to distinguish them from broker config):
+//
+//	_workload_guid: process_guid (LRP) or task_guid (Task)
+//	_workload_type: "lrp" or "task"
+//
+// Containers without a lifecycle tag are returned unchanged.
+func injectWorkloadIdentity(config map[string]interface{}, info executor.Container) map[string]interface{} {
+	lifecycle, ok := info.Tags["lifecycle"]
+	if !ok {
+		return config
+	}
+
+	enriched := make(map[string]interface{}, len(config)+2)
+	for k, v := range config {
+		enriched[k] = v
+	}
+
+	switch lifecycle {
+	case "lrp":
+		enriched["_workload_guid"] = info.Tags["process-guid"]
+		enriched["_workload_type"] = "lrp"
+	case "task":
+		enriched["_workload_guid"] = info.Guid
+		enriched["_workload_type"] = "task"
+	}
+
+	return enriched
 }
 
 func (n *storeNode) gardenProperties(container *executor.Container) (garden.Properties, error) {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
@@ -1,0 +1,99 @@
+package containerstore
+
+import (
+	"code.cloudfoundry.org/executor"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("injectWorkloadIdentity", func() {
+	var (
+		baseConfig map[string]interface{}
+		container  executor.Container
+	)
+
+	BeforeEach(func() {
+		baseConfig = map[string]interface{}{
+			"source":         "nfs://10.0.0.1/share",
+			"mount-endpoint": "https://fss.example.com",
+		}
+	})
+
+	Context("when the container is an LRP", func() {
+		BeforeEach(func() {
+			container = executor.Container{
+				Guid: "instance-guid-abc",
+				Tags: executor.Tags{
+					"lifecycle":    "lrp",
+					"process-guid": "app-guid-123",
+				},
+			}
+		})
+
+		It("injects _workload_guid with the process-guid and _workload_type as lrp", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result["_workload_guid"]).To(Equal("app-guid-123"))
+			Expect(result["_workload_type"]).To(Equal("lrp"))
+		})
+
+		It("preserves existing config keys", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result["source"]).To(Equal("nfs://10.0.0.1/share"))
+			Expect(result["mount-endpoint"]).To(Equal("https://fss.example.com"))
+		})
+
+		It("does not mutate the original config map", func() {
+			injectWorkloadIdentity(baseConfig, container)
+			Expect(baseConfig).NotTo(HaveKey("_workload_guid"))
+			Expect(baseConfig).NotTo(HaveKey("_workload_type"))
+		})
+	})
+
+	Context("when the container is a Task", func() {
+		BeforeEach(func() {
+			container = executor.Container{
+				Guid: "task-guid-xyz",
+				Tags: executor.Tags{
+					"lifecycle": "task",
+				},
+			}
+		})
+
+		It("injects _workload_guid with the task guid and _workload_type as task", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result["_workload_guid"]).To(Equal("task-guid-xyz"))
+			Expect(result["_workload_type"]).To(Equal("task"))
+		})
+	})
+
+	Context("when the container has no lifecycle tag", func() {
+		BeforeEach(func() {
+			container = executor.Container{
+				Guid: "some-guid",
+				Tags: executor.Tags{},
+			}
+		})
+
+		It("returns the original config unchanged", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result).NotTo(HaveKey("_workload_guid"))
+			Expect(result).NotTo(HaveKey("_workload_type"))
+			Expect(result).To(Equal(baseConfig))
+		})
+	})
+
+	Context("when config is nil", func() {
+		It("returns a new map with identity keys for LRPs", func() {
+			container = executor.Container{
+				Guid: "instance-guid",
+				Tags: executor.Tags{
+					"lifecycle":    "lrp",
+					"process-guid": "pg-1",
+				},
+			}
+			result := injectWorkloadIdentity(nil, container)
+			Expect(result["_workload_guid"]).To(Equal("pg-1"))
+			Expect(result["_workload_type"]).To(Equal("lrp"))
+		})
+	})
+})

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
@@ -24,16 +24,16 @@ var _ = Describe("injectWorkloadIdentity", func() {
 			container = executor.Container{
 				Guid: "instance-guid-abc",
 				Tags: executor.Tags{
-					"lifecycle":    "lrp",
-					"process-guid": "app-guid-123",
+					executor.LifecycleTag:   executor.LRPLifecycle,
+					executor.ProcessGuidTag: "app-guid-123",
 				},
 			}
 		})
 
-		It("injects _workload_guid with the process-guid and _workload_type as lrp", func() {
+		It("injects the workload guid with the process-guid and the type as lrp", func() {
 			result := injectWorkloadIdentity(baseConfig, container)
-			Expect(result["_workload_guid"]).To(Equal("app-guid-123"))
-			Expect(result["_workload_type"]).To(Equal("lrp"))
+			Expect(result[executor.WorkloadGuidKey]).To(Equal("app-guid-123"))
+			Expect(result[executor.WorkloadTypeKey]).To(Equal(executor.LRPLifecycle))
 		})
 
 		It("preserves existing config keys", func() {
@@ -44,8 +44,21 @@ var _ = Describe("injectWorkloadIdentity", func() {
 
 		It("does not mutate the original config map", func() {
 			injectWorkloadIdentity(baseConfig, container)
-			Expect(baseConfig).NotTo(HaveKey("_workload_guid"))
-			Expect(baseConfig).NotTo(HaveKey("_workload_type"))
+			Expect(baseConfig).NotTo(HaveKey(executor.WorkloadGuidKey))
+			Expect(baseConfig).NotTo(HaveKey(executor.WorkloadTypeKey))
+		})
+
+		Context("but the process-guid tag is empty", func() {
+			BeforeEach(func() {
+				container.Tags[executor.ProcessGuidTag] = ""
+			})
+
+			It("returns the original config unchanged", func() {
+				result := injectWorkloadIdentity(baseConfig, container)
+				Expect(result).NotTo(HaveKey(executor.WorkloadGuidKey))
+				Expect(result).NotTo(HaveKey(executor.WorkloadTypeKey))
+				Expect(result).To(Equal(baseConfig))
+			})
 		})
 	})
 
@@ -54,15 +67,21 @@ var _ = Describe("injectWorkloadIdentity", func() {
 			container = executor.Container{
 				Guid: "task-guid-xyz",
 				Tags: executor.Tags{
-					"lifecycle": "task",
+					executor.LifecycleTag: executor.TaskLifecycle,
 				},
 			}
 		})
 
-		It("injects _workload_guid with the task guid and _workload_type as task", func() {
+		It("injects the workload guid with the task guid and the type as task", func() {
 			result := injectWorkloadIdentity(baseConfig, container)
-			Expect(result["_workload_guid"]).To(Equal("task-guid-xyz"))
-			Expect(result["_workload_type"]).To(Equal("task"))
+			Expect(result[executor.WorkloadGuidKey]).To(Equal("task-guid-xyz"))
+			Expect(result[executor.WorkloadTypeKey]).To(Equal(executor.TaskLifecycle))
+		})
+
+		It("preserves existing config keys", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result["source"]).To(Equal("nfs://10.0.0.1/share"))
+			Expect(result["mount-endpoint"]).To(Equal("https://fss.example.com"))
 		})
 	})
 
@@ -76,8 +95,8 @@ var _ = Describe("injectWorkloadIdentity", func() {
 
 		It("returns the original config unchanged", func() {
 			result := injectWorkloadIdentity(baseConfig, container)
-			Expect(result).NotTo(HaveKey("_workload_guid"))
-			Expect(result).NotTo(HaveKey("_workload_type"))
+			Expect(result).NotTo(HaveKey(executor.WorkloadGuidKey))
+			Expect(result).NotTo(HaveKey(executor.WorkloadTypeKey))
 			Expect(result).To(Equal(baseConfig))
 		})
 	})
@@ -87,38 +106,70 @@ var _ = Describe("injectWorkloadIdentity", func() {
 			container = executor.Container{
 				Guid: "some-guid",
 				Tags: executor.Tags{
-					"lifecycle": "other",
+					executor.LifecycleTag: "other",
 				},
 			}
 		})
 
 		It("injects no identity keys and preserves the existing config", func() {
 			result := injectWorkloadIdentity(baseConfig, container)
-			Expect(result).NotTo(HaveKey("_workload_guid"))
-			Expect(result).NotTo(HaveKey("_workload_type"))
+			Expect(result).NotTo(HaveKey(executor.WorkloadGuidKey))
+			Expect(result).NotTo(HaveKey(executor.WorkloadTypeKey))
 			Expect(result["source"]).To(Equal("nfs://10.0.0.1/share"))
 			Expect(result["mount-endpoint"]).To(Equal("https://fss.example.com"))
 		})
 
 		It("does not mutate the original config map", func() {
 			injectWorkloadIdentity(baseConfig, container)
-			Expect(baseConfig).NotTo(HaveKey("_workload_guid"))
-			Expect(baseConfig).NotTo(HaveKey("_workload_type"))
+			Expect(baseConfig).NotTo(HaveKey(executor.WorkloadGuidKey))
+			Expect(baseConfig).NotTo(HaveKey(executor.WorkloadTypeKey))
 		})
 	})
 
 	Context("when config is nil", func() {
-		It("returns a new map with identity keys for LRPs", func() {
+		It("returns a new map with identity keys for an LRP", func() {
 			container = executor.Container{
 				Guid: "instance-guid",
 				Tags: executor.Tags{
-					"lifecycle":    "lrp",
-					"process-guid": "pg-1",
+					executor.LifecycleTag:   executor.LRPLifecycle,
+					executor.ProcessGuidTag: "pg-1",
 				},
 			}
 			result := injectWorkloadIdentity(nil, container)
-			Expect(result["_workload_guid"]).To(Equal("pg-1"))
-			Expect(result["_workload_type"]).To(Equal("lrp"))
+			Expect(result[executor.WorkloadGuidKey]).To(Equal("pg-1"))
+			Expect(result[executor.WorkloadTypeKey]).To(Equal(executor.LRPLifecycle))
+		})
+
+		It("returns a new map with identity keys for a Task", func() {
+			container = executor.Container{
+				Guid: "task-guid",
+				Tags: executor.Tags{
+					executor.LifecycleTag: executor.TaskLifecycle,
+				},
+			}
+			result := injectWorkloadIdentity(nil, container)
+			Expect(result[executor.WorkloadGuidKey]).To(Equal("task-guid"))
+			Expect(result[executor.WorkloadTypeKey]).To(Equal(executor.TaskLifecycle))
+		})
+
+		It("returns nil when there is no lifecycle tag", func() {
+			container = executor.Container{
+				Guid: "some-guid",
+				Tags: executor.Tags{},
+			}
+			result := injectWorkloadIdentity(nil, container)
+			Expect(result).To(BeNil())
+		})
+
+		It("returns nil when the lifecycle tag is unrecognized", func() {
+			container = executor.Container{
+				Guid: "some-guid",
+				Tags: executor.Tags{
+					executor.LifecycleTag: "other",
+				},
+			}
+			result := injectWorkloadIdentity(nil, container)
+			Expect(result).To(BeNil())
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/workload_identity_test.go
@@ -82,6 +82,31 @@ var _ = Describe("injectWorkloadIdentity", func() {
 		})
 	})
 
+	Context("when the lifecycle tag has an unrecognized value", func() {
+		BeforeEach(func() {
+			container = executor.Container{
+				Guid: "some-guid",
+				Tags: executor.Tags{
+					"lifecycle": "other",
+				},
+			}
+		})
+
+		It("injects no identity keys and preserves the existing config", func() {
+			result := injectWorkloadIdentity(baseConfig, container)
+			Expect(result).NotTo(HaveKey("_workload_guid"))
+			Expect(result).NotTo(HaveKey("_workload_type"))
+			Expect(result["source"]).To(Equal("nfs://10.0.0.1/share"))
+			Expect(result["mount-endpoint"]).To(Equal("https://fss.example.com"))
+		})
+
+		It("does not mutate the original config map", func() {
+			injectWorkloadIdentity(baseConfig, container)
+			Expect(baseConfig).NotTo(HaveKey("_workload_guid"))
+			Expect(baseConfig).NotTo(HaveKey("_workload_type"))
+		})
+	})
+
 	Context("when config is nil", func() {
 		It("returns a new map with identity keys for LRPs", func() {
 			container = executor.Container{

--- a/src/code.cloudfoundry.org/executor/resources.go
+++ b/src/code.cloudfoundry.org/executor/resources.go
@@ -314,6 +314,26 @@ func (r *ExecutorResources) Add(res *Resource) {
 
 type Tags map[string]string
 
+// Container tag keys and lifecycle values shared between the components that
+// produce the tags (rep) and those that consume them (e.g. the executor's
+// volume-mount path). Defined here, in the layer rep already depends on, so
+// there is a single source of truth without an import cycle.
+const (
+	LifecycleTag   = "lifecycle"
+	ProcessGuidTag = "process-guid"
+
+	LRPLifecycle  = "lrp"
+	TaskLifecycle = "task"
+)
+
+// Keys injected into a volume mount config to forward the workload identity to
+// the volume driver. Underscore-prefixed to distinguish them from
+// broker-supplied config.
+const (
+	WorkloadGuidKey = "_workload_guid"
+	WorkloadTypeKey = "_workload_type"
+)
+
 func (t Tags) Copy() Tags {
 	if t == nil {
 		return nil

--- a/src/code.cloudfoundry.org/rep/conversion_helpers.go
+++ b/src/code.cloudfoundry.org/rep/conversion_helpers.go
@@ -16,14 +16,17 @@ import (
 )
 
 const (
-	LifecycleTag  = "lifecycle"
+	// Tag keys and lifecycle values shared with the executor, which consumes
+	// them (e.g. on the volume-mount path). Aliased to the executor
+	// definitions so there is a single source of truth.
+	LifecycleTag  = executor.LifecycleTag
 	ResultFileTag = "result-file"
 	DomainTag     = "domain"
 
-	TaskLifecycle = "task"
-	LRPLifecycle  = "lrp"
+	TaskLifecycle = executor.TaskLifecycle
+	LRPLifecycle  = executor.LRPLifecycle
 
-	ProcessGuidTag  = "process-guid"
+	ProcessGuidTag  = executor.ProcessGuidTag
 	InstanceGuidTag = "instance-guid"
 	ProcessIndexTag = "process-index"
 


### PR DESCRIPTION
## Summary

Rep already knows the authoritative workload identity (process GUID for LRPs, task GUID for Tasks) at the moment it calls `volumeManager.Mount`, but does not forward it to the volume driver. Volume drivers that validate a mount against the workload's service bindings therefore have to reconstruct that identity out-of-band (e.g. a `cfdot actual-lrps --cell-id` cell-wide scan followed by a DesiredLRP fetch), which is slow (~1–2s typical, seconds under load) and requires `sudo` + shell tooling on the cell.

This PR enriches the mount `config` map with the workload identity Rep already holds, before calling `Mount`:

- `_workload_guid` — `process_guid` (LRP) or `task_guid` (Task)
- `_workload_type` — `"lrp"` or `"task"`

No protocol change is required — the keys ride the existing `config` map, which the Docker plugin's `Create` call already forwards to the driver. A binding-validating driver can then read the identity directly instead of reconstructing it.

## Backward compatibility

Breaking change? **No.** The change is additive:

- the original `config` map is not mutated (a copy is enriched);
- containers without a `lifecycle` tag are returned unchanged;
- volume drivers that do not read the keys ignore them;
- the underscore prefix distinguishes these injected keys from broker-supplied config.

## Tests

- Unit tests cover LRP, Task, missing-lifecycle and nil-config cases.
- Existing `containerstore` mount tests continue to pass.
- Validated end-to-end against a binding-validating volume driver.


## Related

Design discussion (cross-component contract, alternatives considered): #1192

