### PR TITLE
Fix SSH algorithm negotiation error format in tests

### DIFF
--- a/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main_test.go
+++ b/src/code.cloudfoundry.org/diego-ssh/cmd/sshd/main_test.go
@@ -435,7 +435,7 @@ var _ = Describe("SSH daemon", func() {
 			})
 
 			It("errors when the client doesn't provide one of the algorithm: 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr'", func() {
-				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; we offered: [arcfour128], peer offered: [aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]"))
+				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; we offered: [\"arcfour128\"], peer offered: [\"aes128-gcm@openssh.com\" \"aes256-ctr\" \"aes192-ctr\" \"aes128-ctr\"]"))
 				Expect(client).To(BeNil())
 			})
 		})
@@ -507,7 +507,7 @@ var _ = Describe("SSH daemon", func() {
 				})
 
 				It("errors when the client doesn't provide one of the algorithms: 'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-256'", func() {
-					Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server MAC; we offered: [hmac-sha1], peer offered: [hmac-sha2-256-etm@openssh.com hmac-sha2-256]"))
+					Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server MAC; we offered: [\"hmac-sha1\"], peer offered: [\"hmac-sha2-256-etm@openssh.com\" \"hmac-sha2-256\"]"))
 					Expect(client).To(BeNil())
 				})
 			})
@@ -564,7 +564,7 @@ var _ = Describe("SSH daemon", func() {
 			})
 
 			It("errors when the client doesn't provide the algorithm: 'curve25519-sha256@libssh.org'", func() {
-				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for key exchange; we offered: [diffie-hellman-group14-sha1 ext-info-c kex-strict-c-v00@openssh.com], peer offered: [curve25519-sha256@libssh.org kex-strict-s-v00@openssh.com]"))
+				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for key exchange; we offered: [\"diffie-hellman-group14-sha1\" \"ext-info-c\" \"kex-strict-c-v00@openssh.com\"], peer offered: [\"curve25519-sha256@libssh.org\" \"kex-strict-s-v00@openssh.com\"]"))
 				Expect(client).To(BeNil())
 			})
 		})


### PR DESCRIPTION
x/crypto updated AlgorithmNegotiationError.Error() from %v to %q, quoting algorithm names in error messages. Update three exact-match test assertions to expect the new quoted format.

ai-assisted=yes

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
