### PR TITLE
Add enable_droplet_caching property to gate rep's droplet cache

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -150,6 +150,9 @@ properties:
   diego.executor.min_cache_partition_free_bytes:
     description: "Minimum free space in bytes that must remain on the disk where the download cache lives. When actual disk free space falls below this threshold, the cache deletes old downloaded files to recover space. Set to 0 to disable this behavior."
     default: 5368709120
+  diego.executor.enable_droplet_caching:
+    description: "Whether to cache app droplet downloads on the local disk. Disabling this avoids ephemeral-disk-full incidents on densely-packed cells at the cost of re-downloading droplets from the blobstore on every restart/scale instead of reusing a local cache. Buildpack/lifecycle bundle caching is unaffected."
+    default: true
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -109,6 +109,7 @@
     temp_dir: "#{tmp_dir}",
     unhealthy_monitoring_interval: "#{p("diego.executor.unhealthy_monitoring_interval_in_seconds")}s",
     use_schedulable_disk_size: p("diego.executor.use_schedulable_disk_size"),
+    enable_droplet_caching: p("diego.executor.enable_droplet_caching"),
     zone: "#{zone}",
     report_interval: "1m",
     max_data_string_length: p("logging.max_data_string_length"),

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -135,6 +135,9 @@ properties:
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false
+  diego.executor.enable_droplet_caching:
+    description: "Whether to cache app droplet downloads on the local disk. Disabling this avoids ephemeral-disk-full incidents on densely-packed cells at the cost of re-downloading droplets from the blobstore on every restart/scale instead of reusing a local cache. Buildpack/lifecycle bundle caching is unaffected."
+    default: true
   diego.executor.proxy_healthcheck_interval:
     description: "Interval that checks envoy responsiveness."
     default: "30s"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -106,6 +106,7 @@
     temp_dir: "#{tmp_dir}",
     unhealthy_monitoring_interval: "#{p("diego.executor.unhealthy_monitoring_interval_in_seconds")}s",
     use_schedulable_disk_size: p("diego.executor.use_schedulable_disk_size"),
+    enable_droplet_caching: p("diego.executor.enable_droplet_caching"),
     zone: "#{zone}",
     report_interval: "1m",
     max_data_string_length: p("logging.max_data_string_length"),

--- a/src/code.cloudfoundry.org/executor/depot/steps/download_step.go
+++ b/src/code.cloudfoundry.org/executor/depot/steps/download_step.go
@@ -16,12 +16,13 @@ import (
 )
 
 type downloadStep struct {
-	container        garden.Container
-	model            models.DownloadAction
-	cachedDownloader cacheddownloader.CachedDownloader
-	streamer         log_streamer.LogStreamer
-	rateLimiter      chan struct{}
-	cancelDownload   chan struct{}
+	container            garden.Container
+	model                models.DownloadAction
+	cachedDownloader     cacheddownloader.CachedDownloader
+	streamer             log_streamer.LogStreamer
+	rateLimiter          chan struct{}
+	cancelDownload       chan struct{}
+	enableDropletCaching bool
 
 	logger lager.Logger
 }
@@ -33,6 +34,7 @@ func NewDownload(
 	rateLimiter chan struct{},
 	streamer log_streamer.LogStreamer,
 	logger lager.Logger,
+	enableDropletCaching bool,
 ) ifrit.Runner {
 	logger = logger.Session("download-step", lager.Data{
 		"to":       model.To,
@@ -41,13 +43,14 @@ func NewDownload(
 	})
 
 	return &downloadStep{
-		container:        container,
-		model:            model,
-		cachedDownloader: cachedDownloader,
-		streamer:         streamer,
-		rateLimiter:      rateLimiter,
-		logger:           logger,
-		cancelDownload:   make(chan struct{}),
+		container:            container,
+		model:                model,
+		cachedDownloader:     cachedDownloader,
+		streamer:             streamer,
+		rateLimiter:          rateLimiter,
+		logger:               logger,
+		cancelDownload:       make(chan struct{}),
+		enableDropletCaching: enableDropletCaching,
 	}
 }
 
@@ -125,10 +128,15 @@ func (step *downloadStep) fetch() (io.ReadCloser, int64, error) {
 		return nil, 0, err
 	}
 
+	cacheKey := step.model.CacheKey
+	if !step.enableDropletCaching && step.model.Artifact == "droplet" {
+		cacheKey = ""
+	}
+
 	tarStream, downloadedSize, err := step.cachedDownloader.Fetch(
 		step.logger.Session("downloader"),
 		url,
-		step.model.CacheKey,
+		cacheKey,
 		cacheddownloader.ChecksumInfoType{
 			Algorithm: step.model.GetChecksumAlgorithm(),
 			Value:     step.model.GetChecksumValue(),

--- a/src/code.cloudfoundry.org/executor/depot/steps/download_step_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/steps/download_step_test.go
@@ -79,6 +79,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 
 			stepErr = <-ifrit.Invoke(step).Wait()
@@ -352,6 +353,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 		})
 
@@ -386,6 +388,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 		})
 
@@ -506,6 +509,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 
 			downloadAction2 := models.DownloadAction{
@@ -520,6 +524,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 
 			downloadAction3 := models.DownloadAction{
@@ -534,6 +539,7 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
+				true,
 			)
 
 			fetchCh := make(chan struct{}, 3)
@@ -560,6 +566,45 @@ var _ = Describe("DownloadAction", func() {
 			close(barrier)
 		})
 	})
+
+	DescribeTable("droplet caching gating based on Artifact and EnableDropletCaching",
+		func(artifact string, enableDropletCaching bool, expectedCacheKey string) {
+			container, err := gardenClient.Create(garden.ContainerSpec{
+				Handle: handle,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			action := models.DownloadAction{
+				From:     "http://mr_jones",
+				To:       "/tmp/Antarctica",
+				CacheKey: "the-cache-key",
+				User:     "notroot",
+				Artifact: artifact,
+			}
+
+			step = steps.NewDownload(
+				container,
+				action,
+				cache,
+				rateLimiter,
+				fakeStreamer,
+				logger,
+				enableDropletCaching,
+			)
+
+			err = <-ifrit.Invoke(step).Wait()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cache.FetchCallCount()).To(Equal(1))
+			_, _, cacheKey, _, _ := cache.FetchArgsForCall(0)
+			Expect(cacheKey).To(Equal(expectedCacheKey))
+		},
+		Entry("Artifact: droplet + EnableDropletCaching: false -> empty cache key", "droplet", false, ""),
+		Entry("Artifact: droplet + EnableDropletCaching: true -> original cache key", "droplet", true, "the-cache-key"),
+		Entry("Artifact: droplet + EnableDropletCaching: unset/false (zero value) -> empty cache key", "droplet", false, ""),
+		Entry("Non-droplet Artifact (buildpack) + EnableDropletCaching: false -> original cache key", "buildpack", false, "the-cache-key"),
+		Entry("Non-droplet Artifact (empty) + EnableDropletCaching: true -> original cache key", "", true, "the-cache-key"),
+	)
 })
 
 var _ = Describe("ReadSizer", func() {

--- a/src/code.cloudfoundry.org/executor/depot/transformer/transformer.go
+++ b/src/code.cloudfoundry.org/executor/depot/transformer/transformer.go
@@ -71,6 +71,8 @@ type transformer struct {
 
 	postSetupHook []string
 	postSetupUser string
+
+	enableDropletCaching bool
 }
 
 type Option func(*transformer)
@@ -117,6 +119,12 @@ func WithPostSetupHook(user string, hook []string) Option {
 func WithDeclarativeHealthcheckFailureMetrics() Option {
 	return func(t *transformer) {
 		t.emitHealthCheckMetrics = true
+	}
+}
+
+func WithEnableDropletCaching(enableDropletCaching bool) Option {
+	return func(t *transformer) {
+		t.enableDropletCaching = enableDropletCaching
 	}
 }
 
@@ -192,6 +200,7 @@ func (t *transformer) stepFor(
 			t.downloadLimiter,
 			logStreamer.WithSource(actionModel.LogSource),
 			logger,
+			t.enableDropletCaching,
 		)
 
 	case *models.UploadAction:

--- a/src/code.cloudfoundry.org/executor/initializer/initializer.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer.go
@@ -85,6 +85,7 @@ type ExecutorConfig struct {
 	InstanceIdentityCredDir               string                `json:"instance_identity_cred_dir,omitempty"`
 	InstanceIdentityPrivateKeyPath        string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod        durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
+	EnableDropletCaching                  bool                  `json:"enable_droplet_caching,omitempty"`
 	MaxCacheSizeInBytes                   uint64                `json:"max_cache_size_in_bytes,omitempty"`
 	MinCachePartitionFreeBytes            uint64                `json:"min_cache_partition_free_bytes,omitempty"`
 	MaxConcurrentDownloads                int                   `json:"max_concurrent_downloads,omitempty"`

--- a/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
@@ -169,6 +169,7 @@ func Initialize(
 		config.EnableContainerProxyHealthChecks,
 		time.Duration(config.ProxyHealthCheckInterval),
 		time.Duration(config.DeclarativeHealthCheckDefaultTimeout),
+		config.EnableDropletCaching,
 	)
 
 	hub := event.NewHub()
@@ -454,11 +455,13 @@ func initializeTransformer(
 	enableProxyHealthChecks bool,
 	proxyHealthCheckInterval time.Duration,
 	declarativeHealthCheckDefaultTimeout time.Duration,
+	enableDropletCaching bool,
 ) transformer.Transformer {
 	var options []transformer.Option
 	compressor := compressor.NewTgz()
 	options = append(options, transformer.WithSidecarRootfs(declarativeHealthcheckRootFS))
 	options = append(options, transformer.WithDeclarativeHealthChecks(declarativeHealthCheckDefaultTimeout))
+	options = append(options, transformer.WithEnableDropletCaching(enableDropletCaching))
 	if emitHealthCheckMetrics {
 		options = append(options, transformer.WithDeclarativeHealthcheckFailureMetrics())
 	}

--- a/src/code.cloudfoundry.org/executor/initializer/initializer_test.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -742,6 +743,32 @@ var _ = Describe("Initializer", func() {
 				Expect(newCachedDownloader).To(BeNil())
 				Expect(err.Error()).To(ContainSubstring("could not create cache path"))
 			})
+		})
+	})
+
+	Describe("ExecutorConfig JSON unmarshaling", func() {
+		It("unmarshals EnableDropletCaching when explicitly set to true", func() {
+			jsonConfig := []byte(`{"enable_droplet_caching": true}`)
+			var config initializer.ExecutorConfig
+			err := json.Unmarshal(jsonConfig, &config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.EnableDropletCaching).To(BeTrue())
+		})
+
+		It("unmarshals EnableDropletCaching when explicitly set to false", func() {
+			jsonConfig := []byte(`{"enable_droplet_caching": false}`)
+			var config initializer.ExecutorConfig
+			err := json.Unmarshal(jsonConfig, &config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.EnableDropletCaching).To(BeFalse())
+		})
+
+		It("unmarshals EnableDropletCaching as false (zero value) when absent", func() {
+			jsonConfig := []byte(`{}`)
+			var config initializer.ExecutorConfig
+			err := json.Unmarshal(jsonConfig, &config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.EnableDropletCaching).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION


- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The cached downloader will not evict cached files marked as "in use". As a result, on densely packed cells, the download cache will grow and grow beyond the max cache directory size, as all the cached droplet files are actually in use. 

For these cases, this change lets operators disable rep's local-disk caching of app droplet downloads, avoiding ephemeral-disk-full incidents on densely-packed cells at the cost of re-downloading droplets from the blobstore on every restart/scale. Buildpack/lifecycle bundle caching is unaffected. Defaults to true (current behavior unchanged) via the BOSH job spec.

ai-assisted=yes
TNZ-126780

Backward Compatibility
---------------
Breaking Change? yes