### PR TITLE
Fix cached-downloader bugs and implement periodic download_cache cleanup rather than waiting for the next download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ docs/superpowers
 .bash-guard
 
 _rocket-agent/
+.worktrees/

--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -150,9 +150,6 @@ properties:
   diego.executor.min_cache_partition_free_bytes:
     description: "Minimum free space in bytes that must remain on the disk where the download cache lives. When actual disk free space falls below this threshold, the cache deletes old downloaded files to recover space. Set to 0 to disable this behavior."
     default: 5368709120
-  diego.executor.enable_droplet_caching:
-    description: "Whether to cache app droplet downloads on the local disk. Disabling this avoids ephemeral-disk-full incidents on densely-packed cells at the cost of re-downloading droplets from the blobstore on every restart/scale instead of reusing a local cache. Buildpack/lifecycle bundle caching is unaffected."
-    default: true
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -109,7 +109,6 @@
     temp_dir: "#{tmp_dir}",
     unhealthy_monitoring_interval: "#{p("diego.executor.unhealthy_monitoring_interval_in_seconds")}s",
     use_schedulable_disk_size: p("diego.executor.use_schedulable_disk_size"),
-    enable_droplet_caching: p("diego.executor.enable_droplet_caching"),
     zone: "#{zone}",
     report_interval: "1m",
     max_data_string_length: p("logging.max_data_string_length"),

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -135,9 +135,6 @@ properties:
   diego.executor.use_schedulable_disk_size:
     description: "Use total space available to containers reported by Garden. If false the total size of image plugin store minus max_cache_size_in_bytes is used."
     default: false
-  diego.executor.enable_droplet_caching:
-    description: "Whether to cache app droplet downloads on the local disk. Disabling this avoids ephemeral-disk-full incidents on densely-packed cells at the cost of re-downloading droplets from the blobstore on every restart/scale instead of reusing a local cache. Buildpack/lifecycle bundle caching is unaffected."
-    default: true
   diego.executor.proxy_healthcheck_interval:
     description: "Interval that checks envoy responsiveness."
     default: "30s"

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -106,7 +106,6 @@
     temp_dir: "#{tmp_dir}",
     unhealthy_monitoring_interval: "#{p("diego.executor.unhealthy_monitoring_interval_in_seconds")}s",
     use_schedulable_disk_size: p("diego.executor.use_schedulable_disk_size"),
-    enable_droplet_caching: p("diego.executor.enable_droplet_caching"),
     zone: "#{zone}",
     report_interval: "1m",
     max_data_string_length: p("logging.max_data_string_length"),

--- a/packages/rep/spec
+++ b/packages/rep/spec
@@ -71,6 +71,7 @@ files:
   - code.cloudfoundry.org/operationq/*.go # gosub
   - code.cloudfoundry.org/rep/*.go # gosub
   - code.cloudfoundry.org/rep/auctioncellrep/*.go # gosub
+  - code.cloudfoundry.org/rep/cachecleanup/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/gocurl/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/rep/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/rep/config/*.go # gosub

--- a/packages/rep_windows/spec
+++ b/packages/rep_windows/spec
@@ -72,6 +72,7 @@ files:
   - code.cloudfoundry.org/operationq/*.go # gosub
   - code.cloudfoundry.org/rep/*.go # gosub
   - code.cloudfoundry.org/rep/auctioncellrep/*.go # gosub
+  - code.cloudfoundry.org/rep/cachecleanup/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/gocurl/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/rep/*.go # gosub
   - code.cloudfoundry.org/rep/cmd/rep/config/*.go # gosub

--- a/src/code.cloudfoundry.org/cacheddownloader/cached_downloader.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/cached_downloader.go
@@ -47,6 +47,9 @@ type CachedDownloader interface {
 	// RecoverState checks to see if a state file exists (from a previous SaveState call), and restores
 	// the cache state from that information if such a file exists. This should be called on startup.
 	RecoverState(logger lager.Logger) error
+
+	// MakeRoom attempts to evict unused cache entries to bring the cache under budget.
+	MakeRoom(logger lager.Logger)
 }
 
 func NoopTransform(source, destination string) (int64, error) {
@@ -200,6 +203,10 @@ func (c *cachedDownloader) RecoverState(logger lager.Logger) error {
 	}
 
 	return err
+}
+
+func (c *cachedDownloader) MakeRoom(logger lager.Logger) {
+	c.cache.MakeRoom(logger)
 }
 
 func (c *cachedDownloader) CloseDirectory(logger lager.Logger, cacheKey, directoryPath string) error {

--- a/src/code.cloudfoundry.org/cacheddownloader/cached_downloader_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/cached_downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -1203,6 +1204,46 @@ var _ = Describe("File cache", func() {
 			Expect(err).NotTo(HaveOccurred())
 			saveStateFile := filepath.Join(cachedPath, "saved_cache.json")
 			Expect(saveStateFile).To(BeARegularFile())
+		})
+	})
+
+	Describe("MakeRoom", func() {
+		BeforeEach(func() {
+			fileContent := []byte("a file with lots of content")
+			returnedHeader := http.Header{}
+			returnedHeader.Set("ETag", "some-etag")
+
+			server.AppendHandlers(ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/file_to_evict"),
+				ghttp.RespondWith(http.StatusOK, string(fileContent), returnedHeader),
+			))
+
+			fileUrl, err := Url.Parse(server.URL() + "/file_to_evict")
+			Expect(err).NotTo(HaveOccurred())
+
+			file, _, err := cachedDownloader.Fetch(logger, fileUrl, "evictable-cache-key", checksum, cancelChan)
+			Expect(err).NotTo(HaveOccurred())
+			file.Close()
+
+			expectCacheToHaveNEntries(cachedPath, 1)
+
+			saveStateFile := filepath.Join(cachedPath, "saved_cache.json")
+			Expect(cachedDownloader.SaveState(logger)).To(Succeed())
+
+			cache = cacheddownloader.NewCache(cachedPath, 1, 0)
+			stateFile, err := os.Open(saveStateFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(json.NewDecoder(stateFile).Decode(cache)).To(Succeed())
+			stateFile.Close()
+			Expect(os.Remove(saveStateFile)).To(Succeed())
+
+			cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("evicts old unused entries from the cache", func() {
+			cachedDownloader.MakeRoom(logger)
+			expectCacheToHaveNEntries(cachedPath, 0)
 		})
 	})
 

--- a/src/code.cloudfoundry.org/cacheddownloader/cacheddownloaderfakes/fake_cached_downloader.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/cacheddownloaderfakes/fake_cached_downloader.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/cacheddownloader"
-	"code.cloudfoundry.org/lager/v3"
+	lager "code.cloudfoundry.org/lager/v3"
 )
 
 type FakeCachedDownloader struct {
@@ -61,6 +61,11 @@ type FakeCachedDownloader struct {
 		result1 string
 		result2 int64
 		result3 error
+	}
+	MakeRoomStub        func(lager.Logger)
+	makeRoomMutex       sync.RWMutex
+	makeRoomArgsForCall []struct {
+		arg1 lager.Logger
 	}
 	RecoverStateStub        func(lager.Logger) error
 	recoverStateMutex       sync.RWMutex
@@ -293,6 +298,38 @@ func (fake *FakeCachedDownloader) FetchAsDirectoryReturnsOnCall(i int, result1 s
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCachedDownloader) MakeRoom(arg1 lager.Logger) {
+	fake.makeRoomMutex.Lock()
+	fake.makeRoomArgsForCall = append(fake.makeRoomArgsForCall, struct {
+		arg1 lager.Logger
+	}{arg1})
+	stub := fake.MakeRoomStub
+	fake.recordInvocation("MakeRoom", []interface{}{arg1})
+	fake.makeRoomMutex.Unlock()
+	if stub != nil {
+		fake.MakeRoomStub(arg1)
+	}
+}
+
+func (fake *FakeCachedDownloader) MakeRoomCallCount() int {
+	fake.makeRoomMutex.RLock()
+	defer fake.makeRoomMutex.RUnlock()
+	return len(fake.makeRoomArgsForCall)
+}
+
+func (fake *FakeCachedDownloader) MakeRoomCalls(stub func(lager.Logger)) {
+	fake.makeRoomMutex.Lock()
+	defer fake.makeRoomMutex.Unlock()
+	fake.MakeRoomStub = stub
+}
+
+func (fake *FakeCachedDownloader) MakeRoomArgsForCall(i int) lager.Logger {
+	fake.makeRoomMutex.RLock()
+	defer fake.makeRoomMutex.RUnlock()
+	argsForCall := fake.makeRoomArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeCachedDownloader) RecoverState(arg1 lager.Logger) error {
 	fake.recoverStateMutex.Lock()
 	ret, specificReturn := fake.recoverStateReturnsOnCall[len(fake.recoverStateArgsForCall)]
@@ -418,16 +455,6 @@ func (fake *FakeCachedDownloader) SaveStateReturnsOnCall(i int, result1 error) {
 func (fake *FakeCachedDownloader) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.closeDirectoryMutex.RLock()
-	defer fake.closeDirectoryMutex.RUnlock()
-	fake.fetchMutex.RLock()
-	defer fake.fetchMutex.RUnlock()
-	fake.fetchAsDirectoryMutex.RLock()
-	defer fake.fetchAsDirectoryMutex.RUnlock()
-	fake.recoverStateMutex.RLock()
-	defer fake.recoverStateMutex.RUnlock()
-	fake.saveStateMutex.RLock()
-	defer fake.saveStateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache.go
@@ -183,6 +183,8 @@ func (e *FileCacheEntry) expandedDirectory() (string, error) {
 		e.ExpandedDirectoryPath = e.FilePath + ".d"
 		err := extractTarToDirectory(e.FilePath, e.ExpandedDirectoryPath)
 		if err != nil {
+			os.RemoveAll(e.ExpandedDirectoryPath)
+			e.ExpandedDirectoryPath = ""
 			return "", err
 		}
 
@@ -228,6 +230,20 @@ func (c *FileCache) CloseDirectory(logger lager.Logger, cacheKey, dirPath string
 
 	entry.decrementDirectoryInUseCount()
 	if !entry.inUse() {
+		if entry.ExpandedDirectoryPath != "" {
+			err := os.RemoveAll(entry.ExpandedDirectoryPath)
+			if err != nil {
+				logger.Error("failed-deleting-cached-directory", err, lager.Data{"dir": entry.ExpandedDirectoryPath})
+			}
+			entry.ExpandedDirectoryPath = ""
+		}
+		if entry.FilePath != "" {
+			err := os.RemoveAll(entry.FilePath)
+			if err != nil {
+				logger.Error("failed-deleting-cached-file", err, lager.Data{"file": entry.FilePath})
+			}
+			entry.FilePath = ""
+		}
 		// done with this old entry, so clean it up
 		delete(c.OldEntries, cacheKey+dirPath)
 	}
@@ -385,6 +401,13 @@ func (c *FileCache) updateOldEntries(logger lager.Logger, cacheKey string, entry
 			delete(c.OldEntries, cacheKey+entry.ExpandedDirectoryPath)
 		}
 	}
+}
+
+func (c *FileCache) MakeRoom(logger lager.Logger) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	c.makeRoom(logger, 0, "")
 }
 
 func (c *FileCache) makeRoom(logger lager.Logger, size int64, excludedCacheKey string) {

--- a/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
+++ b/src/code.cloudfoundry.org/cacheddownloader/file_cache_test.go
@@ -877,6 +877,43 @@ var _ = Describe("FileCache", func() {
 				Expect(cache.CloseDirectory(logger, cacheKey, dir2)).To(Succeed())
 			})
 		})
+
+		Context("when extraction fails", func() {
+			var corruptFile *os.File
+
+			BeforeEach(func() {
+				corruptFile = createFile("corrupt-archive", "not a valid tar content")
+				rc, err := cache.Add(logger, cacheKey, corruptFile.Name(), fileSize, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rc.Close()).To(Succeed())
+			})
+
+			AfterEach(func() {
+				os.RemoveAll(corruptFile.Name())
+			})
+
+			It("cleans up partial directory, resets ExpandedDirectoryPath, and allows subsequent retry to succeed", func() {
+				_, _, err := cache.GetDirectory(logger, cacheKey)
+				Expect(err).To(HaveOccurred())
+
+				entry := cache.Entries[cacheKey]
+				Expect(entry).NotTo(BeNil())
+				Expect(entry.ExpandedDirectoryPath).To(BeEmpty())
+				Expect(entry.FilePath + ".d").NotTo(BeAnExistingFile())
+
+				validArchive := createArchive("valid-archive", "valid content")
+				defer os.RemoveAll(validArchive.Name())
+
+				validData, err := os.ReadFile(validArchive.Name())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(entry.FilePath, validData, 0600)).To(Succeed())
+
+				dir, _, err := cache.GetDirectory(logger, cacheKey)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dir).To(BeADirectory())
+				Expect(recursiveList(dir)).To(ContainElement("/testdir/file.txt"))
+			})
+		})
 	})
 
 	Describe("makeRoom partition free-space eviction", func() {
@@ -1023,6 +1060,55 @@ var _ = Describe("FileCache", func() {
 					cache.CloseDirectory(logger, cacheKey, dir)
 					Expect(filenamesInDir(cacheDir)).To(HaveLen(0))
 				})
+			})
+		})
+	})
+
+	Describe("CloseDirectory", func() {
+		Context("when closing an entry in OldEntries", func() {
+			var (
+				cacheKey   string
+				fileSize   int64
+				cacheInfo  cacheddownloader.CachingInfoType
+				dir1, dir2 string
+				a1, a2     *os.File
+			)
+
+			BeforeEach(func() {
+				cacheKey = "old-entries-key"
+				fileSize = 100
+				cacheInfo = cacheddownloader.CachingInfoType{}
+
+				a1 = createArchive("cache-test-file1", "content1")
+				a2 = createArchive("cache-test-file2", "content2")
+
+				var err error
+				dir1, err = cache.AddDirectory(logger, cacheKey, a1.Name(), fileSize, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Increase directoryInUseCount to 2 so replacement won't decrement count to 0
+				_, _, err = cache.GetDirectory(logger, cacheKey)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Replacing the entry moves dir1 to OldEntries with directoryInUseCount = 1
+				cacheInfo.LastModified = "new-mod"
+				dir2, err = cache.AddDirectory(logger, cacheKey, a2.Name(), fileSize, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				os.RemoveAll(a1.Name())
+				os.RemoveAll(a2.Name())
+				cache.CloseDirectory(logger, cacheKey, dir2)
+			})
+
+			It("deletes the entry's expanded directory from disk when it becomes unused", func() {
+				Expect(dir1).To(BeADirectory())
+
+				err := cache.CloseDirectory(logger, cacheKey, dir1)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dir1).NotTo(BeAnExistingFile())
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/executor/client.go
+++ b/src/code.cloudfoundry.org/executor/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	Healthy(lager.Logger) bool
 	SetHealthy(lager.Logger, bool)
 	Cleanup(lager.Logger)
+	ReclaimCacheSpace(logger lager.Logger)
 }
 
 //go:generate counterfeiter -o fakes/fake_event_source.go . EventSource

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore.go
@@ -47,6 +47,8 @@ type ContainerStore interface {
 
 	// shutdown the dependency manager
 	Cleanup(logger lager.Logger)
+
+	ReclaimCacheSpace(logger lager.Logger)
 }
 
 type ContainerConfig struct {
@@ -141,6 +143,10 @@ func New(
 
 func (cs *containerStore) Cleanup(logger lager.Logger) {
 	cs.dependencyManager.Stop(logger)
+}
+
+func (cs *containerStore) ReclaimCacheSpace(logger lager.Logger) {
+	cs.dependencyManager.ReclaimCacheSpace(logger)
 }
 
 func (cs *containerStore) Reserve(logger lager.Logger, traceID string, req *executor.AllocationRequest) (executor.Container, error) {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstore_test.go
@@ -967,6 +967,28 @@ var _ = Describe("Container Store", func() {
 					Expect(container.RunResult.FailureReason).To(Equal(containerstore.DownloadCachedDependenciesFailed))
 					Expect(container.RunResult.Retryable).To(BeTrue())
 				})
+
+				Context("when partial bind mounts are returned with the error", func() {
+					var partialMounts containerstore.BindMounts
+
+					BeforeEach(func() {
+						partialMounts = containerstore.BindMounts{
+							CacheKeys: []containerstore.BindMountCacheKey{
+								{CacheKey: "key-1", Dir: "dir-1"},
+							},
+						}
+						dependencyManager.DownloadCachedDependenciesReturns(partialMounts, errors.New("partial download failure"))
+					})
+
+					It("releases the partial cache keys", func() {
+						_, err := containerStore.Create(logger, "some-trace-id", containerGuid)
+						Expect(err).To(HaveOccurred())
+
+						Expect(dependencyManager.ReleaseCachedDependenciesCallCount()).To(Equal(1))
+						_, keys := dependencyManager.ReleaseCachedDependenciesArgsForCall(0)
+						Expect(keys).To(Equal(partialMounts.CacheKeys))
+					})
+				})
 			})
 
 			Context("when egress rules are requested", func() {
@@ -3769,6 +3791,14 @@ var _ = Describe("Container Store", func() {
 				clock.Increment(30 * time.Millisecond)
 				Eventually(logger).Should(gbytes.Say("failed-to-destroy-container"))
 			})
+		})
+	})
+
+	Describe("ReclaimCacheSpace", func() {
+		It("delegates to the dependency manager", func() {
+			containerStore.ReclaimCacheSpace(logger)
+			Expect(dependencyManager.ReclaimCacheSpaceCallCount()).To(Equal(1))
+			Expect(dependencyManager.ReclaimCacheSpaceArgsForCall(0)).To(Equal(logger))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstorefakes/fake_bindmounter.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstorefakes/fake_bindmounter.go
@@ -28,6 +28,11 @@ type FakeDependencyManager struct {
 		result1 containerstore.BindMounts
 		result2 error
 	}
+	ReclaimCacheSpaceStub        func(lager.Logger)
+	reclaimCacheSpaceMutex       sync.RWMutex
+	reclaimCacheSpaceArgsForCall []struct {
+		arg1 lager.Logger
+	}
 	ReleaseCachedDependenciesStub        func(lager.Logger, []containerstore.BindMountCacheKey) error
 	releaseCachedDependenciesMutex       sync.RWMutex
 	releaseCachedDependenciesArgsForCall []struct {
@@ -119,6 +124,38 @@ func (fake *FakeDependencyManager) DownloadCachedDependenciesReturnsOnCall(i int
 		result1 containerstore.BindMounts
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeDependencyManager) ReclaimCacheSpace(arg1 lager.Logger) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	fake.reclaimCacheSpaceArgsForCall = append(fake.reclaimCacheSpaceArgsForCall, struct {
+		arg1 lager.Logger
+	}{arg1})
+	stub := fake.ReclaimCacheSpaceStub
+	fake.recordInvocation("ReclaimCacheSpace", []interface{}{arg1})
+	fake.reclaimCacheSpaceMutex.Unlock()
+	if stub != nil {
+		fake.ReclaimCacheSpaceStub(arg1)
+	}
+}
+
+func (fake *FakeDependencyManager) ReclaimCacheSpaceCallCount() int {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	return len(fake.reclaimCacheSpaceArgsForCall)
+}
+
+func (fake *FakeDependencyManager) ReclaimCacheSpaceCalls(stub func(lager.Logger)) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	defer fake.reclaimCacheSpaceMutex.Unlock()
+	fake.ReclaimCacheSpaceStub = stub
+}
+
+func (fake *FakeDependencyManager) ReclaimCacheSpaceArgsForCall(i int) lager.Logger {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	argsForCall := fake.reclaimCacheSpaceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeDependencyManager) ReleaseCachedDependencies(arg1 lager.Logger, arg2 []containerstore.BindMountCacheKey) error {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/containerstorefakes/fake_containerstore.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/containerstorefakes/fake_containerstore.go
@@ -132,6 +132,11 @@ type FakeContainerStore struct {
 	newRegistryPrunerReturnsOnCall map[int]struct {
 		result1 ifrit.Runner
 	}
+	ReclaimCacheSpaceStub        func(lager.Logger)
+	reclaimCacheSpaceMutex       sync.RWMutex
+	reclaimCacheSpaceArgsForCall []struct {
+		arg1 lager.Logger
+	}
 	RemainingResourcesStub        func(lager.Logger) executor.ExecutorResources
 	remainingResourcesMutex       sync.RWMutex
 	remainingResourcesArgsForCall []struct {
@@ -799,6 +804,38 @@ func (fake *FakeContainerStore) NewRegistryPrunerReturnsOnCall(i int, result1 if
 	fake.newRegistryPrunerReturnsOnCall[i] = struct {
 		result1 ifrit.Runner
 	}{result1}
+}
+
+func (fake *FakeContainerStore) ReclaimCacheSpace(arg1 lager.Logger) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	fake.reclaimCacheSpaceArgsForCall = append(fake.reclaimCacheSpaceArgsForCall, struct {
+		arg1 lager.Logger
+	}{arg1})
+	stub := fake.ReclaimCacheSpaceStub
+	fake.recordInvocation("ReclaimCacheSpace", []interface{}{arg1})
+	fake.reclaimCacheSpaceMutex.Unlock()
+	if stub != nil {
+		fake.ReclaimCacheSpaceStub(arg1)
+	}
+}
+
+func (fake *FakeContainerStore) ReclaimCacheSpaceCallCount() int {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	return len(fake.reclaimCacheSpaceArgsForCall)
+}
+
+func (fake *FakeContainerStore) ReclaimCacheSpaceCalls(stub func(lager.Logger)) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	defer fake.reclaimCacheSpaceMutex.Unlock()
+	fake.ReclaimCacheSpaceStub = stub
+}
+
+func (fake *FakeContainerStore) ReclaimCacheSpaceArgsForCall(i int) lager.Logger {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	argsForCall := fake.reclaimCacheSpaceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeContainerStore) RemainingResources(arg1 lager.Logger) executor.ExecutorResources {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/dependencymanager.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/dependencymanager.go
@@ -1,6 +1,7 @@
 package containerstore
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -20,6 +21,7 @@ import (
 type DependencyManager interface {
 	DownloadCachedDependencies(logger lager.Logger, mounts []executor.CachedDependency, logconfig models.LogConfig, metronClient loggingclient.IngressClient) (BindMounts, error)
 	ReleaseCachedDependencies(logger lager.Logger, keys []BindMountCacheKey) error
+	ReclaimCacheSpace(logger lager.Logger)
 	Stop(logger lager.Logger)
 }
 
@@ -39,6 +41,10 @@ func (bm *dependencyManager) Stop(logger lager.Logger) {
 	if err != nil {
 		logger.Error("failed-saving-cache-state", err, lager.Data{"err": err})
 	}
+}
+
+func (bm *dependencyManager) ReclaimCacheSpace(logger lager.Logger) {
+	bm.cache.MakeRoom(logger)
 }
 
 func (bm *dependencyManager) DownloadCachedDependencies(logger lager.Logger, mounts []executor.CachedDependency, logConfig models.LogConfig, metronClient loggingclient.IngressClient) (BindMounts, error) {
@@ -86,7 +92,14 @@ func (bm *dependencyManager) DownloadCachedDependencies(logger lager.Logger, mou
 		case err := <-errChan:
 			close(cancelChan)
 			wg.Wait()
-			return bindMounts, err
+			for {
+				select {
+				case cachedMount := <-mountChan:
+					bindMounts.AddBindMount(cachedMount.CacheKey, cachedMount.BindMount)
+				default:
+					return bindMounts, err
+				}
+			}
 		case cachedMount := <-mountChan:
 			bindMounts.AddBindMount(cachedMount.CacheKey, cachedMount.BindMount)
 			completed++
@@ -164,16 +177,17 @@ func (bm *dependencyManager) downloadCachedDependency(logger lager.Logger, mount
 }
 
 func (bm *dependencyManager) ReleaseCachedDependencies(logger lager.Logger, keys []BindMountCacheKey) error {
+	var errs error
 	for i := range keys {
 		key := &keys[i]
 		logger.Debug("releasing-cache-key", lager.Data{"cache-key": key.CacheKey, "dir": key.Dir})
 		err := bm.cache.CloseDirectory(logger, key.CacheKey, key.Dir)
 		if err != nil && err != cacheddownloader.AlreadyClosed && err != cacheddownloader.EntryNotFound {
 			logger.Error("failed-releasing-cache-key", err, lager.Data{"cache-key": key.CacheKey, "dir": key.Dir})
-			return err
+			errs = errors.Join(errs, err)
 		}
 	}
-	return nil
+	return errs
 }
 
 type cachedBindMount struct {

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/dependencymanager_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/dependencymanager_test.go
@@ -76,6 +76,98 @@ var _ = Describe("DependencyManager", func() {
 		})
 	})
 
+	Context("when some dependencies succeed and one fails", func() {
+		type testCase struct {
+			name                 string
+			deps                 []executor.CachedDependency
+			stub                 func(logger lager.Logger, urlToFetch *url.URL, cacheKey string, checksum cacheddownloader.ChecksumInfoType, cancelChan <-chan struct{}) (string, int64, error)
+			expectedCacheKeys    []containerstore.BindMountCacheKey
+			expectedGardenMounts []garden.BindMount
+		}
+
+		DescribeTable("preserves successful cache keys in returned BindMounts even when an error occurs",
+			func(tc testCase) {
+				downloadRateLimiter = make(chan struct{}, len(tc.deps))
+				dependencyManager = containerstore.NewDependencyManager(cache, downloadRateLimiter)
+				cache.FetchAsDirectoryStub = tc.stub
+
+				bindMounts, err := dependencyManager.DownloadCachedDependencies(logger, tc.deps, logConfig, fakeClient)
+				Expect(err).To(HaveOccurred())
+				Expect(bindMounts.CacheKeys).To(ConsistOf(tc.expectedCacheKeys))
+				Expect(bindMounts.GardenBindMounts).To(ConsistOf(tc.expectedGardenMounts))
+			},
+			Entry("when a dependency succeeds before another fails", testCase{
+				name: "early success",
+				deps: []executor.CachedDependency{
+					{CacheKey: "cache-key-success-1", From: "http://example.com/1", To: "/var/data/1"},
+					{CacheKey: "cache-key-fail", From: "http://example.com/fail", To: "/var/data/fail"},
+				},
+				stub: func(_ lager.Logger, _ *url.URL, cacheKey string, _ cacheddownloader.ChecksumInfoType, _ <-chan struct{}) (string, int64, error) {
+					if cacheKey == "cache-key-success-1" {
+						return "/tmp/download/1", 100, nil
+					}
+					time.Sleep(50 * time.Millisecond)
+					return "", 0, errors.New("download-failed")
+				},
+				expectedCacheKeys: []containerstore.BindMountCacheKey{
+					{CacheKey: "cache-key-success-1", Dir: "/tmp/download/1"},
+				},
+				expectedGardenMounts: []garden.BindMount{
+					{SrcPath: "/tmp/download/1", DstPath: "/var/data/1", Mode: garden.BindMountModeRO, Origin: garden.BindMountOriginHost},
+				},
+			}),
+			Entry("when a dependency succeeds after another fails (during wg.Wait)", testCase{
+				name: "late success during cancel",
+				deps: []executor.CachedDependency{
+					{CacheKey: "cache-key-fail", From: "http://example.com/fail", To: "/var/data/fail"},
+					{CacheKey: "cache-key-success-late", From: "http://example.com/late", To: "/var/data/late"},
+				},
+				stub: func(_ lager.Logger, _ *url.URL, cacheKey string, _ cacheddownloader.ChecksumInfoType, _ <-chan struct{}) (string, int64, error) {
+					if cacheKey == "cache-key-fail" {
+						return "", 0, errors.New("download-failed-immediately")
+					}
+					time.Sleep(50 * time.Millisecond)
+					return "/tmp/download/late", 200, nil
+				},
+				expectedCacheKeys: []containerstore.BindMountCacheKey{
+					{CacheKey: "cache-key-success-late", Dir: "/tmp/download/late"},
+				},
+				expectedGardenMounts: []garden.BindMount{
+					{SrcPath: "/tmp/download/late", DstPath: "/var/data/late", Mode: garden.BindMountModeRO, Origin: garden.BindMountOriginHost},
+				},
+			}),
+			Entry("when multiple dependencies succeed and one fails", testCase{
+				name: "multiple successes",
+				deps: []executor.CachedDependency{
+					{CacheKey: "cache-key-1", From: "http://example.com/1", To: "/var/data/1"},
+					{CacheKey: "cache-key-fail", From: "http://example.com/fail", To: "/var/data/fail"},
+					{CacheKey: "cache-key-2", From: "http://example.com/2", To: "/var/data/2"},
+				},
+				stub: func(_ lager.Logger, _ *url.URL, cacheKey string, _ cacheddownloader.ChecksumInfoType, _ <-chan struct{}) (string, int64, error) {
+					switch cacheKey {
+					case "cache-key-1":
+						return "/tmp/download/1", 100, nil
+					case "cache-key-2":
+						time.Sleep(50 * time.Millisecond)
+						return "/tmp/download/2", 200, nil
+					case "cache-key-fail":
+						time.Sleep(10 * time.Millisecond)
+						return "", 0, errors.New("download-failed")
+					}
+					return "", 0, errors.New("unknown")
+				},
+				expectedCacheKeys: []containerstore.BindMountCacheKey{
+					{CacheKey: "cache-key-1", Dir: "/tmp/download/1"},
+					{CacheKey: "cache-key-2", Dir: "/tmp/download/2"},
+				},
+				expectedGardenMounts: []garden.BindMount{
+					{SrcPath: "/tmp/download/1", DstPath: "/var/data/1", Mode: garden.BindMountModeRO, Origin: garden.BindMountOriginHost},
+					{SrcPath: "/tmp/download/2", DstPath: "/var/data/2", Mode: garden.BindMountModeRO, Origin: garden.BindMountOriginHost},
+				},
+			}),
+		)
+	})
+
 	Context("when fetching all of the dependencies succeeds", func() {
 		var bindMounts containerstore.BindMounts
 
@@ -280,6 +372,14 @@ var _ = Describe("DependencyManager", func() {
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(cache.CloseDirectoryCallCount()).To(Equal(1))
+		})
+	})
+
+	Context("ReclaimCacheSpace", func() {
+		It("calls MakeRoom on the downloader cache", func() {
+			dependencyManager.ReclaimCacheSpace(logger)
+			Expect(cache.MakeRoomCallCount()).To(Equal(1))
+			Expect(cache.MakeRoomArgsForCall(0)).To(Equal(logger))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
+++ b/src/code.cloudfoundry.org/executor/depot/containerstore/storenode.go
@@ -207,6 +207,7 @@ func (n *storeNode) Create(logger lager.Logger, traceID string) error {
 	createContainer := func() error {
 		mounts, err := n.dependencyManager.DownloadCachedDependencies(logger, info.CachedDependencies, info.LogConfig, n.metronClient)
 		if err != nil {
+			n.dependencyManager.ReleaseCachedDependencies(logger, mounts.CacheKeys)
 			n.complete(logger, traceID, true, DownloadCachedDependenciesFailed, true)
 			return err
 		}

--- a/src/code.cloudfoundry.org/executor/depot/depot.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot.go
@@ -66,6 +66,10 @@ func (c *client) Cleanup(logger lager.Logger) {
 	c.containerStore.Cleanup(logger)
 }
 
+func (c *client) ReclaimCacheSpace(logger lager.Logger) {
+	c.containerStore.ReclaimCacheSpace(logger)
+}
+
 func (c *client) AllocateContainers(logger lager.Logger, traceID string, requests []executor.AllocationRequest) []executor.AllocationFailure {
 	logger = logger.Session("allocate-containers")
 	failures := make([]executor.AllocationFailure, 0)

--- a/src/code.cloudfoundry.org/executor/depot/depot_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/depot_test.go
@@ -795,6 +795,14 @@ var _ = Describe("Depot", func() {
 			})
 		})
 	})
+
+	Describe("ReclaimCacheSpace", func() {
+		It("delegates to the container store", func() {
+			depotClient.ReclaimCacheSpace(logger)
+			Expect(containerStore.ReclaimCacheSpaceCallCount()).To(Equal(1))
+			Expect(containerStore.ReclaimCacheSpaceArgsForCall(0)).To(Equal(logger))
+		})
+	})
 })
 
 func newAllocationRequest(guid string, tagses ...executor.Tags) executor.AllocationRequest {

--- a/src/code.cloudfoundry.org/executor/depot/steps/download_step.go
+++ b/src/code.cloudfoundry.org/executor/depot/steps/download_step.go
@@ -16,13 +16,12 @@ import (
 )
 
 type downloadStep struct {
-	container            garden.Container
-	model                models.DownloadAction
-	cachedDownloader     cacheddownloader.CachedDownloader
-	streamer             log_streamer.LogStreamer
-	rateLimiter          chan struct{}
-	cancelDownload       chan struct{}
-	enableDropletCaching bool
+	container        garden.Container
+	model            models.DownloadAction
+	cachedDownloader cacheddownloader.CachedDownloader
+	streamer         log_streamer.LogStreamer
+	rateLimiter      chan struct{}
+	cancelDownload   chan struct{}
 
 	logger lager.Logger
 }
@@ -34,7 +33,6 @@ func NewDownload(
 	rateLimiter chan struct{},
 	streamer log_streamer.LogStreamer,
 	logger lager.Logger,
-	enableDropletCaching bool,
 ) ifrit.Runner {
 	logger = logger.Session("download-step", lager.Data{
 		"to":       model.To,
@@ -43,14 +41,13 @@ func NewDownload(
 	})
 
 	return &downloadStep{
-		container:            container,
-		model:                model,
-		cachedDownloader:     cachedDownloader,
-		streamer:             streamer,
-		rateLimiter:          rateLimiter,
-		logger:               logger,
-		cancelDownload:       make(chan struct{}),
-		enableDropletCaching: enableDropletCaching,
+		container:        container,
+		model:            model,
+		cachedDownloader: cachedDownloader,
+		streamer:         streamer,
+		rateLimiter:      rateLimiter,
+		logger:           logger,
+		cancelDownload:   make(chan struct{}),
 	}
 }
 
@@ -128,15 +125,10 @@ func (step *downloadStep) fetch() (io.ReadCloser, int64, error) {
 		return nil, 0, err
 	}
 
-	cacheKey := step.model.CacheKey
-	if !step.enableDropletCaching && step.model.Artifact == "droplet" {
-		cacheKey = ""
-	}
-
 	tarStream, downloadedSize, err := step.cachedDownloader.Fetch(
 		step.logger.Session("downloader"),
 		url,
-		cacheKey,
+		step.model.CacheKey,
 		cacheddownloader.ChecksumInfoType{
 			Algorithm: step.model.GetChecksumAlgorithm(),
 			Value:     step.model.GetChecksumValue(),

--- a/src/code.cloudfoundry.org/executor/depot/steps/download_step_test.go
+++ b/src/code.cloudfoundry.org/executor/depot/steps/download_step_test.go
@@ -79,7 +79,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 
 			stepErr = <-ifrit.Invoke(step).Wait()
@@ -353,7 +352,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 		})
 
@@ -388,7 +386,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 		})
 
@@ -509,7 +506,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 
 			downloadAction2 := models.DownloadAction{
@@ -524,7 +520,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 
 			downloadAction3 := models.DownloadAction{
@@ -539,7 +534,6 @@ var _ = Describe("DownloadAction", func() {
 				rateLimiter,
 				fakeStreamer,
 				logger,
-				true,
 			)
 
 			fetchCh := make(chan struct{}, 3)
@@ -566,45 +560,6 @@ var _ = Describe("DownloadAction", func() {
 			close(barrier)
 		})
 	})
-
-	DescribeTable("droplet caching gating based on Artifact and EnableDropletCaching",
-		func(artifact string, enableDropletCaching bool, expectedCacheKey string) {
-			container, err := gardenClient.Create(garden.ContainerSpec{
-				Handle: handle,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			action := models.DownloadAction{
-				From:     "http://mr_jones",
-				To:       "/tmp/Antarctica",
-				CacheKey: "the-cache-key",
-				User:     "notroot",
-				Artifact: artifact,
-			}
-
-			step = steps.NewDownload(
-				container,
-				action,
-				cache,
-				rateLimiter,
-				fakeStreamer,
-				logger,
-				enableDropletCaching,
-			)
-
-			err = <-ifrit.Invoke(step).Wait()
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(cache.FetchCallCount()).To(Equal(1))
-			_, _, cacheKey, _, _ := cache.FetchArgsForCall(0)
-			Expect(cacheKey).To(Equal(expectedCacheKey))
-		},
-		Entry("Artifact: droplet + EnableDropletCaching: false -> empty cache key", "droplet", false, ""),
-		Entry("Artifact: droplet + EnableDropletCaching: true -> original cache key", "droplet", true, "the-cache-key"),
-		Entry("Artifact: droplet + EnableDropletCaching: unset/false (zero value) -> empty cache key", "droplet", false, ""),
-		Entry("Non-droplet Artifact (buildpack) + EnableDropletCaching: false -> original cache key", "buildpack", false, "the-cache-key"),
-		Entry("Non-droplet Artifact (empty) + EnableDropletCaching: true -> original cache key", "", true, "the-cache-key"),
-	)
 })
 
 var _ = Describe("ReadSizer", func() {

--- a/src/code.cloudfoundry.org/executor/depot/transformer/transformer.go
+++ b/src/code.cloudfoundry.org/executor/depot/transformer/transformer.go
@@ -71,8 +71,6 @@ type transformer struct {
 
 	postSetupHook []string
 	postSetupUser string
-
-	enableDropletCaching bool
 }
 
 type Option func(*transformer)
@@ -119,12 +117,6 @@ func WithPostSetupHook(user string, hook []string) Option {
 func WithDeclarativeHealthcheckFailureMetrics() Option {
 	return func(t *transformer) {
 		t.emitHealthCheckMetrics = true
-	}
-}
-
-func WithEnableDropletCaching(enableDropletCaching bool) Option {
-	return func(t *transformer) {
-		t.enableDropletCaching = enableDropletCaching
 	}
 }
 
@@ -200,7 +192,6 @@ func (t *transformer) stepFor(
 			t.downloadLimiter,
 			logStreamer.WithSource(actionModel.LogSource),
 			logger,
-			t.enableDropletCaching,
 		)
 
 	case *models.UploadAction:

--- a/src/code.cloudfoundry.org/executor/fakes/fake_client.go
+++ b/src/code.cloudfoundry.org/executor/fakes/fake_client.go
@@ -118,6 +118,11 @@ type FakeClient struct {
 	pingReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ReclaimCacheSpaceStub        func(lager.Logger)
+	reclaimCacheSpaceMutex       sync.RWMutex
+	reclaimCacheSpaceArgsForCall []struct {
+		arg1 lager.Logger
+	}
 	RemainingResourcesStub        func(lager.Logger) (executor.ExecutorResources, error)
 	remainingResourcesMutex       sync.RWMutex
 	remainingResourcesArgsForCall []struct {
@@ -760,6 +765,38 @@ func (fake *FakeClient) PingReturnsOnCall(i int, result1 error) {
 	fake.pingReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeClient) ReclaimCacheSpace(arg1 lager.Logger) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	fake.reclaimCacheSpaceArgsForCall = append(fake.reclaimCacheSpaceArgsForCall, struct {
+		arg1 lager.Logger
+	}{arg1})
+	stub := fake.ReclaimCacheSpaceStub
+	fake.recordInvocation("ReclaimCacheSpace", []interface{}{arg1})
+	fake.reclaimCacheSpaceMutex.Unlock()
+	if stub != nil {
+		fake.ReclaimCacheSpaceStub(arg1)
+	}
+}
+
+func (fake *FakeClient) ReclaimCacheSpaceCallCount() int {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	return len(fake.reclaimCacheSpaceArgsForCall)
+}
+
+func (fake *FakeClient) ReclaimCacheSpaceCalls(stub func(lager.Logger)) {
+	fake.reclaimCacheSpaceMutex.Lock()
+	defer fake.reclaimCacheSpaceMutex.Unlock()
+	fake.ReclaimCacheSpaceStub = stub
+}
+
+func (fake *FakeClient) ReclaimCacheSpaceArgsForCall(i int) lager.Logger {
+	fake.reclaimCacheSpaceMutex.RLock()
+	defer fake.reclaimCacheSpaceMutex.RUnlock()
+	argsForCall := fake.reclaimCacheSpaceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) RemainingResources(arg1 lager.Logger) (executor.ExecutorResources, error) {

--- a/src/code.cloudfoundry.org/executor/initializer/initializer.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer.go
@@ -85,7 +85,6 @@ type ExecutorConfig struct {
 	InstanceIdentityCredDir               string                `json:"instance_identity_cred_dir,omitempty"`
 	InstanceIdentityPrivateKeyPath        string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod        durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
-	EnableDropletCaching                  bool                  `json:"enable_droplet_caching,omitempty"`
 	MaxCacheSizeInBytes                   uint64                `json:"max_cache_size_in_bytes,omitempty"`
 	MinCachePartitionFreeBytes            uint64                `json:"min_cache_partition_free_bytes,omitempty"`
 	MaxConcurrentDownloads                int                   `json:"max_concurrent_downloads,omitempty"`

--- a/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer_garden.go
@@ -169,7 +169,6 @@ func Initialize(
 		config.EnableContainerProxyHealthChecks,
 		time.Duration(config.ProxyHealthCheckInterval),
 		time.Duration(config.DeclarativeHealthCheckDefaultTimeout),
-		config.EnableDropletCaching,
 	)
 
 	hub := event.NewHub()
@@ -455,13 +454,11 @@ func initializeTransformer(
 	enableProxyHealthChecks bool,
 	proxyHealthCheckInterval time.Duration,
 	declarativeHealthCheckDefaultTimeout time.Duration,
-	enableDropletCaching bool,
 ) transformer.Transformer {
 	var options []transformer.Option
 	compressor := compressor.NewTgz()
 	options = append(options, transformer.WithSidecarRootfs(declarativeHealthcheckRootFS))
 	options = append(options, transformer.WithDeclarativeHealthChecks(declarativeHealthCheckDefaultTimeout))
-	options = append(options, transformer.WithEnableDropletCaching(enableDropletCaching))
 	if emitHealthCheckMetrics {
 		options = append(options, transformer.WithDeclarativeHealthcheckFailureMetrics())
 	}

--- a/src/code.cloudfoundry.org/executor/initializer/initializer_test.go
+++ b/src/code.cloudfoundry.org/executor/initializer/initializer_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -743,32 +742,6 @@ var _ = Describe("Initializer", func() {
 				Expect(newCachedDownloader).To(BeNil())
 				Expect(err.Error()).To(ContainSubstring("could not create cache path"))
 			})
-		})
-	})
-
-	Describe("ExecutorConfig JSON unmarshaling", func() {
-		It("unmarshals EnableDropletCaching when explicitly set to true", func() {
-			jsonConfig := []byte(`{"enable_droplet_caching": true}`)
-			var config initializer.ExecutorConfig
-			err := json.Unmarshal(jsonConfig, &config)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(config.EnableDropletCaching).To(BeTrue())
-		})
-
-		It("unmarshals EnableDropletCaching when explicitly set to false", func() {
-			jsonConfig := []byte(`{"enable_droplet_caching": false}`)
-			var config initializer.ExecutorConfig
-			err := json.Unmarshal(jsonConfig, &config)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(config.EnableDropletCaching).To(BeFalse())
-		})
-
-		It("unmarshals EnableDropletCaching as false (zero value) when absent", func() {
-			jsonConfig := []byte(`{}`)
-			var config initializer.ExecutorConfig
-			err := json.Unmarshal(jsonConfig, &config)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(config.EnableDropletCaching).To(BeFalse())
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/rep/cachecleanup/cachecleanup_suite_test.go
+++ b/src/code.cloudfoundry.org/rep/cachecleanup/cachecleanup_suite_test.go
@@ -1,0 +1,12 @@
+package cachecleanup_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestCachecleanup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cachecleanup Suite")
+}

--- a/src/code.cloudfoundry.org/rep/cachecleanup/package.go
+++ b/src/code.cloudfoundry.org/rep/cachecleanup/package.go
@@ -1,0 +1,1 @@
+package cachecleanup // import "code.cloudfoundry.org/rep/cachecleanup"

--- a/src/code.cloudfoundry.org/rep/cachecleanup/runner.go
+++ b/src/code.cloudfoundry.org/rep/cachecleanup/runner.go
@@ -1,0 +1,55 @@
+package cachecleanup
+
+import (
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/lager/v3"
+)
+
+// Runner is an ifrit.Runner that periodically triggers cache space reclamation on the executor.
+type Runner struct {
+	logger         lager.Logger
+	clock          clock.Clock
+	interval       time.Duration
+	executorClient executor.Client
+}
+
+// NewRunner constructs a Runner.
+func NewRunner(
+	logger lager.Logger,
+	clk clock.Clock,
+	interval time.Duration,
+	executorClient executor.Client,
+) *Runner {
+	return &Runner{
+		logger:         logger.Session("cache-cleanup"),
+		clock:          clk,
+		interval:       interval,
+		executorClient: executorClient,
+	}
+}
+
+// Run implements ifrit.Runner.
+func (r *Runner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	logger := r.logger.Session("run")
+	logger.Info("starting")
+
+	close(ready)
+
+	ticker := r.clock.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-signals:
+			logger.Info("signalled")
+			return nil
+
+		case <-ticker.C():
+			r.executorClient.ReclaimCacheSpace(logger)
+		}
+	}
+}

--- a/src/code.cloudfoundry.org/rep/cachecleanup/runner_test.go
+++ b/src/code.cloudfoundry.org/rep/cachecleanup/runner_test.go
@@ -1,0 +1,83 @@
+package cachecleanup_test
+
+import (
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/clock/fakeclock"
+	fakeexecutor "code.cloudfoundry.org/executor/fakes"
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	"code.cloudfoundry.org/rep/cachecleanup"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
+)
+
+var _ = Describe("Runner", func() {
+	var (
+		runner          *cachecleanup.Runner
+		process         ifrit.Process
+		logger          *lagertest.TestLogger
+		executorClient  *fakeexecutor.FakeClient
+		fakeClock       *fakeclock.FakeClock
+		cleanupInterval time.Duration
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("cachecleanup-test")
+		executorClient = &fakeexecutor.FakeClient{}
+		fakeClock = fakeclock.NewFakeClock(time.Now())
+		cleanupInterval = 30 * time.Minute
+	})
+
+	JustBeforeEach(func() {
+		runner = cachecleanup.NewRunner(logger, fakeClock, cleanupInterval, executorClient)
+		process = ifrit.Background(runner)
+	})
+
+	AfterEach(func() {
+		ginkgomon.Interrupt(process)
+	})
+
+	It("becomes ready immediately", func() {
+		Eventually(process.Ready()).Should(BeClosed())
+	})
+
+	It("does not call ReclaimCacheSpace before the first tick", func() {
+		Eventually(process.Ready()).Should(BeClosed())
+		Expect(executorClient.ReclaimCacheSpaceCallCount()).To(Equal(0))
+	})
+
+	Context("when the ticker ticks", func() {
+		JustBeforeEach(func() {
+			Eventually(process.Ready()).Should(BeClosed())
+		})
+
+		It("calls ReclaimCacheSpace on each tick", func() {
+			fakeClock.WaitForWatcherAndIncrement(cleanupInterval)
+			Eventually(executorClient.ReclaimCacheSpaceCallCount).Should(Equal(1))
+
+			fakeClock.WaitForWatcherAndIncrement(cleanupInterval)
+			Eventually(executorClient.ReclaimCacheSpaceCallCount).Should(Equal(2))
+		})
+
+		It("passes the logger to ReclaimCacheSpace", func() {
+			fakeClock.WaitForWatcherAndIncrement(cleanupInterval)
+			Eventually(executorClient.ReclaimCacheSpaceCallCount).Should(Equal(1))
+			passedLogger := executorClient.ReclaimCacheSpaceArgsForCall(0)
+			Expect(passedLogger).NotTo(BeNil())
+		})
+	})
+
+	Context("when signalled", func() {
+		JustBeforeEach(func() {
+			Eventually(process.Ready()).Should(BeClosed())
+		})
+
+		It("exits with nil", func() {
+			process.Signal(os.Interrupt)
+			Eventually(process.Wait()).Should(Receive(BeNil()))
+		})
+	})
+})

--- a/src/code.cloudfoundry.org/rep/cmd/rep/main.go
+++ b/src/code.cloudfoundry.org/rep/cmd/rep/main.go
@@ -36,6 +36,7 @@ import (
 	"code.cloudfoundry.org/operationq"
 	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/rep/auctioncellrep"
+	"code.cloudfoundry.org/rep/cachecleanup"
 	"code.cloudfoundry.org/rep/cmd/rep/config"
 	"code.cloudfoundry.org/rep/diskcheck"
 	"code.cloudfoundry.org/rep/evacuation"
@@ -50,6 +51,8 @@ import (
 	"github.com/tedsuo/ifrit/sigmon"
 	"github.com/tedsuo/rata"
 )
+
+const cacheCleanupInterval = 1 * time.Minute
 
 var configFilePath = flag.String(
 	"config",
@@ -247,6 +250,7 @@ func main() {
 		{Name: "event-consumer", Runner: harmonizer.NewEventConsumer(logger, opGenerator, queue)},
 		{Name: "evacuator", Runner: evacuator},
 		{Name: "request-metrics-notifier", Runner: requestMetrics},
+		{Name: "cache-cleanup", Runner: cachecleanup.NewRunner(logger, clock, cacheCleanupInterval, executorClient)},
 	}
 
 	members = append(executorMembers, members...)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes 4 issues:
1. When staging containers run for apps that don't specify a buildpack, many resources are downloaded + cached. This can cause the cache to exceed it's configured size limit until the next cleanup is run, which used to only happen the next time an uncached asset needed to be downloaded. Now we will check minutely as well to prune faster when over the limit.
2. Fix DownloadCachedDependencies losing late-arriving successful mounts when an earlier download fails (mountChan wasn't drained after the error path).
3. Fix unused OldEntries never being deleted from disk in FileCache.CloseDirectory.
4. Fix a failed tar extraction leaving a stale ExpandedDirectoryPath, permanently blocking retry.


Backward Compatibility
---------------
Breaking Change? no