### PR TITLE
Add deployment name for the cell annotations

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -83,7 +83,7 @@ properties:
     description: "Array of optional tags used for scheduling Tasks and LRPs"
     default: []
   diego.rep.cell_annotations:
-    description: "Map of string key-value annotations to attach to the cell presence"
+    description: "Map of string key-value annotations to attach to the cell presence. A deployment_guid key set to the BOSH deployment name is automatically added."
     default: {}
 
   loggregator.v2_api_port:

--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -96,7 +96,7 @@
     max_concurrent_downloads: p("diego.executor.max_concurrent_downloads"),
     memory_mb: p("diego.executor.memory_capacity_mb").to_s,
     metrics_work_pool_size: p("diego.executor.metrics_work_pool_size"),
-    cell_annotations: p("diego.rep.cell_annotations"),
+    cell_annotations: p("diego.rep.cell_annotations").merge("deployment_guid" => spec.deployment),
     optional_placement_tags: p("diego.rep.optional_placement_tags"),
     placement_tags: p("diego.rep.placement_tags"),
     polling_interval: "#{p("diego.rep.polling_interval_in_seconds")}s",

--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -228,7 +228,7 @@ properties:
     description: "Array of optional tags used for scheduling Tasks and LRPs"
     default: []
   diego.rep.cell_annotations:
-    description: "Map of string key-value annotations to attach to the cell presence"
+    description: "Map of string key-value annotations to attach to the cell presence. A deployment_guid key set to the BOSH deployment name is automatically added."
     default: {}
 
   syslog_daemon_config.address:

--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -93,7 +93,7 @@
     max_concurrent_downloads: p("diego.executor.max_concurrent_downloads"),
     memory_mb: p("diego.executor.memory_capacity_mb").to_s,
     metrics_work_pool_size: p("diego.executor.metrics_work_pool_size"),
-    cell_annotations: p("diego.rep.cell_annotations"),
+    cell_annotations: p("diego.rep.cell_annotations").merge("deployment_guid" => spec.deployment),
     optional_placement_tags: p("diego.rep.optional_placement_tags"),
     placement_tags: p("diego.rep.placement_tags"),
     polling_interval: "#{p("diego.rep.polling_interval_in_seconds")}s",

--- a/spec/rep_template_spec.rb
+++ b/spec/rep_template_spec.rb
@@ -135,6 +135,31 @@ describe 'rep' do
       end
     end
 
+    context 'cell_annotations' do
+      it 'includes the deployment_guid based on the bosh deployment name' do
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq('deployment_guid' => 'my-deployment')
+      end
+
+      it 'merges the deployment_guid into operator-provided annotations' do
+        deployment_manifest_fragment['diego']['rep']['cell_annotations'] = { 'team' => 'diego' }
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq(
+          'team' => 'diego',
+          'deployment_guid' => 'my-deployment'
+        )
+      end
+
+      it 'always overrides an operator-provided deployment_guid with the bosh deployment name' do
+        deployment_manifest_fragment['diego']['rep']['cell_annotations'] = { 'deployment_guid' => 'user-provided' }
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq('deployment_guid' => 'my-deployment')
+      end
+
+      it 'reflects a custom bosh deployment name' do
+        spec = Bosh::Template::Test::InstanceSpec.new(deployment: 'cf-4f4d28d91b17601281d4')
+        rendered = template.render(deployment_manifest_fragment, spec: spec)
+        expect(JSON.parse(rendered)['cell_annotations']).to eq('deployment_guid' => 'cf-4f4d28d91b17601281d4')
+      end
+    end
+
     context 'min_cache_partition_free_bytes' do
       it 'defaults to 5368709120 (5GB)' do
         expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(5_368_709_120)

--- a/spec/rep_windows_template_spec.rb
+++ b/spec/rep_windows_template_spec.rb
@@ -135,6 +135,31 @@ describe 'rep' do
       end
     end
 
+    context 'cell_annotations' do
+      it 'includes the deployment_guid based on the bosh deployment name' do
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq('deployment_guid' => 'my-deployment')
+      end
+
+      it 'merges the deployment_guid into operator-provided annotations' do
+        deployment_manifest_fragment['diego']['rep']['cell_annotations'] = { 'team' => 'diego' }
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq(
+          'team' => 'diego',
+          'deployment_guid' => 'my-deployment'
+        )
+      end
+
+      it 'always overrides an operator-provided deployment_guid with the bosh deployment name' do
+        deployment_manifest_fragment['diego']['rep']['cell_annotations'] = { 'deployment_guid' => 'user-provided' }
+        expect(JSON.parse(rendered_template)['cell_annotations']).to eq('deployment_guid' => 'my-deployment')
+      end
+
+      it 'reflects a custom bosh deployment name' do
+        spec = Bosh::Template::Test::InstanceSpec.new(deployment: 'cf-4f4d28d91b17601281d4')
+        rendered = template.render(deployment_manifest_fragment, spec: spec)
+        expect(JSON.parse(rendered)['cell_annotations']).to eq('deployment_guid' => 'cf-4f4d28d91b17601281d4')
+      end
+    end
+
     context 'min_cache_partition_free_bytes' do
       it 'defaults to 5368709120 (5GB)' do
         expect(JSON.parse(rendered_template)['min_cache_partition_free_bytes']).to eq(5_368_709_120)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Always add spec.deployment to the cell annotation, so that `cfdot cells` output can be distinguished.


Backward Compatibility
---------------
Breaking Change? **No**
